### PR TITLE
Buffers: Improved guard clauses

### DIFF
--- a/src/J2N/IO/Buffer.cs
+++ b/src/J2N/IO/Buffer.cs
@@ -84,6 +84,7 @@ namespace J2N.IO
         /// Construct a buffer with the specified capacity.
         /// </summary>
         /// <param name="capacity">The capacity of this buffer</param>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="capacity"/> is less than zero.</exception>
         internal Buffer(int capacity)
         {
             if (capacity < 0)
@@ -172,13 +173,13 @@ namespace J2N.IO
         /// </summary>
         /// <param name="newLimit">The new limit value; must be non-negative and no larger than this buffer's capacity</param>
         /// <returns>This buffer</returns>
-        /// <exception cref="ArgumentException">If <paramref name="newLimit"/> is invalid.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="newLimit"/> is less than zero or greater than <see cref="Capacity"/>.</exception>
         public Buffer SetLimit(int newLimit)
         {
-            if (newLimit < 0 || newLimit > capacity)
-            {
-                throw new ArgumentException();
-            }
+            if (newLimit < 0)
+                throw new ArgumentOutOfRangeException(nameof(newLimit), newLimit, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (newLimit > capacity)
+                throw new ArgumentOutOfRangeException(nameof(newLimit), newLimit, J2N.SR.Format(SR.Argument_MinMaxValue, nameof(newLimit), nameof(Capacity)));
 
             limit = newLimit;
             if (position > newLimit)
@@ -220,13 +221,13 @@ namespace J2N.IO
         /// </summary>
         /// <param name="newPosition">The new position, must be not negative and not greater than limit.</param>
         /// <returns>This buffer</returns>
-        /// <exception cref="ArgumentException">If <paramref name="newPosition"/> is invalid.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="newPosition"/> is less than zero or greater than <see cref="Limit"/>.</exception>
         public Buffer SetPosition(int newPosition)
         {
-            if (newPosition < 0 || newPosition > limit)
-            {
-                throw new ArgumentException();
-            }
+            if (newPosition < 0)
+                throw new ArgumentOutOfRangeException(nameof(newPosition), newPosition, SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (newPosition > limit)
+                throw new ArgumentOutOfRangeException(nameof(newPosition), newPosition, J2N.SR.Format(SR.Argument_MinMaxValue, nameof(newPosition), nameof(Limit)));
 
             position = newPosition;
             if ((mark != UnsetMark) && (mark > position))

--- a/src/J2N/IO/ByteBuffer.cs
+++ b/src/J2N/IO/ByteBuffer.cs
@@ -692,7 +692,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public ByteBuffer Put(byte[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -725,7 +725,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual ByteBuffer Put(byte[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -758,10 +758,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual ByteBuffer Put(ByteBuffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/IO/CharBuffer.cs
+++ b/src/J2N/IO/CharBuffer.cs
@@ -611,7 +611,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
         public CharBuffer Put(char[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -640,7 +640,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
         public virtual CharBuffer Put(char[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -675,10 +675,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual CharBuffer Put(CharBuffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)
@@ -715,7 +715,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
         public CharBuffer Put(string source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -747,7 +747,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <c>null</c>.</exception>
         public virtual CharBuffer Put(string source, int startIndex, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -1112,7 +1112,7 @@ namespace J2N.IO
                 {
                     return -1;
                 }
-                throw new ArgumentException();
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(target), nameof(target)));
             }
             if (remaining == 0)
             {

--- a/src/J2N/IO/CharSequenceAdapter.cs
+++ b/src/J2N/IO/CharSequenceAdapter.cs
@@ -113,7 +113,7 @@ namespace J2N.IO
 
         public override sealed CharBuffer Put(char[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
             if (offset < 0)
                 throw new ArgumentOutOfRangeException(nameof(offset));
@@ -129,7 +129,7 @@ namespace J2N.IO
 
         public override CharBuffer Put(string source, int startIndex, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
             int len = source.Length;
             if (startIndex < 0)

--- a/src/J2N/IO/DoubleBuffer.cs
+++ b/src/J2N/IO/DoubleBuffer.cs
@@ -387,7 +387,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public DoubleBuffer Put(double[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -415,7 +415,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual DoubleBuffer Put(double[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -448,10 +448,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual DoubleBuffer Put(DoubleBuffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/IO/Int16Buffer.cs
+++ b/src/J2N/IO/Int16Buffer.cs
@@ -392,7 +392,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public Int16Buffer Put(short[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -421,7 +421,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int16Buffer Put(short[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -454,10 +454,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int16Buffer Put(Int16Buffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/IO/Int32Buffer.cs
+++ b/src/J2N/IO/Int32Buffer.cs
@@ -388,7 +388,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public Int32Buffer Put(int[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -416,7 +416,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int32Buffer Put(int[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -449,10 +449,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int32Buffer Put(Int32Buffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/IO/Int64Buffer.cs
+++ b/src/J2N/IO/Int64Buffer.cs
@@ -408,7 +408,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public Int64Buffer Put(long[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -436,7 +436,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int64Buffer Put(long[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -469,10 +469,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual Int64Buffer Put(Int64Buffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/IO/MemoryMappedFiles/ReadWriteMemoryMappedViewByteBuffer.cs
+++ b/src/J2N/IO/MemoryMappedFiles/ReadWriteMemoryMappedViewByteBuffer.cs
@@ -88,7 +88,7 @@ namespace J2N.IO.MemoryMappedFiles
 
         public override ByteBuffer Put(byte[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
@@ -76,7 +76,7 @@ namespace J2N.IO
 
         public override CharBuffer Put(string source, int startIndex, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteCharArrayBuffer.cs
@@ -82,7 +82,7 @@ namespace J2N.IO
 
         public override CharBuffer Put(char[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
@@ -81,7 +81,7 @@ namespace J2N.IO
 
         public override DoubleBuffer Put(double[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteHeapByteBuffer.cs
+++ b/src/J2N/IO/ReadWriteHeapByteBuffer.cs
@@ -93,7 +93,7 @@ namespace J2N.IO
 
         public override ByteBuffer Put(byte[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
@@ -85,7 +85,7 @@ namespace J2N.IO
 
         public override Int16Buffer Put(short[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
@@ -84,7 +84,7 @@ namespace J2N.IO
 
         public override Int32Buffer Put(int[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
@@ -81,7 +81,7 @@ namespace J2N.IO
 
         public override Int64Buffer Put(long[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
@@ -81,7 +81,7 @@ namespace J2N.IO
 
         public override SingleBuffer Put(float[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;

--- a/src/J2N/IO/SingleBuffer.cs
+++ b/src/J2N/IO/SingleBuffer.cs
@@ -385,7 +385,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public SingleBuffer Put(float[] source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             return Put(source, 0, source.Length);
@@ -413,7 +413,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual SingleBuffer Put(float[] source, int offset, int length)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
             int len = source.Length;
@@ -446,10 +446,10 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="source"/> is <c>null</c>.</exception>
         public virtual SingleBuffer Put(SingleBuffer source)
         {
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
-            if (source == this)
-                throw new ArgumentException();
+            if (ReferenceEquals(source, this))
+                throw new ArgumentException(J2N.SR.Format(SR.Argument_MustNotBeThis, nameof(source), nameof(source)));
             if (source.Remaining > Remaining)
                 throw new BufferOverflowException();
             if (IsReadOnly)

--- a/src/J2N/Resources/Strings.Designer.cs
+++ b/src/J2N/Resources/Strings.Designer.cs
@@ -10,7 +10,7 @@
 
 namespace J2N.Resources {
     using System;
-    using System.Reflection;
+    
     
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -39,12 +39,7 @@ namespace J2N.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("J2N.Resources.Strings",
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                        typeof(Strings).GetTypeInfo().Assembly);
-#else
-                        typeof(Strings).Assembly);
-#endif
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("J2N.Resources.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -251,6 +246,15 @@ namespace J2N.Resources {
         internal static string Argument_MustBePrimitiveType {
             get {
                 return ResourceManager.GetString("Argument_MustBePrimitiveType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; must not be the same instance as this..
+        /// </summary>
+        internal static string Argument_MustNotBeThis {
+            get {
+                return ResourceManager.GetString("Argument_MustNotBeThis", resourceCulture);
             }
         }
         

--- a/src/J2N/Resources/Strings.resx
+++ b/src/J2N/Resources/Strings.resx
@@ -168,6 +168,9 @@
   <data name="Argument_MustBePrimitiveType" xml:space="preserve">
     <value>'{0}' is not a primitive type.</value>
   </data>
+  <data name="Argument_MustNotBeThis" xml:space="preserve">
+    <value>'{0}' must not be the same instance as this.</value>
+  </data>
   <data name="Argument_TypeOfKeyIncorrect" xml:space="preserve">
     <value>The key was of an incorrect type for this dictionary.</value>
   </data>


### PR DESCRIPTION
`J2N.IO.Buffer` + subclasses: Improved guard clauses by throwing more specific exceptions (`ArgumentOutOfRangeException` rather than `ArgumentException`), adding better error descriptions, and avoiding the guard clause checks being accidentally overridden because of operator overrides.