### PR TITLE
Completed Nullable Reference Type Support (closes #10)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -48,9 +48,12 @@
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_OUTVALUE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRIMEXCESS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRYADD</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
-    
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPENDJOIN</DefineConstants>
+
   </PropertyGroup>
 
   <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, and .NET 5.x -->

--- a/src/J2N.TestFramework/J2N.TestFramework.csproj
+++ b/src/J2N.TestFramework/J2N.TestFramework.csproj
@@ -14,6 +14,8 @@
     <NoWarn Label="Member 'member1' overrides obsolete member 'member2. Add the Obsolete attribute to 'member1'">$(NoWarn);CS0672</NoWarn>
     <NoWarn Label="Obsolete member 'memberA' overrides non-obsolete member 'memberB'.">$(NoWarn);CS0809</NoWarn>
     <NoWarn Label="Missing XML comment for publicly visible type or member 'Type_or_Member'">$(NoWarn);CS1591</NoWarn>
+
+    <NoWarn Label="Naming rule violation: Must begin with upper case characters">$(NoWarn);IDE1006</NoWarn>
     
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>

--- a/src/J2N/ArrayExtensions.cs
+++ b/src/J2N/ArrayExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using SR2 = J2N.Resources.Strings;
-#nullable enable
+
 
 namespace J2N
 {
@@ -18,7 +18,7 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="array"/> is <c>null</c>.</exception>
         public static void Fill<T>(this T[] array, T value)
         {
-            if (array == null)
+            if (array is null)
                 throw new ArgumentNullException(nameof(array));
 
             for (int i = 0; i < array.Length; i++)
@@ -47,7 +47,7 @@ namespace J2N
         /// </exception>
         public static void Fill<T>(this T[] array, int startIndex, int length, T value)
         {
-            if (array == null)
+            if (array is null)
                 throw new ArgumentNullException(nameof(array));
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));

--- a/src/J2N/AssemblyExtensions.cs
+++ b/src/J2N/AssemblyExtensions.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/BitConversion.cs
+++ b/src/J2N/BitConversion.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using SR2 = J2N.Resources.Strings;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Collections/ArrayEqualityComparer.cs
+++ b/src/J2N/Collections/ArrayEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/Arrays.cs
+++ b/src/J2N/Collections/Arrays.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/BitSet.cs
+++ b/src/J2N/Collections/BitSet.cs
@@ -2,7 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/CollectionUtil.cs
+++ b/src/J2N/Collections/CollectionUtil.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -21,6 +21,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+
 namespace J2N.Collections.Concurrent
 {
     using SR = J2N.Resources.Strings;
@@ -57,7 +58,9 @@ namespace J2N.Collections.Concurrent
     /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
     public class LurchTable<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
@@ -67,11 +70,11 @@ namespace J2N.Collections.Concurrent
         public delegate void ItemUpdatedMethod(KeyValuePair<TKey, TValue> previous, KeyValuePair<TKey, TValue> next);
 
         /// <summary> Event raised after an item is removed from the collection </summary>
-        public event Action<KeyValuePair<TKey, TValue>> ItemRemoved;
+        public event Action<KeyValuePair<TKey, TValue>>? ItemRemoved;
         /// <summary> Event raised after an item is updated in the collection </summary>
-        public event ItemUpdatedMethod ItemUpdated;
+        public event ItemUpdatedMethod? ItemUpdated;
         /// <summary> Event raised after an item is added to the collection </summary>
-        public event Action<KeyValuePair<TKey, TValue>> ItemAdded;
+        public event Action<KeyValuePair<TKey, TValue>>? ItemAdded;
 
         private const int OverAlloc = 128;
         private const int FreeSlots = 32;
@@ -89,7 +92,7 @@ namespace J2N.Collections.Concurrent
         private int _used, _count;
         private int _allocNext, _freeVersion;
 
-        private object _syncRoot;
+        private object? _syncRoot;
 
         #region Constructors
 
@@ -127,7 +130,7 @@ namespace J2N.Collections.Concurrent
         /// <paramref name="capacity"/> items efficiently with the specified <paramref name="comparer"/>.</summary>
         /// <param name="capacity">The initial allowable number of items before allocation of more memory.</param>
         /// <param name="comparer">The element hash generator for keys, or <c>null</c> to use <see cref="J2N.Collections.Generic.EqualityComparer{TKey}.Default"/>.</param>
-        public LurchTable(int capacity, IEqualityComparer<TKey> comparer)
+        public LurchTable(int capacity, IEqualityComparer<TKey>? comparer)
             : this(capacity, LurchTableOrder.None, int.MaxValue, comparer) { }
 
         /// <summary>Initializes a new instance of <see cref="LurchTable{TKey, TValue}"/> that orders items by
@@ -156,7 +159,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// <paramref name="ordering"/> is <see cref="LurchTableOrder.None"/> and <paramref name="limit"/> is less than <see cref="int.MaxValue"/>.
         /// </exception>
-        public LurchTable(LurchTableOrder ordering, int limit, IEqualityComparer<TKey> comparer)
+        public LurchTable(LurchTableOrder ordering, int limit, IEqualityComparer<TKey>? comparer)
             : this(limit, ordering, limit, comparer) { }
 
         /// <summary>
@@ -179,7 +182,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// <paramref name="ordering"/> is <see cref="LurchTableOrder.None"/> and <paramref name="limit"/> is less than <see cref="int.MaxValue"/>.
         /// </exception>
-        public LurchTable(int capacity, LurchTableOrder ordering, int limit, IEqualityComparer<TKey> comparer)
+        public LurchTable(int capacity, LurchTableOrder ordering, int limit, IEqualityComparer<TKey>? comparer)
             : this(capacity, ordering, limit, capacity >> 1, capacity >> 4, capacity >> 8, comparer) { }
 
         /// <summary>
@@ -201,10 +204,12 @@ namespace J2N.Collections.Concurrent
         /// </exception>
         // J2N: Original constructor still used by tests. This constructor didn't provide a straightforward way to put a guard clause on
         // capacity to ensure it is non-negative.
-        internal LurchTable(LurchTableOrder ordering, int limit, int hashSize, int allocSize, int lockSize, IEqualityComparer<TKey> comparer)
+        internal LurchTable(LurchTableOrder ordering, int limit, int hashSize, int allocSize, int lockSize, IEqualityComparer<TKey>? comparer)
             : this(hashSize << 1, ordering, limit, hashSize, allocSize, lockSize, comparer) { }
 
-        private LurchTable(int capacity, LurchTableOrder ordering, int limit, int hashSize, int allocSize, int lockSize, IEqualityComparer<TKey> comparer)
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        private LurchTable(int capacity, LurchTableOrder ordering, int limit, int hashSize, int allocSize, int lockSize, IEqualityComparer<TKey>? comparer)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -266,7 +271,9 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(n) operation, where n is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary) : this(dictionary, LurchTableOrder.None, null) { }
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements
@@ -294,7 +301,9 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(n) operation, where n is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering) : this(dictionary, ordering, null) { }
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements copied
@@ -327,7 +336,9 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-        public LurchTable(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) : this(dictionary, LurchTableOrder.None, comparer) { }
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+        public LurchTable(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer) : this(dictionary, LurchTableOrder.None, comparer) { }
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements copied
@@ -361,7 +372,9 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-        public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, IEqualityComparer<TKey> comparer)
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+        public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, IEqualityComparer<TKey>? comparer)
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
             : this(dictionary, ordering, int.MaxValue, comparer) { }
 
         /// <summary>
@@ -397,8 +410,10 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-        public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, int limit, IEqualityComparer<TKey> comparer)
-            : this(dictionary != null ? dictionary.Count : 0, ordering, limit, comparer)
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+        public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, int limit, IEqualityComparer<TKey>? comparer)
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
+            : this(dictionary is null ? 0 : dictionary.Count, ordering, limit, comparer)
         {
             if (dictionary == null)
                 throw new ArgumentNullException(nameof(dictionary));
@@ -492,7 +507,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="collection"/>.
         /// </remarks>
-        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer) : this(collection, LurchTableOrder.None, comparer) { }
+        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer) : this(collection, LurchTableOrder.None, comparer) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements copied
@@ -526,7 +541,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="collection"/>.
         /// </remarks>
-        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, LurchTableOrder ordering, IEqualityComparer<TKey> comparer)
+        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, LurchTableOrder ordering, IEqualityComparer<TKey>? comparer)
             : this(collection, ordering, int.MaxValue, comparer) { }
 
         /// <summary>
@@ -563,10 +578,10 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="collection"/>.
         /// </remarks>
-        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, LurchTableOrder ordering, int limit, IEqualityComparer<TKey> comparer)
+        public LurchTable(IEnumerable<KeyValuePair<TKey, TValue>> collection, LurchTableOrder ordering, int limit, IEqualityComparer<TKey>? comparer)
             : this(collection is ICollection<KeyValuePair<TKey, TValue>> col ? col.Count : 0, ordering, limit, comparer)
         {
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
             CopyConstructorAddRange(collection);
@@ -592,7 +607,7 @@ namespace J2N.Collections.Concurrent
         {
             if (disposing)
             {
-                _entries = null;
+                _entries = null!;
                 _used = _count = 0;
             }
         }
@@ -762,13 +777,13 @@ namespace J2N.Collections.Concurrent
             {
                 if (_syncRoot == null)
                 {
-                    Interlocked.CompareExchange<object/*?*/>(ref _syncRoot, new object(), null);
+                    Interlocked.CompareExchange<object?>(ref _syncRoot, new object(), null);
                 }
                 return _syncRoot;
             }
         }
 
-        object IDictionary.this[object key]
+        object? IDictionary.this[object key]
         {
             get
             {
@@ -795,7 +810,7 @@ namespace J2N.Collections.Concurrent
                     TKey tempKey = (TKey)key;
                     try
                     {
-                        this[tempKey] = (TValue)value;
+                        this[tempKey!] = (TValue)value!;
                     }
                     catch (InvalidCastException)
                     {
@@ -809,7 +824,7 @@ namespace J2N.Collections.Concurrent
             }
         }
 
-        void IDictionary.Add(object key, object value)
+        void IDictionary.Add(object? key, object? value)
         {
             // J2N: Only throw if the generic closing type is not nullable
             if (key is null && !typeof(TKey).IsNullableType())
@@ -823,7 +838,7 @@ namespace J2N.Collections.Concurrent
 
                 try
                 {
-                    Add(tempKey, (TValue)value);
+                    Add(tempKey!, (TValue)value!);
                 }
                 catch (InvalidCastException)
                 {
@@ -878,7 +893,7 @@ namespace J2N.Collections.Concurrent
             else if (array is DictionaryEntry[] dictEntryArray)
             {
                 foreach (var item in this)
-                    dictEntryArray[index++] = new DictionaryEntry(item.Key, item.Value);
+                    dictEntryArray[index++] = new DictionaryEntry(item.Key!, item.Value);
             }
             else
             {
@@ -978,7 +993,9 @@ namespace J2N.Collections.Concurrent
         /// <c>true</c> if the object that implements <see cref="T:System.Collections.Generic.IDictionary`2"/>
         /// contains an element with the specified key; otherwise, <c>false</c>.
         /// </returns>
-        public bool TryGetValue(TKey key, out TValue value)
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
         {
             int hash = GetHash(key);
             return InternalGetValue(hash, key, out value);
@@ -991,9 +1008,9 @@ namespace J2N.Collections.Concurrent
         /// <param name="value">The value of the element to add. The value can be <c>null</c> for reference types.</param>
         /// <exception cref="ArgumentException">An element with the same key already exists
         /// in the <see cref="Dictionary{TKey, TValue}"/>.</exception>
-        public void Add(TKey key, TValue value)
+        public void Add([AllowNull] TKey key, [AllowNull] TValue value)
         {
-            var info = new AddInfo<TKey, TValue> { Value = value };
+            var info = new AddInfo<TKey, TValue> { Value = value! };
             if (InsertResult.Inserted != Insert(key, ref info))
                 throw new ArgumentException(J2N.SR.Format(SR.Argument_AddingDuplicate, key));
         }
@@ -1077,7 +1094,7 @@ namespace J2N.Collections.Concurrent
         /// <c>true</c> if the element is successfully removed; otherwise, <c>false</c>. This method also returns
         /// <c>false</c> if <paramref name="key"/> was not found in the original <see cref="T:System.Collections.Generic.IDictionary`2"/>.
         /// </returns>
-        public bool TryRemove(TKey key, out TValue value)
+        public bool TryRemove(TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             var info = new DelInfo<TKey, TValue>();
             if (Delete(key, ref info))
@@ -1444,7 +1461,7 @@ namespace J2N.Collections.Concurrent
 
                     if (_getEnumeratorRetType == DictEntry)
                     {
-                        return new DictionaryEntry(Current.Key, Current.Value);
+                        return new DictionaryEntry(Current.Key!, Current.Value);
                     }
                     else
                     {
@@ -1503,9 +1520,11 @@ namespace J2N.Collections.Concurrent
                 _state.Init();
             }
 
-            object IDictionaryEnumerator.Key
+            object? IDictionaryEnumerator.Key
             {
+#pragma warning disable CS8616, CS8768 // Nullability of reference types in return type doesn't match implemented member (possibly because of nullability attributes).
                 get
+#pragma warning restore CS8616, CS8768 // Nullability of reference types in return type doesn't match implemented member (possibly because of nullability attributes).
                 {
                     int index = _state.Current;
                     if (index <= 0)
@@ -1515,7 +1534,7 @@ namespace J2N.Collections.Concurrent
                 }
             }
 
-            object IDictionaryEnumerator.Value
+            object? IDictionaryEnumerator.Value
             {
                 get
                 {
@@ -1535,7 +1554,7 @@ namespace J2N.Collections.Concurrent
                     if (index <= 0)
                         throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
 
-                    return new DictionaryEntry(Current.Key, Current.Value);
+                    return new DictionaryEntry(Current.Key!, Current.Value);
                 }
             }
         }
@@ -1644,19 +1663,20 @@ namespace J2N.Collections.Concurrent
                 if (array.Length - index < _owner.Count)
                     throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
 
-                TKey[] keys = array as TKey[];
+                TKey[]? keys = array as TKey[];
                 if (keys != null)
                 {
                     CopyTo(keys, index);
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
                     try
                     {
+                        object?[] objects = (object?[])array;
                         foreach (var item in this)
                             objects[index++] = item;
                     }
@@ -1743,7 +1763,7 @@ namespace J2N.Collections.Concurrent
                     _state.Unlock();
                 }
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {
@@ -1831,7 +1851,7 @@ namespace J2N.Collections.Concurrent
             #endregion
         }
 
-        private KeyCollection _keyCollection;
+        private KeyCollection? _keyCollection;
 
         /// <summary>
         /// Gets an <see cref="T:System.Collections.Generic.ICollection`1"/> containing the
@@ -1839,11 +1859,13 @@ namespace J2N.Collections.Concurrent
         /// </summary>
         public KeyCollection Keys => _keyCollection ?? (_keyCollection = new KeyCollection(this));
 
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
 #if FEATURE_IREADONLYCOLLECTIONS
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 #endif
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         #endregion
 
@@ -1952,12 +1974,13 @@ namespace J2N.Collections.Concurrent
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
                     try
                     {
+                        object?[] objects = (object?[])array;
                         foreach (var entry in this)
                             objects[index++] = entry;
                     }
@@ -2040,7 +2063,7 @@ namespace J2N.Collections.Concurrent
                     _state.Unlock();
                 }
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {
@@ -2129,18 +2152,20 @@ namespace J2N.Collections.Concurrent
             #endregion
         }
 
-        private ValueCollection _valueCollection;
+        private ValueCollection? _valueCollection;
 
         /// <summary>
         /// Gets an <see cref="T:System.Collections.Generic.ICollection`1"/> containing the values in the <see cref="T:System.Collections.Generic.IDictionary`2"/>.
         /// </summary>
         public ValueCollection Values => _valueCollection ?? (_valueCollection = new ValueCollection(this));
 
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
 #if FEATURE_IREADONLYCOLLECTIONS
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
 #endif
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         #endregion
 
@@ -2224,7 +2249,7 @@ namespace J2N.Collections.Concurrent
         /// </summary>
         /// <returns>False if no item was available</returns>
         /// <exception cref="InvalidOperationException">The table is unordered.</exception>
-        public bool TryDequeue(Predicate<KeyValuePair<TKey, TValue>> predicate, out KeyValuePair<TKey, TValue> value)
+        public bool TryDequeue(Predicate<KeyValuePair<TKey, TValue>>? predicate, out KeyValuePair<TKey, TValue> value)
         {
             if (_ordering == LurchTableOrder.None)
                 throw new InvalidOperationException();
@@ -2312,7 +2337,7 @@ namespace J2N.Collections.Concurrent
 
         private enum InsertResult { Inserted = 1, Updated = 2, Exists = 3, NotFound = 4 }
 
-        private bool InternalGetValue(int hash, TKey key, out TValue value)
+        private bool InternalGetValue(int hash, [AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             if (_entries == null)
                 throw new ObjectDisposedException(nameof(LurchTable<TKey, TValue>));
@@ -2373,7 +2398,7 @@ namespace J2N.Collections.Concurrent
             return false;
         }
 
-        private InsertResult Insert<T>(TKey key, ref T value) where T : ICreateOrUpdateValue<TKey, TValue>
+        private InsertResult Insert<T>([AllowNull] TKey key, [MaybeNull] ref T value) where T : ICreateOrUpdateValue<TKey, TValue>
         {
             if (_entries == null)
                 throw new ObjectDisposedException(nameof(LurchTable<TKey, TValue>));
@@ -2389,7 +2414,7 @@ namespace J2N.Collections.Concurrent
             return result;
         }
 
-        private InsertResult InternalInsert<T>(int hash, TKey key, out int added, ref T value) where T : ICreateOrUpdateValue<TKey, TValue>
+        private InsertResult InternalInsert<T>(int hash, [AllowNull] TKey key, out int added, ref T value) where T : ICreateOrUpdateValue<TKey, TValue>
         {
             int bucket = hash % _hsize;
             lock (_locks[bucket % _lsize])
@@ -2413,7 +2438,7 @@ namespace J2N.Collections.Concurrent
                                 InternalLink(index);
                             }
 
-                            ItemUpdated?.Invoke(new KeyValuePair<TKey, TValue>(key, original), new KeyValuePair<TKey, TValue>(key, temp));
+                            ItemUpdated?.Invoke(new KeyValuePair<TKey, TValue>(key!, original), new KeyValuePair<TKey, TValue>(key!, temp));
 
                             added = -1;
                             return InsertResult.Updated;
@@ -2437,7 +2462,7 @@ namespace J2N.Collections.Concurrent
                     if (_ordering != LurchTableOrder.None)
                         InternalLink(index);
 
-                    ItemAdded?.Invoke(new KeyValuePair<TKey, TValue>(key, temp));
+                    ItemAdded?.Invoke(new KeyValuePair<TKey, TValue>(key!, temp));
 
                     return InsertResult.Inserted;
                 }
@@ -2641,8 +2666,8 @@ namespace J2N.Collections.Concurrent
 
         private void FreeSlot(ref int index, int ver)
         {
-            _entries[index >> _shift][index & _shiftMask].Key = default;
-            _entries[index >> _shift][index & _shiftMask].Value = default;
+            _entries[index >> _shift][index & _shiftMask].Key = default!;
+            _entries[index >> _shift][index & _shiftMask].Value = default!;
             Interlocked.Exchange(ref _entries[index >> _shift][index & _shiftMask].Link, 0);
 
             int slot = (ver & int.MaxValue) % FreeSlots;
@@ -2657,7 +2682,7 @@ namespace J2N.Collections.Concurrent
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        private int GetHash(TKey key)
+        private int GetHash([AllowNull] TKey key)
         {
             return (key is null ? 0 : _comparer.GetHashCode(key)) & int.MaxValue;
         }
@@ -2665,10 +2690,13 @@ namespace J2N.Collections.Concurrent
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        private bool KeyEquals(TKey key1, TKey key2)
+        private bool KeyEquals([AllowNull] TKey key1, [AllowNull] TKey key2)
         {
             if (key1 is null)
                 return key2 is null;
+            if (key2 is null)
+                return false;
+
             return _comparer.Equals(key1, key2);
         }
 
@@ -2687,13 +2715,13 @@ namespace J2N.Collections.Concurrent
             public int Prev, Next; // insertion/access sequence ordering
             public int Link;
             public int Hash; // hash value of entry's Key
-            public TKey Key; // key of entry
-            public TValue Value; // value of entry
+            [AllowNull] public TKey Key; // key of entry
+            [AllowNull] public TValue Value; // value of entry
         }
 
         private struct EnumState
         {
-            private object _locked;
+            private object? _locked;
             public int Bucket, Current, Next;
             public void Init()
             {
@@ -2737,6 +2765,9 @@ namespace J2N.Collections.Concurrent
             {
                 if (x is null)
                     return y is null;
+                if (y is null)
+                    return false;
+
                 return wrappedComparer.Equals(x, y);
             }
 
@@ -2760,12 +2791,12 @@ namespace J2N.Collections.Concurrent
 
     internal struct DelInfo<TKey, TValue> : IRemoveValue<TKey, TValue>
     {
-        public TValue Value;
-        readonly bool _hasTestValue;
-        readonly TValue _testValue;
-        public KeyValuePredicate<TKey, TValue> Condition;
+        [AllowNull] public TValue Value;
+        private readonly bool _hasTestValue;
+        [AllowNull] private readonly TValue _testValue;
+        [AllowNull] public KeyValuePredicate<TKey, TValue> Condition;
 
-        public DelInfo(TValue expected)
+        public DelInfo([AllowNull] TValue expected)
         {
             Value = default;
             _testValue = expected;
@@ -2773,11 +2804,11 @@ namespace J2N.Collections.Concurrent
             Condition = null;
         }
 
-        public bool RemoveValue(TKey key, TValue value)
+        public bool RemoveValue([AllowNull] TKey key, [AllowNull] TValue value)
         {
             Value = value;
 
-            if (_hasTestValue && !J2N.Collections.Generic.EqualityComparer<TValue>.Default.Equals(_testValue, value))
+            if (_hasTestValue && !J2N.Collections.Generic.EqualityComparer<TValue>.Default.Equals(_testValue, value!))
                 return false;
             if (Condition != null && !Condition(key, value))
                 return false;
@@ -2786,17 +2817,18 @@ namespace J2N.Collections.Concurrent
         }
     }
 
+
     internal struct AddInfo<TKey, TValue> : ICreateOrUpdateValue<TKey, TValue>
     {
         public bool CanUpdate;
-        public TValue Value;
-        public bool CreateValue(TKey key, out TValue value)
+        [AllowNull] public TValue Value;
+        public bool CreateValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             value = Value;
             return true;
         }
 
-        public bool UpdateValue(TKey key, ref TValue value)
+        public bool UpdateValue([AllowNull] TKey key, [AllowNull] ref TValue value)
         {
             if (!CanUpdate)
             {
@@ -2811,19 +2843,19 @@ namespace J2N.Collections.Concurrent
 
     internal struct Add2Info<TKey, TValue> : ICreateOrUpdateValue<TKey, TValue>
     {
-        readonly bool _hasAddValue;
-        readonly TValue _addValue;
-        public TValue Value;
-        public Func<TKey, TValue> Create;
-        public KeyValueUpdate<TKey, TValue> Update;
+        private readonly bool _hasAddValue;
+        [AllowNull] private readonly TValue _addValue;
+        [AllowNull] public TValue Value;
+        [AllowNull] public Func<TKey, TValue> Create;
+        [AllowNull] public KeyValueUpdate<TKey, TValue> Update;
 
-        public Add2Info(TValue addValue) : this()
+        public Add2Info([AllowNull] TValue addValue) : this()
         {
             _hasAddValue = true;
             _addValue = addValue;
         }
 
-        public bool CreateValue(TKey key, out TValue value)
+        public bool CreateValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             if (_hasAddValue)
             {
@@ -2832,14 +2864,14 @@ namespace J2N.Collections.Concurrent
             }
             if (Create != null)
             {
-                value = Value = Create(key);
+                value = Value = Create(key!);
                 return true;
             }
-            value = Value = default(TValue);
+            value = Value = default;
             return false;
         }
 
-        public bool UpdateValue(TKey key, ref TValue value)
+        public bool UpdateValue([AllowNull] TKey key, [AllowNull] ref TValue value)
         {
             if (Update == null)
             {
@@ -2854,25 +2886,25 @@ namespace J2N.Collections.Concurrent
 
     internal struct UpdateInfo<TKey, TValue> : ICreateOrUpdateValue<TKey, TValue>
     {
-        public TValue Value;
-        readonly bool _hasTestValue;
-        readonly TValue _testValue;
+        [AllowNull] public TValue Value;
+        private readonly bool _hasTestValue;
+        [AllowNull] private readonly TValue _testValue;
 
-        public UpdateInfo(TValue expected)
+        public UpdateInfo([AllowNull] TValue expected)
         {
             Value = default;
             _testValue = expected;
             _hasTestValue = true;
         }
 
-        bool ICreateValue<TKey, TValue>.CreateValue(TKey key, out TValue value)
+        bool ICreateValue<TKey, TValue>.CreateValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             value = default;
             return false;
         }
-        public bool UpdateValue(TKey key, ref TValue value)
+        public bool UpdateValue([AllowNull] TKey key, [AllowNull] ref TValue value)
         {
-            if (_hasTestValue && !J2N.Collections.Generic.EqualityComparer<TValue>.Default.Equals(_testValue, value))
+            if (_hasTestValue && !J2N.Collections.Generic.EqualityComparer<TValue>.Default.Equals(_testValue, value!))
                 return false;
 
             value = Value;
@@ -2925,7 +2957,7 @@ namespace J2N.Collections.Concurrent
         /// <summary>
         /// Constructs the exception from an hresult and message bypassing the message formatting
         /// </summary>
-        protected LurchTableCorruptionException(Exception innerException, int hResult, string message) : base(message, innerException)
+        protected LurchTableCorruptionException(Exception? innerException, int hResult, string message) : base(message, innerException)
         {
             base.HResult = hResult;
         }
@@ -2939,7 +2971,7 @@ namespace J2N.Collections.Concurrent
         /// Initializes a new instance of <see cref="LurchTableCorruptionException"/> with the default message
         /// and original exception.
         /// </summary>
-        public LurchTableCorruptionException(Exception innerException) : this(innerException, -1, SR.LurchTable_CorruptedData) { }
+        public LurchTableCorruptionException(Exception? innerException) : this(innerException, -1, SR.LurchTable_CorruptedData) { }
 
         /// <summary>
         /// If <paramref name="condition"/> is <c>false</c>, throws <see cref="LurchTableCorruptionException"/> with the default message.
@@ -2955,10 +2987,10 @@ namespace J2N.Collections.Concurrent
     #region Delegates
 
     /// <summary> Provides a delegate that performs an atomic update of a key/value pair </summary>
-    public delegate TValue KeyValueUpdate<TKey, TValue>(TKey key, TValue original);
+    public delegate TValue KeyValueUpdate<TKey, TValue>([AllowNull] TKey key, [AllowNull] TValue original);
 
     /// <summary> Provides a delegate that performs a test on key/value pair </summary>
-    public delegate bool KeyValuePredicate<TKey, TValue>(TKey key, TValue original);
+    public delegate bool KeyValuePredicate<TKey, TValue>([AllowNull] TKey key, [AllowNull] TValue original);
 
     #endregion // Delegates
 
@@ -2973,7 +3005,7 @@ namespace J2N.Collections.Concurrent
         /// Called when the key was not found within the dictionary to produce a new value that can be added.
         /// Return true to continue with the insertion, or false to prevent the key/value from being inserted.
         /// </summary>
-        bool CreateValue(TKey key, out TValue value);
+        bool CreateValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value);
     }
 
     /// <summary>
@@ -2985,7 +3017,7 @@ namespace J2N.Collections.Concurrent
         /// Called when the key was found within the dictionary to produce a modified value to update the item
         /// to. Return true to continue with the update, or false to prevent the key/value from being updated.
         /// </summary>
-        bool UpdateValue(TKey key, ref TValue value);
+        bool UpdateValue([AllowNull] TKey key, [MaybeNullWhen(false)] ref TValue value);
     }
 
     /// <summary>

--- a/src/J2N/Collections/Generic/BitHelper.cs
+++ b/src/J2N/Collections/Generic/BitHelper.cs
@@ -5,7 +5,7 @@
 // Dependency of SortedSet, SortedDictionary
 
 using System;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/Comparer.cs
+++ b/src/J2N/Collections/Generic/Comparer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/DebugView/ICollectionDebugView.cs
+++ b/src/J2N/Collections/Generic/DebugView/ICollectionDebugView.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+
 namespace J2N.Collections.Generic
 {
     internal sealed class ICollectionDebugView<T>
@@ -14,7 +15,7 @@ namespace J2N.Collections.Generic
 
         public ICollectionDebugView(ICollection<T> collection)
         {
-            if (collection == null)
+            if (collection is null)
             {
                 throw new ArgumentNullException(nameof(collection));
             }

--- a/src/J2N/Collections/Generic/DebugView/IDictionaryDebugView.cs
+++ b/src/J2N/Collections/Generic/DebugView/IDictionaryDebugView.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+
 namespace J2N.Collections.Generic
 {
     internal sealed class IDictionaryDebugView<K, V> where K : notnull
@@ -14,7 +15,7 @@ namespace J2N.Collections.Generic
 
         public IDictionaryDebugView(IDictionary<K, V> dictionary)
         {
-            if (dictionary == null)
+            if (dictionary is null)
                 throw new ArgumentNullException(nameof(dictionary));
 
             _dict = dictionary;
@@ -38,7 +39,7 @@ namespace J2N.Collections.Generic
 
         public DictionaryKeyCollectionDebugView(ICollection<TKey> collection)
         {
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
             _collection = collection;
@@ -62,7 +63,7 @@ namespace J2N.Collections.Generic
 
         public DictionaryValueCollectionDebugView(ICollection<TValue> collection)
         {
-            if (collection == null)
+            if (collection is null)
                 throw new ArgumentNullException(nameof(collection));
 
             _collection = collection;

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using SCG = System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {
@@ -506,8 +506,8 @@ namespace J2N.Collections.Generic
             int count = siInfo.GetInt32(CountName);
             if (count > 0)
             {
-                KeyValuePair<TKey, TValue>[] array = (KeyValuePair<TKey, TValue>[])
-                    siInfo.GetValue(KeyValuePairsName, typeof(KeyValuePair<TKey, TValue>[]))!;
+                KeyValuePair<TKey, TValue>[]? array = (KeyValuePair<TKey, TValue>[]?)
+                    siInfo.GetValue(KeyValuePairsName, typeof(KeyValuePair<TKey, TValue>[]));
 
                 if (array == null)
                 {
@@ -772,7 +772,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation.
         /// </remarks>
-        public bool Remove(TKey key)
+        public bool Remove([AllowNull] TKey key)
         {
             if (TKeyIsNullable && key is null)
             {
@@ -784,7 +784,7 @@ namespace J2N.Collections.Generic
                 version++;
                 return true;
             }
-            else if (dictionary.Remove(key))
+            else if (dictionary.Remove(key!))
             {
                 version++;
                 return true;
@@ -927,13 +927,13 @@ namespace J2N.Collections.Generic
         /// </remarks>
         // J2N: This is an extension method on IDictionary<TKey, TValue>, but only for .NET Standard 2.1+.
         // It is redefined here to ensure we have it in prior platforms.
-        public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool Remove([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             if (TKeyIsNullable && key is null)
             {
                 if (!hasNullKey)
                 {
-                    value = default!;
+                    value = default;
                     return false;
                 }
 
@@ -941,9 +941,9 @@ namespace J2N.Collections.Generic
                 return true;
             }
 
-            if (dictionary.TryGetValue(key, out value))
+            if (dictionary.TryGetValue(key!, out value))
             {
-                dictionary.Remove(key);
+                dictionary.Remove(key!);
                 return true;
             }
 
@@ -1036,7 +1036,7 @@ namespace J2N.Collections.Generic
                         if (hasNullKey)
                             return nullEntry.Value;
                     }
-                    else if (TryGetValue((TKey)key!, out TValue value))
+                    else if (TryGetValue((TKey)key, out TValue value))
                     {
                         return value;
                     }
@@ -1053,7 +1053,7 @@ namespace J2N.Collections.Generic
 
                 try
                 {
-                    TKey tempKey = (TKey)key!;
+                    TKey tempKey = (TKey)key;
 
                     try
                     {
@@ -1081,11 +1081,11 @@ namespace J2N.Collections.Generic
 
             try
             {
-                TKey tempKey = (TKey)key!;
+                TKey tempKey = (TKey)key;
 
                 try
                 {
-                    Add(tempKey, (TValue)value!);
+                    Add(tempKey, (TValue)value);
                 }
                 catch (InvalidCastException)
                 {
@@ -1102,7 +1102,7 @@ namespace J2N.Collections.Generic
         {
             if (IsCompatibleKey(key))
             {
-                return ContainsKey((TKey)key!);
+                return ContainsKey((TKey)key);
             }
             return false;
         }
@@ -1115,7 +1115,7 @@ namespace J2N.Collections.Generic
             return ((IDictionary)dictionary).GetEnumerator();
         }
 
-        void IDictionary.Remove(object key)
+        void IDictionary.Remove(object? key)
         {
             if (IsCompatibleKey(key))
             {
@@ -1388,15 +1388,16 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
                     try
                     {
+                        object?[] objects = (object?[])array;
                         // Null check not needed because we are enumerating this
                         foreach (var item in this)
-                            objects[index++] = item!;
+                            objects[index++] = item;
                     }
                     catch (ArrayTypeMismatchException)
                     {
@@ -1541,16 +1542,17 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
 
                     try
                     {
+                        object?[] objects = (object?[])array;
                         // Null check not needed because we are enumerating this
                         foreach (var entry in this)
-                            objects[index++] = entry!;
+                            objects[index++] = entry;
                     }
                     catch (ArrayTypeMismatchException)
                     {

--- a/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/EnumerableHelpers.cs
+++ b/src/J2N/Collections/Generic/EnumerableHelpers.cs
@@ -6,7 +6,7 @@
 
 using System;
 using System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/EqualityComparer.cs
+++ b/src/J2N/Collections/Generic/EqualityComparer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/Extensions/CollectionExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/CollectionExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Collections.Generic.Extensions
 {

--- a/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Collections.Generic.Extensions
 {

--- a/src/J2N/Collections/Generic/Extensions/ListExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/ListExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Collections.Generic.Extensions
 {

--- a/src/J2N/Collections/Generic/Extensions/SetExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/SetExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Collections.Generic.Extensions
 {

--- a/src/J2N/Collections/Generic/HashHelpers.cs
+++ b/src/J2N/Collections/Generic/HashHelpers.cs
@@ -5,7 +5,7 @@
 using J2N;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace System.Collections
 {

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using SCG = System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
+
 namespace J2N.Collections.Generic
 {
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -50,7 +51,9 @@ namespace J2N.Collections.Generic
 #endif
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
     public class LinkedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
@@ -72,11 +75,11 @@ namespace J2N.Collections.Generic
 #if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
-        private KeyCollection keys;
+        private KeyCollection? keys;
 #if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
-        private ValueCollection values;
+        private ValueCollection? values;
 
 #if FEATURE_SERIALIZABLE
         [NonSerialized]
@@ -84,7 +87,7 @@ namespace J2N.Collections.Generic
         private int version;
 
 #if FEATURE_SERIALIZABLE
-        private System.Runtime.Serialization.SerializationInfo/*?*/ siInfo; //A temporary variable which we need during deserialization.
+        private System.Runtime.Serialization.SerializationInfo? siInfo; //A temporary variable which we need during deserialization.
 
         // names for serialization
         private const string EqualityComparerName = "EqualityComparer"; // Do not rename (binary serialization)
@@ -96,21 +99,21 @@ namespace J2N.Collections.Generic
         #region Constructors
 
         public LinkedDictionary()
-            : this(0, (IEqualityComparer<TKey>)null)
+            : this(0, (IEqualityComparer<TKey>?)null)
         {
         }
 
-        public LinkedDictionary(IEqualityComparer<TKey> comparer)
+        public LinkedDictionary(IEqualityComparer<TKey>? comparer)
             : this(0, comparer)
         {
         }
 
         public LinkedDictionary(int capacity)
-            : this(capacity, (IEqualityComparer<TKey>)null)
+            : this(capacity, (IEqualityComparer<TKey>?)null)
         {
         }
 
-        public LinkedDictionary(int capacity, IEqualityComparer<TKey> comparer)
+        public LinkedDictionary(int capacity, IEqualityComparer<TKey>? comparer)
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -119,9 +122,11 @@ namespace J2N.Collections.Generic
             list = new LinkedList<KeyValuePair<TKey, TValue>>();
         }
 
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LinkedDictionary(IDictionary<TKey, TValue> dictionary) : this(dictionary, null) { }
 
-        public LinkedDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
+        public LinkedDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer)
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
             : this(dictionary != null ? dictionary.Count : 0, comparer)
         {
             if (dictionary == null)
@@ -135,7 +140,7 @@ namespace J2N.Collections.Generic
             : this(collection, null)
         { }
 
-        public LinkedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey> comparer)
+        public LinkedDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer)
             : this(collection is ICollection<KeyValuePair<TKey, TValue>> col ? col.Count : 0, comparer)
         {
             if (collection == null)
@@ -163,7 +168,7 @@ namespace J2N.Collections.Generic
         {
             siInfo = info;
             int capacity = info.GetInt32(CountName);
-            var comparer = (IEqualityComparer<TKey>)siInfo.GetValue(EqualityComparerName, typeof(IEqualityComparer<TKey>));
+            var comparer = (IEqualityComparer<TKey>?)siInfo.GetValue(EqualityComparerName, typeof(IEqualityComparer<TKey>));
             dictionary = new Dictionary<TKey, LinkedListNode<KeyValuePair<TKey, TValue>>>(capacity, comparer);
             list = new LinkedList<KeyValuePair<TKey, TValue>>();
         }
@@ -206,7 +211,7 @@ namespace J2N.Collections.Generic
         /// </remarks>
         public bool ContainsValue(TValue value)
         {
-            return ContainsValue(value, EqualityComparer<TValue>.Default);
+            return ContainsValue(value, null);
         }
 
         /// <summary>
@@ -224,8 +229,10 @@ namespace J2N.Collections.Generic
         /// is proportional to <see cref="Count"/>. That is, this method is an O(<c>n</c>) operation,
         /// where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-        public bool ContainsValue(TValue value, IEqualityComparer<TValue> valueComparer) // Overload added so end user can override J2N's equality comparer
+        public bool ContainsValue(TValue value, IEqualityComparer<TValue>? valueComparer) // Overload added so end user can override J2N's equality comparer
         {
+            valueComparer ??= EqualityComparer<TValue>.Default;
+
             foreach (var pair in dictionary)
             {
                 if (valueComparer.Equals(pair.Value.Value.Value, value))
@@ -321,7 +328,7 @@ namespace J2N.Collections.Generic
         /// The <see cref="System.Runtime.Serialization.SerializationInfo"/> object associated with the current
         /// <see cref="LinkedDictionary{TKey, TValue}"/> instance is invalid.</exception>
         /// <remarks>This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.</remarks>
-        public virtual void OnDeserialization(object sender)
+        public virtual void OnDeserialization(object? sender)
         {
             if (siInfo == null)
             {
@@ -331,7 +338,7 @@ namespace J2N.Collections.Generic
             int count = siInfo.GetInt32(CountName);
             if (count > 0)
             {
-                KeyValuePair<TKey, TValue>[] array = (KeyValuePair<TKey, TValue>[])
+                KeyValuePair<TKey, TValue>[]? array = (KeyValuePair<TKey, TValue>[]?)
                     siInfo.GetValue(KeyValuePairsName, typeof(KeyValuePair<TKey, TValue>[]));
 
                 if (array == null)
@@ -405,7 +412,7 @@ namespace J2N.Collections.Generic
         /// <see cref="TryAdd(TKey, TValue)"/> does nothing and returns <c>false</c>.</remarks>
         // J2N: Explicitly defined to undercut the extension method in CollectionExtensions that doesn't allow
         // null keys.
-        public bool TryAdd(TKey key, TValue value)
+        public bool TryAdd([AllowNull] TKey key, [AllowNull] TValue value)
         {
             if (!dictionary.ContainsKey(key))
             {
@@ -430,16 +437,16 @@ namespace J2N.Collections.Generic
         /// </remarks>
         // J2N: This is an extension method on IDictionary<TKey, TValue>, but only for .NET Standard 2.1+.
         // It is redefined here to ensure we have it in prior platforms.
-        public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool Remove([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
-            if (dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+            if (dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
                 value = node.Value.Value;
                 DoRemove(node);
                 return true;
             }
 
-            value = default!;
+            value = default;
             return false;
         }
 
@@ -582,23 +589,23 @@ namespace J2N.Collections.Generic
         /// Getting the value of this property is an O(log <c>n</c>) operation; setting the property is also
         /// an O(log <c>n</c>) operation.
         /// </remarks>
-        public TValue this[TKey key]
+        public TValue this[[AllowNull] TKey key]
         {
             get
             {
-                if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+                if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
                 {
                     throw new KeyNotFoundException(J2N.SR.Format(SR.Arg_KeyNotFoundWithKey, key));
                 }
 
-                if (node == null)
-                    return default(TValue);
+                if (node is null)
+                    return default(TValue)!;
 
                 return node.Value.Value;
             }
             set
             {
-                if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+                if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
                 {
                     DoAdd(key, value);
                     return;
@@ -627,7 +634,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-        public void Add(TKey key, TValue value)
+        public void Add([AllowNull] TKey key, [AllowNull] TValue value)
         {
             if (dictionary.ContainsKey(key))
                 throw new ArgumentException(J2N.SR.Format(SR.Argument_AddingDuplicate, key));
@@ -642,7 +649,7 @@ namespace J2N.Collections.Generic
         /// <returns><c>true</c> if the <see cref="LinkedDictionary{TKey, TValue}"/> contains an element
         /// with the specified key; otherwise, <c>false</c>.</returns>
         /// <remarks>This method is an O(log <c>n</c>) operation.</remarks>
-        public bool ContainsKey(TKey key)
+        public bool ContainsKey([AllowNull] TKey key)
             => dictionary.ContainsKey(key);
 
         /// <summary>
@@ -668,9 +675,11 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method approaches an O(1) operation.
         /// </remarks>
-        public bool TryGetValue(TKey key, out TValue value)
+#pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
+        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
+#pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
         {
-            if (dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+            if (dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
                 value = node.Value.Value;
                 return true;
@@ -691,9 +700,9 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation.
         /// </remarks>
-        public bool Remove(TKey key)
+        public bool Remove([AllowNull] TKey key)
         {
-            if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+            if (!dictionary.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
                 return false;
             }
@@ -705,19 +714,19 @@ namespace J2N.Collections.Generic
 
         #region Private Helper Methods
 
-        private void DoAdd(TKey key, TValue value)
+        private void DoAdd([AllowNull] TKey key, [AllowNull] TValue value)
         {
             version++;
-            var pair = new KeyValuePair<TKey, TValue>(key, value);
+            var pair = new KeyValuePair<TKey, TValue>(key!, value!);
             var node = new LinkedListNode<KeyValuePair<TKey, TValue>>(pair);
             dictionary.Add(key, node);
             list.AddLast(node);
         }
 
-        private void DoSet(LinkedListNode<KeyValuePair<TKey, TValue>> node, TKey key, TValue value)
+        private void DoSet(LinkedListNode<KeyValuePair<TKey, TValue>> node, [AllowNull] TKey key, [AllowNull] TValue value)
         {
             version++;
-            var pair = new KeyValuePair<TKey, TValue>(key, value);
+            var pair = new KeyValuePair<TKey, TValue>(key!, value!);
             var newNode = new LinkedListNode<KeyValuePair<TKey, TValue>>(pair);
             dictionary[key] = newNode;
             list.AddAfter(node, newNode);
@@ -731,7 +740,7 @@ namespace J2N.Collections.Generic
             list.Remove(node);
         }
 
-        private static bool IsCompatibleKey(object key)
+        private static bool IsCompatibleKey(object? key)
         {
             if (key is null)
                 return typeof(TKey).IsNullableType();
@@ -739,9 +748,9 @@ namespace J2N.Collections.Generic
             return (key is TKey);
         }
 
-        private bool TryGetNode(TKey key, TValue value, out LinkedListNode<KeyValuePair<TKey, TValue>> node)
+        private bool TryGetNode([AllowNull] TKey key, [AllowNull] TValue value, [MaybeNullWhen(false)] out LinkedListNode<KeyValuePair<TKey, TValue>> node)
         {
-            if (dictionary.TryGetValue(key, out node) && EqualityComparer<TValue>.Default.Equals(value, node.Value.Value))
+            if (dictionary.TryGetValue(key, out node) && EqualityComparer<TValue>.Default.Equals(value!, node.Value.Value))
                 return true;
             node = null;
             return false;
@@ -795,7 +804,7 @@ namespace J2N.Collections.Generic
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
         {
-            if (!TryGetNode(item.Key, item.Value, out LinkedListNode<KeyValuePair<TKey, TValue>> node))
+            if (!TryGetNode(item.Key, item.Value, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
                 return false;
             }
@@ -819,7 +828,7 @@ namespace J2N.Collections.Generic
 
         object ICollection.SyncRoot => ((IDictionary)dictionary).SyncRoot;
 
-        object IDictionary.this[object key]
+        object? IDictionary.this[object? key]
         {
             get
             {
@@ -846,7 +855,7 @@ namespace J2N.Collections.Generic
                     TKey tempKey = (TKey)key;
                     try
                     {
-                        this[tempKey] = (TValue)value;
+                        this[tempKey] = (TValue)value!;
                     }
                     catch (InvalidCastException)
                     {
@@ -860,7 +869,7 @@ namespace J2N.Collections.Generic
             }
         }
 
-        void IDictionary.Add(object key, object value)
+        void IDictionary.Add(object? key, object? value)
         {
             // J2N: Only throw if the generic closing type is not nullable
             if (key is null && !typeof(TKey).IsNullableType())
@@ -887,7 +896,7 @@ namespace J2N.Collections.Generic
             }
         }
 
-        bool IDictionary.Contains(object key)
+        bool IDictionary.Contains(object? key)
         {
             if (IsCompatibleKey(key))
             {
@@ -901,7 +910,7 @@ namespace J2N.Collections.Generic
             return new Enumerator(this, Enumerator.DictEntry);
         }
 
-        void IDictionary.Remove(object key)
+        void IDictionary.Remove(object? key)
         {
             if (IsCompatibleKey(key))
             {
@@ -929,7 +938,7 @@ namespace J2N.Collections.Generic
             else if (array is DictionaryEntry[] dictEntryArray)
             {
                 foreach (var item in this)
-                    dictEntryArray[index++] = new DictionaryEntry(item.Key, item.Value);
+                    dictEntryArray[index++] = new DictionaryEntry(item.Key!, item.Value);
             }
             else
             {
@@ -954,9 +963,11 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         #region IReadOnlyDictionary<TKey, TValue> Members
 
+#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
 
         #endregion IReadOnlyDictionary<TKey, TValue> Members
 #endif
@@ -973,7 +984,7 @@ namespace J2N.Collections.Generic
         /// <returns><c>true</c> if <paramref name="other"/> is structurally equal to the current dictionary;
         /// otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="comparer"/> is <c>null</c>.</exception>
-        public virtual bool Equals(object other, IEqualityComparer comparer)
+        public virtual bool Equals(object? other, IEqualityComparer comparer)
             => DictionaryEqualityComparer<TKey, TValue>.Equals(this, other, comparer);
 
         /// <summary>
@@ -995,7 +1006,7 @@ namespace J2N.Collections.Generic
         /// <returns><c>true</c> if the specified object implements <see cref="IDictionary{TKey, TValue}"/>
         /// and it contains the same elements; otherwise, <c>false</c>.</returns>
         /// <seealso cref="Equals(object, IEqualityComparer)"/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
             => Equals(obj, DictionaryEqualityComparer<TKey, TValue>.Default);
 
         /// <summary>
@@ -1024,7 +1035,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// The index of a format item is not zero.
         /// </exception>
-        public virtual string ToString(string format, IFormatProvider formatProvider)
+        public virtual string ToString(string? format, IFormatProvider? formatProvider)
             => CollectionUtil.ToString(formatProvider, format, this);
 
         /// <summary>
@@ -1219,7 +1230,7 @@ namespace J2N.Collections.Generic
 
                     if (_getEnumeratorRetType == DictEntry)
                     {
-                        return new DictionaryEntry(Current.Key, Current.Value);
+                        return new DictionaryEntry(Current.Key!, Current.Value);
                     }
                     else
                     {
@@ -1228,9 +1239,11 @@ namespace J2N.Collections.Generic
                 }
             }
 
-            object IDictionaryEnumerator.Key
+            object? IDictionaryEnumerator.Key
             {
+#pragma warning disable CS8616, CS8768 // Nullability of reference types in return type doesn't match implemented member (possibly because of nullability attributes).
                 get
+#pragma warning restore CS8616, CS8768 // Nullability of reference types in return type doesn't match implemented member (possibly because of nullability attributes).
                 {
                     if (notStartedOrEnded)
                     {
@@ -1241,7 +1254,7 @@ namespace J2N.Collections.Generic
                 }
             }
 
-            object IDictionaryEnumerator.Value
+            object? IDictionaryEnumerator.Value
             {
                 get
                 {
@@ -1263,7 +1276,7 @@ namespace J2N.Collections.Generic
                         throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
                     }
 
-                    return new DictionaryEntry(Current.Key, Current.Value);
+                    return new DictionaryEntry(Current.Key!, Current.Value);
                 }
             }
         }
@@ -1353,12 +1366,13 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
                     try
                     {
+                        object?[] objects = (object?[])array;
                         foreach (var item in this)
                             objects[index++] = item;
                     }
@@ -1392,7 +1406,7 @@ namespace J2N.Collections.Generic
 
                 public TKey Current => enumerator.Current.Key;
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {
@@ -1527,12 +1541,13 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
-                    if (!(array is object[] objects))
+                    if (!(array is object?[]))
                     {
                         throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
                     }
                     try
                     {
+                        object?[] objects = (object?[])array;
                         foreach (var entry in this)
                             objects[index++] = entry;
                     }
@@ -1576,7 +1591,7 @@ namespace J2N.Collections.Generic
 
                 public TValue Current => enumerator.Current.Value;
 
-                object IEnumerator.Current
+                object? IEnumerator.Current
                 {
                     get
                     {

--- a/src/J2N/Collections/Generic/LinkedHashSet.cs
+++ b/src/J2N/Collections/Generic/LinkedHashSet.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using SCG = System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -13,7 +13,7 @@ using System.Diagnostics.Contracts;
 #if !FEATURE_CASEINSENSITIVECOMPARER
 using CaseInsensitiveComparer = System.StringComparer; // To fixup documentation - this type doesn't exist on .NET Standard 1.x
 #endif
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/ListEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/ListEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/PriorityQueue.cs
+++ b/src/J2N/Collections/Generic/PriorityQueue.cs
@@ -4,7 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/SetEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/SetEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -12,7 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 #endif
 using SCG = System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {
@@ -674,7 +674,7 @@ namespace J2N.Collections.Generic
         /// This method approaches an O(1) operation.
         /// </remarks>
 #pragma warning disable CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
-        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
         {
             //if (key == null) // J2N: Making key nullable
@@ -682,10 +682,10 @@ namespace J2N.Collections.Generic
             //    throw new ArgumentNullException(nameof(key));
             //}
 
-            TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default!));
+            TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key!, default!));
             if (node == null)
             {
-                value = default!;
+                value = default;
                 return false;
             }
             value = node.Item.Value;
@@ -1339,6 +1339,10 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
+                    if (!(array is object?[]))
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
+                    }
                     try
                     {
                         object?[] objects = (object?[])array;
@@ -1688,6 +1692,10 @@ namespace J2N.Collections.Generic
                 }
                 else
                 {
+                    if (!(array is object?[]))
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
+                    }
                     try
                     {
                         object?[] objects = (object?[])array;

--- a/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -11,7 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE
 using System.Runtime.Serialization;
 #endif
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -12,7 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 #endif
 using Interlocked = System.Threading.Interlocked;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/Generic/SortedSetEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/SortedSetEqualityComparer.cs
@@ -5,7 +5,7 @@
 // Dependency of SortedSet, SortedDictionary
 
 using System.Collections.Generic;
-#nullable enable
+
 
 namespace J2N.Collections.Generic
 {

--- a/src/J2N/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.ObjectModel
 {

--- a/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -9,7 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 #endif
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.ObjectModel
 {

--- a/src/J2N/Collections/ObjectModel/ReadOnlyList.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlyList.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.ObjectModel
 {

--- a/src/J2N/Collections/ObjectModel/ReadOnlySet.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlySet.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections.ObjectModel
 {

--- a/src/J2N/Collections/OneDimensionalArrayEqualityComparer.cs
+++ b/src/J2N/Collections/OneDimensionalArrayEqualityComparer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/StructuralEqualityComparer.cs
+++ b/src/J2N/Collections/StructuralEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/Collections/StructuralEqualityUtil.cs
+++ b/src/J2N/Collections/StructuralEqualityUtil.cs
@@ -1,7 +1,7 @@
 ﻿using J2N.Collections.Generic;
 using System;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N.Collections
 {

--- a/src/J2N/DoubleExtensions.cs
+++ b/src/J2N/DoubleExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Globalization/CultureContext.cs
+++ b/src/J2N/Globalization/CultureContext.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-#nullable enable
+
 
 namespace J2N.Globalization
 {

--- a/src/J2N/IO/Buffer.cs
+++ b/src/J2N/IO/Buffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/BufferOverflowException.cs
+++ b/src/J2N/IO/BufferOverflowException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/BufferUnderflowException.cs
+++ b/src/J2N/IO/BufferUnderflowException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ByteBuffer.cs
+++ b/src/J2N/IO/ByteBuffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ByteOrder.cs
+++ b/src/J2N/IO/ByteOrder.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/CharArrayBuffer.cs
+++ b/src/J2N/IO/CharArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/CharBuffer.cs
+++ b/src/J2N/IO/CharBuffer.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {
@@ -862,7 +862,7 @@ namespace J2N.IO
         /// <returns>This buffer.</returns>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than the length of <paramref name="value"/>.</exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(char[] value)
+        public virtual CharBuffer Append(char[]? value)
         {
             if (value != null)
             {
@@ -894,7 +894,7 @@ namespace J2N.IO
         /// <paramref name="startIndex"/> or <paramref name="count"/> is less than zero.
         /// </exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(char[] value, int startIndex, int count)
+        public virtual CharBuffer Append(char[]? value, int startIndex, int count)
         {
             ICharSequence cs;
             if (value is null)
@@ -921,7 +921,7 @@ namespace J2N.IO
         /// <returns>This buffer.</returns>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than the length of <paramref name="value"/>.</exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(StringBuilder value)
+        public virtual CharBuffer Append(StringBuilder? value)
         {
             if (value != null)
             {
@@ -953,7 +953,7 @@ namespace J2N.IO
         /// <paramref name="startIndex"/> or <paramref name="count"/> is less than zero.
         /// </exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(StringBuilder value, int startIndex, int count)
+        public virtual CharBuffer Append(StringBuilder? value, int startIndex, int count)
         {
             string cs;
             if (value is null)
@@ -981,7 +981,7 @@ namespace J2N.IO
         /// <returns>This buffer.</returns>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than the length of <paramref name="value"/>.</exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(string value)
+        public virtual CharBuffer Append(string? value)
         {
             if (value != null)
             {
@@ -1013,7 +1013,7 @@ namespace J2N.IO
         /// <paramref name="startIndex"/> or <paramref name="count"/> is less than zero.
         /// </exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(string value, int startIndex, int count)
+        public virtual CharBuffer Append(string? value, int startIndex, int count)
         {
             if (value is null)
                 value = "null";
@@ -1039,7 +1039,7 @@ namespace J2N.IO
         /// <returns>This buffer.</returns>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than the length of <paramref name="value"/>.</exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(ICharSequence value)
+        public virtual CharBuffer Append(ICharSequence? value)
         {
             if (value != null)
             {
@@ -1071,7 +1071,7 @@ namespace J2N.IO
         /// <paramref name="startIndex"/> or <paramref name="count"/> is less than zero.
         /// </exception>
         /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
-        public virtual CharBuffer Append(ICharSequence value, int startIndex, int count)
+        public virtual CharBuffer Append(ICharSequence? value, int startIndex, int count)
         {
             if (value is null)
             {
@@ -1131,21 +1131,21 @@ namespace J2N.IO
 
         IAppendable IAppendable.Append(char value) => Append(value);
 
-        IAppendable IAppendable.Append(string value) => Append(value);
+        IAppendable IAppendable.Append(string? value) => Append(value);
 
-        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(string? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(StringBuilder value) => Append(value);
+        IAppendable IAppendable.Append(StringBuilder? value) => Append(value);
 
-        IAppendable IAppendable.Append(StringBuilder value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(StringBuilder? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(char[] value) => Append(value);
+        IAppendable IAppendable.Append(char[]? value) => Append(value);
 
-        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(char[]? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(ICharSequence value) => Append(value);
+        IAppendable IAppendable.Append(ICharSequence? value) => Append(value);
 
-        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(ICharSequence? value, int startIndex, int count) => Append(value, startIndex, count);
 
         #endregion
     }

--- a/src/J2N/IO/CharSequenceAdapter.cs
+++ b/src/J2N/IO/CharSequenceAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using J2N.Text;
 using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/CharToByteBufferAdapter.cs
+++ b/src/J2N/IO/CharToByteBufferAdapter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/DataInputStream.cs
+++ b/src/J2N/IO/DataInputStream.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/DataOutputStream.cs
+++ b/src/J2N/IO/DataOutputStream.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/DoubleArrayBuffer.cs
+++ b/src/J2N/IO/DoubleArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/DoubleBuffer.cs
+++ b/src/J2N/IO/DoubleBuffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/DoubleToByteBufferAdapter.cs
+++ b/src/J2N/IO/DoubleToByteBufferAdapter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Endianness.cs
+++ b/src/J2N/IO/Endianness.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/HeapByteBuffer.cs
+++ b/src/J2N/IO/HeapByteBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/IDataInput.cs
+++ b/src/J2N/IO/IDataInput.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/IDataOutput.cs
+++ b/src/J2N/IO/IDataOutput.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int16ArrayBuffer.cs
+++ b/src/J2N/IO/Int16ArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int16Buffer.cs
+++ b/src/J2N/IO/Int16Buffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int16ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int16ToByteBufferAdapter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int32ArrayBuffer.cs
+++ b/src/J2N/IO/Int32ArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int32Buffer.cs
+++ b/src/J2N/IO/Int32Buffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int32ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int32ToByteBufferAdapter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int64ArrayBuffer.cs
+++ b/src/J2N/IO/Int64ArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int64Buffer.cs
+++ b/src/J2N/IO/Int64Buffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/Int64ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int64ToByteBufferAdapter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/InvalidMarkException.cs
+++ b/src/J2N/IO/InvalidMarkException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/MemoryMappedFiles/MemoryMappedFileExtensions.cs
+++ b/src/J2N/IO/MemoryMappedFiles/MemoryMappedFileExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO.MemoryMappedFiles;
-#nullable enable
+
 
 namespace J2N.IO.MemoryMappedFiles
 {

--- a/src/J2N/IO/MemoryMappedFiles/MemoryMappedViewByteBuffer.cs
+++ b/src/J2N/IO/MemoryMappedFiles/MemoryMappedViewByteBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO.MemoryMappedFiles;
-#nullable enable
+
 
 namespace J2N.IO.MemoryMappedFiles
 {

--- a/src/J2N/IO/MemoryMappedFiles/ReadOnlyMemoryMappedViewByteBuffer.cs
+++ b/src/J2N/IO/MemoryMappedFiles/ReadOnlyMemoryMappedViewByteBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO.MemoryMappedFiles;
-#nullable enable
+
 
 namespace J2N.IO.MemoryMappedFiles
 {

--- a/src/J2N/IO/MemoryMappedFiles/ReadWriteMemoryMappedViewByteBuffer.cs
+++ b/src/J2N/IO/MemoryMappedFiles/ReadWriteMemoryMappedViewByteBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO.MemoryMappedFiles;
-#nullable enable
+
 
 namespace J2N.IO.MemoryMappedFiles
 {

--- a/src/J2N/IO/ReadOnlyBufferException.cs
+++ b/src/J2N/IO/ReadOnlyBufferException.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyDoubleArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyDoubleArrayBuffer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyHeapByteBuffer.cs
+++ b/src/J2N/IO/ReadOnlyHeapByteBuffer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyInt16ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt16ArrayBuffer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyInt32ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt32ArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlyInt64ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt64ArrayBuffer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadOnlySingleArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlySingleArrayBuffer.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+﻿
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteCharArrayBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteHeapByteBuffer.cs
+++ b/src/J2N/IO/ReadWriteHeapByteBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/SingleArrayBuffer.cs
+++ b/src/J2N/IO/SingleArrayBuffer.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/SingleBuffer.cs
+++ b/src/J2N/IO/SingleBuffer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/SingleToByteBufferAdapter.cs
+++ b/src/J2N/IO/SingleToByteBufferAdapter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IO/StreamTokenizer.cs
+++ b/src/J2N/IO/StreamTokenizer.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Text;
-#nullable enable
+
 
 namespace J2N.IO
 {

--- a/src/J2N/IntegralNumberExtensions.cs
+++ b/src/J2N/IntegralNumberExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -4,7 +4,10 @@
     <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <WarningsAsErrors>NU1605;1591</WarningsAsErrors>
+
+    <WarningsAsErrors Label="Force all public members to have XML doc comments.">NU1605;1591</WarningsAsErrors>
+
+    <Nullable>enable</Nullable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -17,12 +17,10 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpPackageReferenceVersion)" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpPackageReferenceVersion)" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">

--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Numerics
 {

--- a/src/J2N/PropertyExtensions.cs
+++ b/src/J2N/PropertyExtensions.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Text;
 using SR2 = J2N.Resources.Strings;
 using StringBuffer = System.Text.StringBuilder;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/PropertyExtensions.cs
+++ b/src/J2N/PropertyExtensions.cs
@@ -17,15 +17,10 @@ namespace J2N
     /// </summary>
     public static class PropertyExtensions
     {
-#if FEATURE_ENCODINGPROVIDERS
-        static PropertyExtensions()
-        {
-            // Support for iso-8859-1 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-            var encodingProvider = CodePagesEncodingProvider.Instance;
-            System.Text.Encoding.RegisterProvider(encodingProvider);
-        }
-#endif
-
+        // J2N Encoding note: This class requires iso-8859-1, which according to the docs is supported already in .NET Core.
+        // Some other platforms may require a reference to the System.Text.Encoding.CodePages NuGet package and to add the line
+        // System.Text.Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        // at startup.
 
         /// <summary>
         /// Retrieves the value of a property from the current dictionary
@@ -240,12 +235,16 @@ namespace J2N
             }
         }
 
-
         /// <summary>
         /// Reads a property list (key and element pairs) from the input
         /// <see cref="TextReader"/> in a simple line-oriented format.
         /// <para/>
         /// The file format is compatible with Java properties, so they can easily be written or consumed by .NET.
+        /// <para/>
+        /// Usage Note: This method requires ISO-8859-1 encoding and depending on your platform, you may need
+        /// to register the encoding provider to use it. See
+        /// <a href="https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider">CodePagesEncodingProvider</a>
+        /// for details about registering a provider.
         /// <para/>
         /// Properties are processed in terms of lines. There are two
         /// kinds of line, <i>natural lines</i> and <i>logical lines</i>.
@@ -416,6 +415,11 @@ namespace J2N
         /// <para/>
         /// The file format is compatible with Java properties, so they can easily be written or consumed by .NET.
         /// <para/>
+        /// Usage Note: This method requires ISO-8859-1 encoding and depending on your platform, you may need
+        /// to register the encoding provider to use it. See
+        /// <a href="https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider">CodePagesEncodingProvider</a>
+        /// for details about registering a provider.
+        /// <para/>
         /// This method outputs the properties keys and values in
         /// the same format as specified in
         /// <see cref="SaveProperties(IDictionary{string, string}, TextWriter)"/>,
@@ -474,6 +478,11 @@ namespace J2N
         /// method.
         /// <para/>
         /// The file format is compatible with Java properties, so they can easily be written or consumed by .NET.
+        /// <para/>
+        /// Usage Note: This method requires ISO-8859-1 encoding and depending on your platform, you may need
+        /// to register the encoding provider to use it. See
+        /// <a href="https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider">CodePagesEncodingProvider</a>
+        /// for details about registering a provider.
         /// <para/>
         /// This method outputs the comments, properties keys and values in
         /// the same format as specified in

--- a/src/J2N/Randomizer.cs
+++ b/src/J2N/Randomizer.cs
@@ -1,7 +1,7 @@
 ﻿using J2N.Numerics;
 using System;
 using SR2 = J2N.Resources.Strings;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Resources/SR.cs
+++ b/src/J2N/Resources/SR.cs
@@ -19,14 +19,14 @@ namespace J2N
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool UsingResourceKeys() => false;
 
-        internal static string GetResourceString(string resourceKey, string defaultString = null)
+        internal static string? GetResourceString(string resourceKey, string? defaultString = null)
         {
             if (UsingResourceKeys())
             {
                 return defaultString ?? resourceKey;
             }
 
-            string resourceString = null;
+            string? resourceString = null;
             try
             {
                 resourceString = Resources.Strings.ResourceManager.GetString(resourceKey);
@@ -41,7 +41,7 @@ namespace J2N
             return resourceString; // only null if missing resources
         }
 
-        internal static string Format(string resourceFormat, object p1)
+        internal static string Format(string resourceFormat, object? p1)
         {
             if (UsingResourceKeys())
             {
@@ -51,7 +51,7 @@ namespace J2N
             return string.Format(resourceFormat, p1);
         }
 
-        internal static string Format(string resourceFormat, object p1, object p2)
+        internal static string Format(string resourceFormat, object? p1, object? p2)
         {
             if (UsingResourceKeys())
             {
@@ -61,7 +61,7 @@ namespace J2N
             return string.Format(resourceFormat, p1, p2);
         }
 
-        internal static string Format(string resourceFormat, object p1, object p2, object p3)
+        internal static string Format(string resourceFormat, object? p1, object? p2, object? p3)
         {
             if (UsingResourceKeys())
             {
@@ -71,7 +71,7 @@ namespace J2N
             return string.Format(resourceFormat, p1, p2, p3);
         }
 
-        internal static string Format(string resourceFormat, params object[] args)
+        internal static string Format(string resourceFormat, params object?[] args)
         {
             if (args != null)
             {

--- a/src/J2N/Resources/Strings.Designer.cs
+++ b/src/J2N/Resources/Strings.Designer.cs
@@ -412,6 +412,15 @@ namespace J2N.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot edit a null {0}..
+        /// </summary>
+        internal static string InvalidOperation_CannotEditNullObject {
+            get {
+                return ResourceManager.GetString("InvalidOperation_CannotEditNullObject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot index a null {0}..
         /// </summary>
         internal static string InvalidOperation_CannotIndexNullObject {

--- a/src/J2N/Resources/Strings.resx
+++ b/src/J2N/Resources/Strings.resx
@@ -234,6 +234,9 @@
   <data name="Format_InvalidUTFTooLong" xml:space="preserve">
     <value>UTF8 data format too long.</value>
   </data>
+  <data name="InvalidOperation_CannotEditNullObject" xml:space="preserve">
+    <value>Cannot edit a null {0}.</value>
+  </data>
   <data name="InvalidOperation_CannotIndexNullObject" xml:space="preserve">
     <value>Cannot index a null {0}.</value>
   </data>

--- a/src/J2N/Runtime/CompilerServices/IdentityEqualityComparer.cs
+++ b/src/J2N/Runtime/CompilerServices/IdentityEqualityComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N.Runtime.CompilerServices
 {

--- a/src/J2N/SingleExtensions.cs
+++ b/src/J2N/SingleExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/Text/CharArrayCharSequence.cs
+++ b/src/J2N/Text/CharArrayCharSequence.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -20,7 +21,7 @@ namespace J2N.Text
         /// Initializes a new instance of <see cref="CharArrayCharSequence"/> with the provided <paramref name="value"/>.
         /// </summary>
         /// <param name="value">A <see cref="T:char[]"/> to wrap in a <see cref="ICharSequence"/>. The value may be <c>null</c>.</param>
-        public CharArrayCharSequence(char[] value)
+        public CharArrayCharSequence(char[]? value)
         {
             this.Value = value;
             this.HasValue = (value != null);
@@ -30,7 +31,7 @@ namespace J2N.Text
         /// Gets the current <see cref="T:char[]"/> value.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819", Justification = "design requires some writable array properties")]
-        public char[] Value { get; }
+        public char[]? Value { get; }
 
         #region ICharSequence Members
 
@@ -57,7 +58,7 @@ namespace J2N.Text
         {
             get
             {
-                if (Value == null)
+                if (Value is null)
                     throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotIndexNullObject, nameof(CharArrayCharSequence)));
                 return Value[index];
             }
@@ -68,7 +69,7 @@ namespace J2N.Text
         /// </summary>
         public int Length
         {
-            get { return (Value == null) ? 0 : Value.Length; }
+            get { return (Value is null) ? 0 : Value.Length; }
         }
 
         /// <summary>
@@ -95,7 +96,7 @@ namespace J2N.Text
         public ICharSequence Subsequence(int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (Value == null || (startIndex == 0 && length == Value.Length))
+            if (Value is null || (startIndex == 0 && length == Value.Length))
             {
                 return new CharArrayCharSequence(Value);
             }
@@ -120,7 +121,7 @@ namespace J2N.Text
         /// <returns>A string based on this sequence.</returns>
         public override string ToString()
         {
-            return (Value == null) ? string.Empty : new string(Value);
+            return (Value is null) ? string.Empty : new string(Value);
         }
 
         #endregion
@@ -135,8 +136,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(CharArrayCharSequence csq1, CharArrayCharSequence csq2)
+        public static bool operator ==(CharArrayCharSequence? csq1, CharArrayCharSequence? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq1.Equals(csq2);
         }
 
@@ -148,7 +154,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(CharArrayCharSequence csq1, CharArrayCharSequence csq2)
+        public static bool operator !=(CharArrayCharSequence? csq1, CharArrayCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -161,8 +167,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(CharArrayCharSequence csq1, char[] csq2)
+        public static bool operator ==(CharArrayCharSequence? csq1, char[]? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null;
+            else if (csq2 is null)
+                return !csq1.HasValue;
+
             return csq1.Equals(csq2);
         }
 
@@ -174,7 +185,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(CharArrayCharSequence csq1, char[] csq2)
+        public static bool operator !=(CharArrayCharSequence? csq1, char[]? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -187,8 +198,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(char[] csq1, CharArrayCharSequence csq2)
+        public static bool operator ==(char[]? csq1, CharArrayCharSequence? csq2)
         {
+            if (csq1 is null)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq2.Equals(csq1);
         }
 
@@ -200,7 +216,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(char[] csq1, CharArrayCharSequence csq2)
+        public static bool operator !=(char[]? csq1, CharArrayCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -214,11 +230,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An <see cref="ICharSequence"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(ICharSequence other)
+        public bool Equals(ICharSequence? other)
         {
-            if (this.Value == null)
-                return other == null || !other.HasValue;
-            if (other == null)
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
                 return false;
 
             int len = other.Length;
@@ -235,8 +251,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="CharArrayCharSequence"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(CharArrayCharSequence other)
+        public bool Equals(CharArrayCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -245,8 +266,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilderCharSequence"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilderCharSequence other)
+        public bool Equals(StringBuilderCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -255,8 +281,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringCharSequence"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringCharSequence other)
+        public bool Equals(StringCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -265,11 +296,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="string"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(string other)
+        public bool Equals(string? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = other.Length;
@@ -286,11 +317,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilder"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilder other)
+        public bool Equals(StringBuilder? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = other.Length;
@@ -310,11 +341,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="T:char[]"/> to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(char[] other)
+        public bool Equals(char[]? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = other.Length;
@@ -331,20 +362,23 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An object to compare to the current <see cref="CharArrayCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="CharArrayCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
-            if (other is string)
-                return Equals(other as string);
-            else if (other is StringBuilder)
-                return Equals(other as StringBuilder);
-            else if (other is char[])
-                return Equals(other as char[]);
-            else if (other is StringCharSequence otherString)
+            if (other is null)
+                return !HasValue;
+
+            if (other is string otherString)
                 return Equals(otherString);
-            else if (other is CharArrayCharSequence otherCharArray)
-                return Equals(otherCharArray);
-            else if (other is StringBuilderCharSequence otherStringBuilder)
+            else if (other is StringBuilder otherStringBuilder)
                 return Equals(otherStringBuilder);
+            else if (other is char[] otherCharArray)
+                return Equals(otherCharArray);
+            else if (other is StringCharSequence otherStringCharSequence)
+                return Equals(otherStringCharSequence);
+            else if (other is CharArrayCharSequence otherCharArrayCharSequence)
+                return Equals(otherCharArrayCharSequence);
+            else if (other is StringBuilderCharSequence otherStringBuilderCharSequence)
+                return Equals(otherStringBuilderCharSequence);
             else if (other is ICharSequence otherCharSequence)
                 return Equals(otherCharSequence);
 
@@ -379,8 +413,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(ICharSequence other)
+        public int CompareTo(ICharSequence? other)
         {
+            if (this.Value is null) return (other is null || !other.HasValue) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -395,8 +432,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(string other)
+        public int CompareTo(string? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -411,8 +451,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(StringBuilder other)
+        public int CompareTo(StringBuilder? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -427,8 +470,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(char[] other)
+        public int CompareTo(char[]? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -443,10 +489,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(object other)
+        public int CompareTo(object? other)
         {
-            if (this.Value == null) return -1;
-            if (other == null) return 1;
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
 
             return this.Value.CompareToOrdinal(other.ToString());
         }

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -15,7 +16,7 @@ namespace J2N.Text
         /// so a <see cref="T:char[]"/> can be used as <see cref="ICharSequence"/> in .NET.
         /// </summary>
         /// <param name="text">This <see cref="T:char[]"/>.</param>
-        public static ICharSequence AsCharSequence(this char[] text)
+        public static ICharSequence AsCharSequence(this char[]? text)
         {
             return new CharArrayCharSequence(text);
         }
@@ -41,10 +42,10 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static ICharSequence Subsequence(this char[] text, int startIndex, int length)
+        public static ICharSequence Subsequence(this char[]? text, int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (text == null || (startIndex == 0 && length == text.Length))
+            if (text is null || (startIndex == 0 && length == text.Length))
             {
                 return text.AsCharSequence();
             }
@@ -80,11 +81,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this char[] str, char[] value)
+        public static int CompareToOrdinal(this char[]? str, char[]? value)
         {
             if (object.ReferenceEquals(str, value)) return 0;
-            if (str == null) return -1;
-            if (value == null) return 1;
+            if (str is null) return -1;
+            if (value is null) return 1;
 
             int length = Math.Min(str.Length, value.Length);
             int result;
@@ -117,10 +118,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this char[] str, StringBuilder value)
+        public static int CompareToOrdinal(this char[]? str, StringBuilder? value)
         {
-            if (str == null) return -1;
-            if (value == null) return 1;
+            if (str is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             // Materialize the string. It is faster to loop through
             // a string than a StringBuilder.
@@ -157,10 +158,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this char[] str, string value)
+        public static int CompareToOrdinal(this char[]? str, string? value)
         {
-            if (str == null) return -1;
-            if (value == null) return 1;
+            if (str is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             int length = Math.Min(str.Length, value.Length);
             int result;
@@ -193,12 +194,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this char[] str, ICharSequence value)
+        public static int CompareToOrdinal(this char[]? str, ICharSequence? value)
         {
             if (value is CharArrayCharSequence && object.ReferenceEquals(str, value)) return 0;
-            if (str == null) return -1;
-            if (value == null) return 1;
-            if (!value.HasValue) return 1;
+            if (str == null) return (value is null || !value.HasValue) ? 0 : -1;
+            if (value == null || !value.HasValue) return 1;
 
             int length = Math.Min(str.Length, value.Length);
             int result;

--- a/src/J2N/Text/CharSequenceComparer.cs
+++ b/src/J2N/Text/CharSequenceComparer.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 
+
 namespace J2N.Text
 {
     /// <summary>
@@ -45,27 +46,26 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public virtual int Compare(object x, object y)
+        public virtual int Compare(object? x, object? y)
         {
             if (x == y) return 0;
             if (x == null) return -1;
             if (y == null) return 1;
 
-            if (x is ICharSequence)
+            if (x is ICharSequence sa)
             {
-                var sa = x as ICharSequence;
-                if (y is ICharSequence)
-                    return Compare(sa, y as ICharSequence);
-                else if (y is string)
-                    return Compare(sa, y as string);
-                else if (y is StringBuilder)
-                    return Compare(sa, y as StringBuilder);
-                else if (y is char[])
-                    return Compare(sa, y as char[]);
+                if (y is ICharSequence otherCharSequence)
+                    return Compare(sa, otherCharSequence);
+                else if (y is string otherString)
+                    return Compare(sa, otherString);
+                else if (y is StringBuilder otherStringBuilder)
+                    return Compare(sa, otherStringBuilder);
+                else if (y is char[] otherCharArray)
+                    return Compare(sa, otherCharArray);
             }
 
-            if (x is IComparable)
-                return ((IComparable)x).CompareTo(y);
+            if (x is IComparable comparable)
+                return comparable.CompareTo(y);
 
             throw new ArgumentException($"Argument '{nameof(x)}' must implement IComparable");
         }
@@ -96,7 +96,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public abstract int Compare(ICharSequence x, ICharSequence y);
+        public abstract int Compare(ICharSequence? x, ICharSequence? y);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -124,7 +124,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public abstract int Compare(ICharSequence x, char[] y);
+        public abstract int Compare(ICharSequence? x, char[]? y);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -152,7 +152,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public abstract int Compare(ICharSequence x, StringBuilder y);
+        public abstract int Compare(ICharSequence? x, StringBuilder? y);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -180,7 +180,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public abstract int Compare(ICharSequence x, string y);
+        public abstract int Compare(ICharSequence? x, string? y);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -208,7 +208,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public virtual int Compare(ICharSequence x, CharArrayCharSequence y) => Compare(x, y.Value);
+        public virtual int Compare(ICharSequence? x, CharArrayCharSequence? y) => Compare(x, y?.Value);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -236,7 +236,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public virtual int Compare(ICharSequence x, StringBuilderCharSequence y) => Compare(x, y.Value);
+        public virtual int Compare(ICharSequence? x, StringBuilderCharSequence? y) => Compare(x, y?.Value);
 
         /// <summary>
         /// Compares two character sequences and returns an indication of their relative sort order.
@@ -264,7 +264,7 @@ namespace J2N.Text
         ///     </item>
         /// </list>
         /// </returns>
-        public virtual int Compare(ICharSequence x, StringCharSequence y) => Compare(x, y.Value);
+        public virtual int Compare(ICharSequence? x, StringCharSequence? y) => Compare(x, y?.Value);
 
         /// <summary>
         /// Indicates whether two objects or character sequences are equal.
@@ -274,22 +274,21 @@ namespace J2N.Text
         /// <returns><c>true</c> if <paramref name="x"/> and <paramref name="y"/> refer to the same object,
         /// or <paramref name="x"/> and <paramref name="y"/> both contain the same sequence of characters,
         /// or both <paramref name="x"/> and <paramref name="y"/> are <c>null</c>; otherwise <c>false</c>.</returns>
-        public virtual new bool Equals(object x, object y)
+        public virtual new bool Equals(object? x, object? y)
         {
             if (x == y) return true;
-            if (x == null || y == null) return false;
+            if (x is null || y is null) return false;
 
-            if (x is ICharSequence)
+            if (x is ICharSequence sa)
             {
-                var sa = x as ICharSequence;
-                if (y is ICharSequence)
-                    return Equals(sa, y as ICharSequence);
-                else if (y is string)
-                    return Equals(sa, y as string);
-                else if (y is StringBuilder)
-                    return Equals(sa, y as StringBuilder);
-                else if (y is char[])
-                    return Equals(sa, y as char[]);
+                if (y is ICharSequence otherCharSequence)
+                    return Equals(sa, otherCharSequence);
+                else if (y is string otherString)
+                    return Equals(sa, otherString);
+                else if (y is StringBuilder otherStringBuilder)
+                    return Equals(sa, otherStringBuilder);
+                else if (y is char[] otherCharArray)
+                    return Equals(sa, otherCharArray);
             }
             return x.Equals(y);
         }
@@ -302,7 +301,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if <paramref name="x"/> and <paramref name="y"/> refer to the same object,
         /// or <paramref name="x"/> and <paramref name="y"/> both contain the same sequence of characters,
         /// or both <paramref name="x"/> and <paramref name="y"/> are <c>null</c>; otherwise <c>false</c>.</returns>
-        public abstract bool Equals(ICharSequence x, ICharSequence y);
+        public abstract bool Equals(ICharSequence? x, ICharSequence? y);
 
         /// <summary>
         /// Indicates whether two character sequences are equal.
@@ -312,7 +311,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if <paramref name="x"/> and <paramref name="y"/> refer to the same object,
         /// or <paramref name="x"/> and <paramref name="y"/> both contain the same sequence of characters,
         /// or both <paramref name="x"/> and <paramref name="y"/> are <c>null</c>; otherwise <c>false</c>.</returns>
-        public abstract bool Equals(ICharSequence x, char[] y);
+        public abstract bool Equals(ICharSequence? x, char[]? y);
 
         /// <summary>
         /// Indicates whether two character sequences are equal.
@@ -322,7 +321,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if <paramref name="x"/> and <paramref name="y"/> refer to the same object,
         /// or <paramref name="x"/> and <paramref name="y"/> both contain the same sequence of characters,
         /// or both <paramref name="x"/> and <paramref name="y"/> are <c>null</c>; otherwise <c>false</c>.</returns>
-        public abstract bool Equals(ICharSequence x, StringBuilder y);
+        public abstract bool Equals(ICharSequence? x, StringBuilder? y);
 
         /// <summary>
         /// Indicates whether two character sequences are equal.
@@ -332,7 +331,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if <paramref name="x"/> and <paramref name="y"/> refer to the same object,
         /// or <paramref name="x"/> and <paramref name="y"/> both contain the same sequence of characters,
         /// or both <paramref name="x"/> and <paramref name="y"/> are <c>null</c>; otherwise <c>false</c>.</returns>
-        public abstract bool Equals(ICharSequence x, string y);
+        public abstract bool Equals(ICharSequence? x, string? y);
 
         /// <summary>
         /// Gets the hash code for the specified object.
@@ -340,23 +339,23 @@ namespace J2N.Text
         /// <param name="obj">An object.</param>
         /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj"/> parameter,
         /// or <see cref="int.MaxValue"/> if <paramref name="obj"/> is <c>null</c>.</returns>
-        public virtual int GetHashCode(object obj)
+        public virtual int GetHashCode(object? obj)
         {
-            if (obj == null)
+            if (obj is null)
                 return int.MaxValue;
 
-            if (obj is string)
-                return GetHashCode(obj as string);
-            else if (obj is StringBuilder)
-                return GetHashCode(obj as StringBuilder);
-            else if (obj is char[])
-                return GetHashCode(obj as char[]);
-            else if (obj is StringCharSequence)
-                return GetHashCode((StringCharSequence)obj);
-            else if (obj is StringBuilderCharSequence)
-                return GetHashCode((StringBuilderCharSequence)obj);
-            else if (obj is CharArrayCharSequence)
-                return GetHashCode((CharArrayCharSequence)obj);
+            if (obj is string otherString)
+                return GetHashCode(otherString);
+            else if (obj is StringBuilder otherStringBuilder)
+                return GetHashCode(otherStringBuilder);
+            else if (obj is char[] otherCharArray)
+                return GetHashCode(otherCharArray);
+            else if (obj is StringCharSequence otherStringCharSequence)
+                return GetHashCode(otherStringCharSequence);
+            else if (obj is StringBuilderCharSequence otherStringBuilderCharSequence)
+                return GetHashCode(otherStringBuilderCharSequence);
+            else if (obj is CharArrayCharSequence otherCharArrayCharSequence)
+                return GetHashCode(otherCharArrayCharSequence);
 
             return obj.GetHashCode();
         }
@@ -367,7 +366,7 @@ namespace J2N.Text
         /// <param name="obj">A character sequence.</param>
         /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj"/> parameter,
         /// or <see cref="int.MaxValue"/> if <paramref name="obj"/> is <c>null</c>.</returns>
-        public abstract int GetHashCode(ICharSequence obj);
+        public abstract int GetHashCode(ICharSequence? obj);
 
         /// <summary>
         /// Gets the hash code for the specified character sequence.
@@ -375,7 +374,7 @@ namespace J2N.Text
         /// <param name="obj">A character sequence.</param>
         /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj"/> parameter,
         /// or <see cref="int.MaxValue"/> if <paramref name="obj"/> is <c>null</c>.</returns>
-        public abstract int GetHashCode(char[] obj);
+        public abstract int GetHashCode(char[]? obj);
 
         /// <summary>
         /// Gets the hash code for the specified character sequence.
@@ -383,7 +382,7 @@ namespace J2N.Text
         /// <param name="obj">A character sequence.</param>
         /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj"/> parameter,
         /// or <see cref="int.MaxValue"/> if <paramref name="obj"/> is <c>null</c>.</returns>
-        public abstract int GetHashCode(StringBuilder obj);
+        public abstract int GetHashCode(StringBuilder? obj);
 
         /// <summary>
         /// Gets the hash code for the specified character sequence.
@@ -391,15 +390,15 @@ namespace J2N.Text
         /// <param name="obj">A character sequence.</param>
         /// <returns>A 32-bit signed hash code calculated from the value of the <paramref name="obj"/> parameter,
         /// or <see cref="int.MaxValue"/> if <paramref name="obj"/> is <c>null</c>.</returns>
-        public abstract int GetHashCode(string obj);
+        public abstract int GetHashCode(string? obj);
 
 
         private class OrdinalComparer : CharSequenceComparer
         {
-            public override int Compare(ICharSequence x, ICharSequence y)
+            public override int Compare(ICharSequence? x, ICharSequence? y)
             {
-                if (x == null) return -1;
-                if (y == null) return 1;
+                if (x is null || !x.HasValue) return (y is null || y.HasValue) ? 0 : -1;
+                if (y is null || !y.HasValue) return 1;
 
                 int length = Math.Min(x.Length, y.Length);
                 int result;
@@ -414,10 +413,10 @@ namespace J2N.Text
                 return x.Length - y.Length;
             }
 
-            public override int Compare(ICharSequence x, char[] y)
+            public override int Compare(ICharSequence? x, char[]? y)
             {
-                if (x == null) return -1;
-                if (y == null) return 1;
+                if (x is null || !x.HasValue) return (y is null) ? 0 : -1;
+                if (y is null) return 1;
 
                 int length = Math.Min(x.Length, y.Length);
                 int result;
@@ -432,10 +431,10 @@ namespace J2N.Text
                 return x.Length - y.Length;
             }
 
-            public override int Compare(ICharSequence x, string y)
+            public override int Compare(ICharSequence? x, string? y)
             {
-                if (x == null) return -1;
-                if (y == null) return 1;
+                if (x is null) return (y is null) ? 0 : -1;
+                if (y is null) return 1;
 
                 int length = Math.Min(x.Length, y.Length);
                 int result;
@@ -450,7 +449,7 @@ namespace J2N.Text
                 return x.Length - y.Length;
             }
 
-            public override int Compare(ICharSequence x, StringBuilder y)
+            public override int Compare(ICharSequence? x, StringBuilder? y)
             {
                 if (x == null) return -1;
                 if (y == null) return 1;
@@ -471,11 +470,11 @@ namespace J2N.Text
                 return x.Length - temp.Length;
             }
 
-            public override bool Equals(ICharSequence x, ICharSequence y)
+            public override bool Equals(ICharSequence? x, ICharSequence? y)
             {
-                if (x == null || !x.HasValue)
-                    return y == null || !y.HasValue;
-                if (y == null)
+                if (x is null || !x.HasValue)
+                    return y is null || !y.HasValue;
+                if (y is null || !y.HasValue)
                     return false;
 
                 int len = x.Length;
@@ -487,11 +486,11 @@ namespace J2N.Text
                 return true;
             }
 
-            public override bool Equals(ICharSequence x, char[] y)
+            public override bool Equals(ICharSequence? x, char[]? y)
             {
-                if (x == null || !x.HasValue)
-                    return y == null;
-                if (y == null)
+                if (x is null || !x.HasValue)
+                    return y is null;
+                if (y is null)
                     return false;
 
                 int len = x.Length;
@@ -503,21 +502,23 @@ namespace J2N.Text
                 return true;
             }
 
-            public override bool Equals(ICharSequence x, StringBuilder y)
+            public override bool Equals(ICharSequence? x, StringBuilder? y)
             {
-                if (x == null || !x.HasValue)
-                    return y == null;
-                if (y == null)
+                if (x is null || !x.HasValue)
+                    return y is null;
+                if (y is null)
                     return false;
 
                 // NOTE: This benchmarked to be faster than looping through the StringBuilder
                 return EqualsImpl(x, y.ToString());
             }
 
-            public override bool Equals(ICharSequence x, string y)
+            public override bool Equals(ICharSequence? x, string? y)
             {
-                if (x == null || !x.HasValue)
-                    return y == null;
+                if (x is null || !x.HasValue)
+                    return y is null;
+                if (y is null)
+                    return false;
 
                 return EqualsImpl(x, y);
             }
@@ -533,9 +534,9 @@ namespace J2N.Text
                 return true;
             }
 
-            public override int GetHashCode(ICharSequence obj)
+            public override int GetHashCode(ICharSequence? obj)
             {
-                if (obj == null ||!obj.HasValue)
+                if (obj is null ||!obj.HasValue)
                     return int.MaxValue;
 
                 // From Apache Harmony
@@ -550,9 +551,9 @@ namespace J2N.Text
                 return hash;
             }
 
-            public override int GetHashCode(char[] obj)
+            public override int GetHashCode(char[]? obj)
             {
-                if (obj == null)
+                if (obj is null)
                     return int.MaxValue;
 
                 // From Apache Harmony
@@ -567,18 +568,18 @@ namespace J2N.Text
                 return hash;
             }
 
-            public override int GetHashCode(StringBuilder obj)
+            public override int GetHashCode(StringBuilder? obj)
             {
-                if (obj == null)
+                if (obj is null)
                     return int.MaxValue;
 
                 // NOTE: This benchmarked to be faster than looping through the StringBuilder
                 return GetHashCodeImpl(obj.ToString());
             }
 
-            public override int GetHashCode(string obj)
+            public override int GetHashCode(string? obj)
             {
-                if (obj == null)
+                if (obj is null)
                     return int.MaxValue;
 
                 return GetHashCodeImpl(obj);

--- a/src/J2N/Text/IAppendable.cs
+++ b/src/J2N/Text/IAppendable.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+
 namespace J2N.Text
 {
     // from Apache Harmony
@@ -22,7 +23,7 @@ namespace J2N.Text
         /// </summary>
         /// <param name="value">The string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        IAppendable Append(string value);
+        IAppendable Append(string? value);
 
         /// <summary>
         /// Appends a copy of a specified substring to this instance.
@@ -48,14 +49,14 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
-        IAppendable Append(string value, int startIndex, int count);
+        IAppendable Append(string? value, int startIndex, int count);
 
         /// <summary>
         /// Appends a copy of the specified string to this instance.
         /// </summary>
         /// <param name="value">The <see cref="StringBuilder"/> that contains the string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        IAppendable Append(StringBuilder value);
+        IAppendable Append(StringBuilder? value);
 
         /// <summary>
         /// Appends a copy of a specified substring to this instance.
@@ -81,14 +82,14 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
-        IAppendable Append(StringBuilder value, int startIndex, int count);
+        IAppendable Append(StringBuilder? value, int startIndex, int count);
 
         /// <summary>
         /// Appends the string representation of the Unicode characters in a specified array to this instance.
         /// </summary>
         /// <param name="value">The array of characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        IAppendable Append(char[] value);
+        IAppendable Append(char[]? value);
 
         /// <summary>
         /// Appends the string representation of a specified subarray of Unicode characters to this instance.
@@ -114,14 +115,14 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
-        IAppendable Append(char[] value, int startIndex, int count);
+        IAppendable Append(char[]? value, int startIndex, int count);
 
         /// <summary>
         /// Appends the string representation of the Unicode characters in a specified <see cref="ICharSequence"/> to this instance.
         /// </summary>
         /// <param name="value">The <see cref="ICharSequence"/> containing the characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        IAppendable Append(ICharSequence value);
+        IAppendable Append(ICharSequence? value);
 
         /// <summary>
         /// Appends the string representation of a specified <see cref="ICharSequence"/> of Unicode characters to this instance.
@@ -147,6 +148,6 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> + <paramref name="count"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
-        IAppendable Append(ICharSequence value, int startIndex, int count);
+        IAppendable Append(ICharSequence? value, int startIndex, int count);
     }
 }

--- a/src/J2N/Text/ICharSequence.cs
+++ b/src/J2N/Text/ICharSequence.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+
 namespace J2N.Text
 {
     /// <summary>

--- a/src/J2N/Text/ICharacterEnumerator.cs
+++ b/src/J2N/Text/ICharacterEnumerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
+
 namespace J2N.Text
 {
     /// <summary>

--- a/src/J2N/Text/IStructuralFormattable.cs
+++ b/src/J2N/Text/IStructuralFormattable.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+
 
 namespace J2N.Text
 {
@@ -20,6 +19,6 @@ namespace J2N.Text
         /// Basic) to obtain the numeric format information from the current locale setting
         /// of the operating system.</param>
         /// <returns>The value of the current instance in the specified format.</returns>
-        new string ToString(string format, IFormatProvider formatProvider);
+        new string ToString(string? format, IFormatProvider? formatProvider);
     }
 }

--- a/src/J2N/Text/ParsePosition.cs
+++ b/src/J2N/Text/ParsePosition.cs
@@ -1,4 +1,6 @@
-﻿namespace J2N.Text
+﻿
+
+namespace J2N.Text
 {
     /// <summary>
     /// Tracks the current position in a parsed string. In case of an error the error
@@ -26,13 +28,13 @@
         /// <returns><c>true</c> if the specified object is equal to this
         /// <see cref="ParsePosition"/>; <c>false</c> otherwise.</returns>
         /// <seealso cref="GetHashCode()"/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            if (!(obj is ParsePosition))
+            if (obj is null) return false;
+            if (!(obj is ParsePosition pos))
             {
                 return false;
             }
-            ParsePosition pos = (ParsePosition)obj;
             return Index == pos.Index
                     && ErrorIndex == pos.ErrorIndex;
         }

--- a/src/J2N/Text/StringArrayExtensions.cs
+++ b/src/J2N/Text/StringArrayExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 
+
 namespace J2N.Text
 {
     /// <summary>
@@ -32,9 +33,9 @@ namespace J2N.Text
         /// </summary>
         /// <param name="input">This string array.</param>
         /// <returns>The array with any null or empty elements removed from the end.</returns>
-        public static string[] TrimEnd(this string[] input)
+        public static string?[]? TrimEnd(this string?[]? input)
         {
-            if (input == null)
+            if (input is null)
                 return null;
             int end;
             int inputLength = input.Length;

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.Contracts;
 #endif
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -100,8 +101,8 @@ namespace J2N.Text
         /// <param name="value">The string used to initialize the value of the instance.
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
-        public StringBuffer(string value)
-            : this(value, (value == null ? 0 : value.Length) + DefaultCapacity)
+        public StringBuffer(string? value)
+            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -111,8 +112,8 @@ namespace J2N.Text
         /// <param name="value">The character sequence used to initialize the value of the instance.
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
-        public StringBuffer(ICharSequence value)
-            : this(value, (value == null ? 0 : value.Length) + DefaultCapacity)
+        public StringBuffer(ICharSequence? value)
+            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
         { }
 
         // .NET Gaps
@@ -126,8 +127,8 @@ namespace J2N.Text
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
-        public StringBuffer(ICharSequence value, int capacity)
-            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        public StringBuffer(ICharSequence? value, int capacity)
+            : this(value, 0, (value is null ? 0 : value.Length), capacity)
         { }
 
         /// <summary>
@@ -147,7 +148,7 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> plus <paramref name="length"/> is not a position within <paramref name="value"/>.
         /// </exception>
-        public StringBuffer(ICharSequence value, int startIndex, int length, int capacity)
+        public StringBuffer(ICharSequence? value, int startIndex, int length, int capacity)
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -160,7 +161,7 @@ namespace J2N.Text
 #endif
 
             string stringValue;
-            if (value == null)
+            if (value is null)
             {
                 stringValue = string.Empty;
             }
@@ -181,8 +182,8 @@ namespace J2N.Text
         /// <param name="value">The character sequence used to initialize the value of the instance.
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
-        public StringBuffer(StringBuilder value)
-            : this(value, (value == null ? 0 : value.Length) + DefaultCapacity)
+        public StringBuffer(StringBuilder? value)
+            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -194,8 +195,8 @@ namespace J2N.Text
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
-        public StringBuffer(StringBuilder value, int capacity)
-            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        public StringBuffer(StringBuilder? value, int capacity)
+            : this(value, 0, (value is null ? 0 : value.Length), capacity)
         { }
 
         /// <summary>
@@ -215,7 +216,7 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> plus <paramref name="length"/> is not a position within <paramref name="value"/>.
         /// </exception>
-        public StringBuffer(StringBuilder value, int startIndex, int length, int capacity)
+        public StringBuffer(StringBuilder? value, int startIndex, int length, int capacity)
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -228,7 +229,7 @@ namespace J2N.Text
 #endif
 
             string stringValue;
-            if (value == null)
+            if (value is null)
             {
                 stringValue = string.Empty;
             }
@@ -249,8 +250,8 @@ namespace J2N.Text
         /// <param name="value">The character sequence used to initialize the value of the instance.
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
-        public StringBuffer(char[] value)
-            : this(value, (value == null ? 0 : value.Length) + DefaultCapacity)
+        public StringBuffer(char[]? value)
+            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -262,8 +263,8 @@ namespace J2N.Text
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
-        public StringBuffer(char[] value, int capacity)
-            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        public StringBuffer(char[]? value, int capacity)
+            : this(value, 0, (value is null ? 0 : value.Length), capacity)
         { }
 
         /// <summary>
@@ -283,7 +284,7 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> plus <paramref name="length"/> is not a position within <paramref name="value"/>.
         /// </exception>
-        public StringBuffer(char[] value, int startIndex, int length, int capacity)
+        public StringBuffer(char[]? value, int startIndex, int length, int capacity)
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -296,7 +297,7 @@ namespace J2N.Text
 #endif
 
             string stringValue;
-            if (value == null)
+            if (value is null)
             {
                 stringValue = string.Empty;
             }
@@ -336,8 +337,8 @@ namespace J2N.Text
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
-        public StringBuffer(string value, int capacity)
-            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        public StringBuffer(string? value, int capacity)
+            : this(value, 0, (value is null ? 0 : value.Length), capacity)
         { }
 
         /// <summary>
@@ -357,7 +358,7 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> plus <paramref name="length"/> is not a position within <paramref name="value"/>.
         /// </exception>
-        public StringBuffer(string value, int startIndex, int length, int capacity)
+        public StringBuffer(string? value, int startIndex, int length, int capacity)
         {
             this.builder = new StringBuilder(value, startIndex, length, capacity);
         }
@@ -609,7 +610,7 @@ namespace J2N.Text
         /// <param name="value">The object to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(object value)
+        public StringBuffer Append(object? value)
         {
             lock (syncRoot)
             {
@@ -624,7 +625,7 @@ namespace J2N.Text
         /// <param name="value">The string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(string value)
+        public StringBuffer Append(string? value)
         {
             lock (syncRoot)
             {
@@ -660,7 +661,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Append(string value, int startIndex, int count)
+        public StringBuffer Append(string? value, int startIndex, int count)
         {
             lock (syncRoot)
             {
@@ -681,9 +682,9 @@ namespace J2N.Text
         /// <param name="value">The <see cref="StringBuffer"/> to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(StringBuffer value)
+        public StringBuffer Append(StringBuffer? value)
         {
-            if (value == null)
+            if (value is null)
                 return this;
 
             lock (syncRoot)
@@ -725,7 +726,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Append(StringBuffer charSequence, int startIndex, int charCount)
+        public StringBuffer Append(StringBuffer? charSequence, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -743,9 +744,9 @@ namespace J2N.Text
         /// <param name="value">The <see cref="StringBuffer"/> to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(StringBuilder value)
+        public StringBuffer Append(StringBuilder? value)
         {
-            if (value == null)
+            if (value is null)
                 return this;
 
             lock (syncRoot)
@@ -787,7 +788,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Append(StringBuilder charSequence, int startIndex, int charCount)
+        public StringBuffer Append(StringBuilder? charSequence, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -808,7 +809,7 @@ namespace J2N.Text
         /// <param name="charSequence">The sequence of characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(ICharSequence charSequence)
+        public StringBuffer Append(ICharSequence? charSequence)
         {
             // Note, synchronization achieved via other invocations
             if (charSequence is StringCharSequence stringCharSequence)
@@ -847,7 +848,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Append(ICharSequence charSequence, int startIndex, int charCount)
+        public StringBuffer Append(ICharSequence? charSequence, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -862,7 +863,7 @@ namespace J2N.Text
         /// <param name="value">The array of characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Append(char[] value)
+        public StringBuffer Append(char[]? value)
         {
             lock (syncRoot)
             {
@@ -895,7 +896,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Append(char[] value, int startIndex, int charCount)
+        public StringBuffer Append(char[]? value, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -1205,7 +1206,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 1 (one).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(string format, object arg0)
+        public StringBuffer AppendFormat(string format, object? arg0)
         {
             lock (syncRoot)
             {
@@ -1236,7 +1237,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 1 (one).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(IFormatProvider provider, string format, object arg0)
+        public StringBuffer AppendFormat(IFormatProvider? provider, string format, object? arg0)
         {
             lock (syncRoot)
             {
@@ -1265,7 +1266,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 2 (two).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(string format, object arg0, object arg1)
+        public StringBuffer AppendFormat(string format, object? arg0, object? arg1)
         {
             lock (syncRoot)
             {
@@ -1297,7 +1298,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 2 (two).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(IFormatProvider provider, string format, object arg0, object arg1)
+        public StringBuffer AppendFormat(IFormatProvider? provider, string format, object? arg0, object? arg1)
         {
             lock (syncRoot)
             {
@@ -1327,7 +1328,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 3 (three).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(string format, object arg0, object arg1, object arg2)
+        public StringBuffer AppendFormat(string format, object? arg0, object? arg1, object? arg2)
         {
             lock (syncRoot)
             {
@@ -1360,7 +1361,7 @@ namespace J2N.Text
         /// The index of a format item is less than 0 (zero), or greater than or equal to 3 (three).
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(IFormatProvider provider, string format, object arg0, object arg1, object arg2)
+        public StringBuffer AppendFormat(IFormatProvider? provider, string format, object? arg0, object? arg1, object? arg2)
         {
             lock (syncRoot)
             {
@@ -1390,7 +1391,7 @@ namespace J2N.Text
         /// length of the <paramref name="args"/> array.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(string format, params object[] args)
+        public StringBuffer AppendFormat(string format, params object?[] args)
         {
             lock (syncRoot)
             {
@@ -1421,7 +1422,7 @@ namespace J2N.Text
         /// length of the <paramref name="args"/> array.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">The length of the expanded string would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendFormat(IFormatProvider provider, string format, params object[] args)
+        public StringBuffer AppendFormat(IFormatProvider? provider, string format, params object?[] args)
         {
             lock (syncRoot)
             {
@@ -1448,7 +1449,7 @@ namespace J2N.Text
         /// <param name="values">An array that contains the strings to
         /// concatenate and append to the current instance of the string builder.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public StringBuffer AppendJoin(char separator, params object[] values)
+        public StringBuffer AppendJoin(char separator, params object?[] values)
         {
             lock (syncRoot)
             {
@@ -1468,7 +1469,7 @@ namespace J2N.Text
         /// <param name="values">An array that contains the strings to
         /// concatenate and append to the current instance of the string builder.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public StringBuffer AppendJoin(char separator, params string[] values)
+        public StringBuffer AppendJoin(char separator, params string?[] values)
         {
             lock (syncRoot)
             {
@@ -1489,7 +1490,7 @@ namespace J2N.Text
         /// <param name="values">An array that contains the strings to
         /// concatenate and append to the current instance of the string builder.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public StringBuffer AppendJoin(string separator, params object[] values)
+        public StringBuffer AppendJoin(string separator, params object?[] values)
         {
             lock (syncRoot)
             {
@@ -1509,7 +1510,7 @@ namespace J2N.Text
         /// <param name="values">An array that contains the strings to concatenate
         /// and append to the current instance of the string builder.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public StringBuffer AppendJoin(string separator, params string[] values)
+        public StringBuffer AppendJoin(string separator, params string?[] values)
         {
             lock (syncRoot)
             {
@@ -1549,7 +1550,7 @@ namespace J2N.Text
         /// <param name="values">A collection that contains the objects to concatenate
         /// and append to the current instance of the string builder.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
-        public StringBuffer AppendJoin<T>(string separator, IEnumerable<T> values)
+        public StringBuffer AppendJoin<T>(string? separator, IEnumerable<T> values)
         {
             lock (syncRoot)
             {
@@ -1594,7 +1595,7 @@ namespace J2N.Text
         /// <param name="value">The string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer AppendLine(string value)
+        public StringBuffer AppendLine(string? value)
         {
             lock (syncRoot)
             {
@@ -1726,9 +1727,9 @@ namespace J2N.Text
         /// <param name="other">An object to compare with this instance, or <c>null</c>.</param>
         /// <returns><c>true</c> if this instance and sb have equal string, <see cref="Capacity"/>,
         /// and <see cref="MaxCapacity"/> values; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilderCharSequence other)
+        public bool Equals(StringBuilderCharSequence? other)
         {
-            if (!other.HasValue)
+            if (other is null || !other.HasValue)
                 return false;
 
             return Equals(other.Value);
@@ -1740,7 +1741,7 @@ namespace J2N.Text
         /// <param name="other">An object to compare with this instance, or <c>null</c>.</param>
         /// <returns><c>true</c> if this instance and sb have equal string, <see cref="Capacity"/>,
         /// and <see cref="MaxCapacity"/> values; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilder other)
+        public bool Equals(StringBuilder? other)
         {
             lock (syncRoot)
                 return builder.Equals(other);
@@ -1752,31 +1753,47 @@ namespace J2N.Text
         /// <param name="other">An object to compare with this instance, or <c>null</c>.</param>
         /// <returns><c>true</c> if this instance and sb have equal string, <see cref="Capacity"/>,
         /// and <see cref="MaxCapacity"/> values; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuffer other)
+        public bool Equals(StringBuffer? other)
         {
-            return Equals(other.builder);
+            return Equals(other?.builder);
         }
 
-        ///// <summary>
-        ///// Returns a value indicating whether this instance is equal to a specified object.
-        ///// </summary>
-        ///// <param name="obj">An object to compare with this instance, or <c>null</c>.</param>
-        ///// <returns><c>true</c> if this instance and sb have equal string, <see cref="Capacity"/>,
-        ///// and <see cref="MaxCapacity"/> values; otherwise, <c>false</c>.</returns>
-        //public override bool Equals(object obj)
-        //{
-        //    if (obj is StringBuffer stringBuffer)
-        //        return Equals(stringBuffer);
-        //    if (obj is StringBuilder stringBuilder)
-        //        return Equals(stringBuilder);
-        //    if (obj is StringBuilderCharSequence stringBuilder1)
-        //        return Equals(stringBuilder1);
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance, or <c>null</c>.</param>
+        /// <returns><c>true</c> if this instance and sb have equal string, <see cref="Capacity"/>,
+        /// and <see cref="MaxCapacity"/> values; otherwise, <c>false</c>.</returns>
+        public override bool Equals(object? obj)
+        {
+            if (obj is null) return false;
 
-        //    lock (syncRoot)
-        //        return builder.Equals(obj);
-        //}
+            if (obj is StringBuffer stringBuffer)
+                return Equals(stringBuffer);
+            if (obj is StringBuilder stringBuilder)
+                return Equals(stringBuilder);
+            if (obj is StringBuilderCharSequence stringBuilder1)
+                return Equals(stringBuilder1);
+
+            lock (syncRoot)
+                return builder.Equals(obj);
+        }
 
         #endregion Equals
+
+        #region GetHashCode
+
+        /// <summary>
+        /// Returns a hash code for the builder.
+        /// </summary>
+        /// <returns>A hash code for the builder.</returns>
+        public override int GetHashCode()
+        {
+            lock (syncRoot)
+                return builder.GetHashCode();
+        }
+
+        #endregion GetHashCode
 
         #region Insert
 
@@ -1870,7 +1887,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, char[] value)
+        public StringBuffer Insert(int index, char[]? value)
         {
             lock (syncRoot)
             {
@@ -1902,7 +1919,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, char[] value, int startIndex, int charCount)
+        public StringBuffer Insert(int index, char[]? value, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -1924,10 +1941,10 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, ICharSequence charSequence)
+        public StringBuffer Insert(int index, ICharSequence? charSequence)
         {
             if (charSequence is StringCharSequence stringCharSequence)
-                return Insert(index, stringCharSequence.Value);
+                return Insert(index, stringCharSequence?.Value);
 
             lock (syncRoot)
             {
@@ -1962,7 +1979,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, ICharSequence charSequence, int startIndex, int charCount)
+        public StringBuffer Insert(int index, ICharSequence? charSequence, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -1984,7 +2001,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, StringBuilder charSequence)
+        public StringBuffer Insert(int index, StringBuilder? charSequence)
         {
             lock (syncRoot)
             {
@@ -2019,7 +2036,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, StringBuilder charSequence, int startIndex, int charCount)
+        public StringBuffer Insert(int index, StringBuilder? charSequence, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -2041,7 +2058,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, string value)
+        public StringBuffer Insert(int index, string? value)
         {
             lock (syncRoot)
             {
@@ -2076,7 +2093,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Insert(int index, string value, int startIndex, int charCount)
+        public StringBuffer Insert(int index, string? value, int startIndex, int charCount)
         {
             lock (syncRoot)
             {
@@ -2094,7 +2111,7 @@ namespace J2N.Text
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero or greater than the length of this instance.</exception>
         /// <exception cref="OutOfMemoryException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Insert(int index, string value, int count)
+        public StringBuffer Insert(int index, string? value, int count)
         {
             lock (syncRoot)
             {
@@ -2111,7 +2128,7 @@ namespace J2N.Text
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero or greater than the length of this instance.</exception>
         /// <exception cref="OutOfMemoryException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Insert(int index, object value)
+        public StringBuffer Insert(int index, object? value)
         {
             lock (syncRoot)
             {
@@ -2481,7 +2498,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException"><paramref name="oldValue"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">The length of <paramref name="oldValue"/> is zero.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.</exception>
-        public StringBuffer Replace(string oldValue, string newValue)
+        public StringBuffer Replace(string oldValue, string? newValue)
         {
             lock (syncRoot)
             {
@@ -2512,7 +2529,7 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="MaxCapacity"/>.
         /// </exception>
-        public StringBuffer Replace(string oldValue, string newValue, int startIndex, int count)
+        public StringBuffer Replace(string oldValue, string? newValue, int startIndex, int count)
         {
             lock (syncRoot)
             {
@@ -2621,21 +2638,21 @@ namespace J2N.Text
 
         IAppendable IAppendable.Append(char value) => Append(value);
 
-        IAppendable IAppendable.Append(string value) => Append(value);
+        IAppendable IAppendable.Append(string? value) => Append(value);
 
-        IAppendable IAppendable.Append(string value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(string? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(StringBuilder value) => Append(value);
+        IAppendable IAppendable.Append(StringBuilder? value) => Append(value);
 
-        IAppendable IAppendable.Append(StringBuilder value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(StringBuilder? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(char[] value) => Append(value);
+        IAppendable IAppendable.Append(char[]? value) => Append(value);
 
-        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(char[]? value, int startIndex, int count) => Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(ICharSequence value) => Append(value);
+        IAppendable IAppendable.Append(ICharSequence? value) => Append(value);
 
-        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => Append(value, startIndex, count);
+        IAppendable IAppendable.Append(ICharSequence? value, int startIndex, int count) => Append(value, startIndex, count);
 
         #endregion IAppendable Members
 

--- a/src/J2N/Text/StringBuilderCharSequence.cs
+++ b/src/J2N/Text/StringBuilderCharSequence.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -29,7 +30,7 @@ namespace J2N.Text
         /// Initializes a new instance of <see cref="StringBuilderCharSequence"/> with the provided <paramref name="value"/>.
         /// </summary>
         /// <param name="value">A <see cref="StringBuilder"/> to wrap in a <see cref="ICharSequence"/>. The value may be <c>null</c>.</param>
-        public StringBuilderCharSequence(StringBuilder value)
+        public StringBuilderCharSequence(StringBuilder? value)
         {
             this.Value = value;
             this.HasValue = (value != null);
@@ -38,7 +39,7 @@ namespace J2N.Text
         /// <summary>
         /// Gets the current <see cref="StringBuilder"/> value.
         /// </summary>
-        public StringBuilder Value { get; }
+        public StringBuilder? Value { get; }
 
         #region ICharSequence
 
@@ -65,7 +66,7 @@ namespace J2N.Text
         {
             get
             {
-                if (Value == null)
+                if (Value is null)
                     throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotIndexNullObject, nameof(StringBuilderCharSequence)));
                 return Value[index];
             }
@@ -76,7 +77,7 @@ namespace J2N.Text
         /// </summary>
         public int Length
         {
-            get { return (Value == null) ? 0 : Value.Length; }
+            get { return (Value is null) ? 0 : Value.Length; }
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace J2N.Text
         public ICharSequence Subsequence(int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (Value == null || (startIndex == 0 && length == Value.Length))
+            if (Value is null || (startIndex == 0 && length == Value.Length))
             {
                 return new StringBuilderCharSequence(Value);
             }
@@ -128,7 +129,7 @@ namespace J2N.Text
         /// <returns>A string based on this sequence.</returns>
         public override string ToString()
         {
-            return (Value == null) ? string.Empty : Value.ToString();
+            return (Value is null) ? string.Empty : Value.ToString();
         }
 
         #endregion
@@ -144,8 +145,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StringBuilderCharSequence csq1, StringBuilderCharSequence csq2)
+        public static bool operator ==(StringBuilderCharSequence? csq1, StringBuilderCharSequence? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq1.Equals(csq2);
         }
 
@@ -157,33 +163,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StringBuilderCharSequence csq1, StringBuilderCharSequence csq2)
-        {
-            return !(csq1.Value == csq2.Value);
-        }
-
-        /// <summary>
-        /// Compares <paramref name="csq1"/> and <paramref name="csq2"/> for equality.
-        /// Two character sequences are considered equal if they have the same characters
-        /// in the same order.
-        /// </summary>
-        /// <param name="csq1">The first sequence.</param>
-        /// <param name="csq2">The second sequence.</param>
-        /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StringBuilderCharSequence csq1, StringBuilder csq2)
-        {
-            return csq1.Equals(csq2);
-        }
-
-        /// <summary>
-        /// Compares <paramref name="csq1"/> and <paramref name="csq2"/> for inequality.
-        /// Two character sequences are considered equal if they have the same characters
-        /// in the same order.
-        /// </summary>
-        /// <param name="csq1">The first sequence.</param>
-        /// <param name="csq2">The second sequence.</param>
-        /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StringBuilderCharSequence csq1, StringBuilder csq2)
+        public static bool operator !=(StringBuilderCharSequence? csq1, StringBuilderCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -196,8 +176,44 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StringBuilder csq1, StringBuilderCharSequence csq2)
+        public static bool operator ==(StringBuilderCharSequence? csq1, StringBuilder? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null;
+            else if (csq2 is null)
+                return !csq1.HasValue;
+
+            return csq1.Equals(csq2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="csq1"/> and <paramref name="csq2"/> for inequality.
+        /// Two character sequences are considered equal if they have the same characters
+        /// in the same order.
+        /// </summary>
+        /// <param name="csq1">The first sequence.</param>
+        /// <param name="csq2">The second sequence.</param>
+        /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
+        public static bool operator !=(StringBuilderCharSequence? csq1, StringBuilder? csq2)
+        {
+            return !(csq1 == csq2);
+        }
+
+        /// <summary>
+        /// Compares <paramref name="csq1"/> and <paramref name="csq2"/> for equality.
+        /// Two character sequences are considered equal if they have the same characters
+        /// in the same order.
+        /// </summary>
+        /// <param name="csq1">The first sequence.</param>
+        /// <param name="csq2">The second sequence.</param>
+        /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
+        public static bool operator ==(StringBuilder? csq1, StringBuilderCharSequence? csq2)
+        {
+            if (csq1 is null)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq2.Equals(csq1);
         }
 
@@ -209,7 +225,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StringBuilder csq1, StringBuilderCharSequence csq2)
+        public static bool operator !=(StringBuilder? csq1, StringBuilderCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -223,11 +239,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An <see cref="ICharSequence"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(ICharSequence other)
+        public bool Equals(ICharSequence? other)
         {
-            if (this.Value == null)
-                return other == null || !other.HasValue;
-            if (other == null)
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
                 return false;
 
             int len = other.Length;
@@ -250,8 +266,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="CharArrayCharSequence"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(CharArrayCharSequence other)
+        public bool Equals(CharArrayCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -260,8 +281,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilderCharSequence"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilderCharSequence other)
+        public bool Equals(StringBuilderCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -270,8 +296,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringCharSequence"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringCharSequence other)
+        public bool Equals(StringCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -280,11 +311,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="string"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(string other)
+        public bool Equals(string? other)
         {
-            if (other == null)
-                return false;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = this.Value.Length;
@@ -301,10 +332,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilder"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilder other)
+        public bool Equals(StringBuilder? other)
         {
-            if (this.Value == null)
-                return other == null;
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
+                return false;
+
             return this.Value.Equals(other);
         }
 
@@ -313,11 +347,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="T:char[]"/> to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(char[] other)
+        public bool Equals(char[]? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = this.Value.Length;
@@ -334,22 +368,25 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An object to compare to the current <see cref="StringBuilderCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringBuilderCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
-            if (other is string)
-                return Equals(other as string);
-            else if (other is StringBuilder)
-                return Equals(other as StringBuilder);
-            else if (other is char[])
-                return Equals(other as char[]);
-            else if (other is CharArrayCharSequence)
-                return Equals((CharArrayCharSequence)other);
-            else if (other is StringBuilderCharSequence)
-                return Equals((StringBuilderCharSequence)other);
-            else if (other is StringCharSequence)
-                return Equals((StringCharSequence)other);
-            else if (other is ICharSequence)
-                return Equals((ICharSequence)other);
+            if (other is null)
+                return !HasValue;
+
+            if (other is string otherString)
+                return Equals(otherString);
+            else if (other is StringBuilder otherStringBuilder)
+                return Equals(otherStringBuilder);
+            else if (other is char[] otherCharArray)
+                return Equals(otherCharArray);
+            else if (other is StringCharSequence otherStringCharSequence)
+                return Equals(otherStringCharSequence);
+            else if (other is CharArrayCharSequence otherCharArrayCharSequence)
+                return Equals(otherCharArrayCharSequence);
+            else if (other is StringBuilderCharSequence otherStringBuilderCharSequence)
+                return Equals(otherStringBuilderCharSequence);
+            else if (other is ICharSequence otherCharSequence)
+                return Equals(otherCharSequence);
 
             return false;
         }
@@ -382,8 +419,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(ICharSequence other)
+        public int CompareTo(ICharSequence? other)
         {
+            if (this.Value is null) return (other is null || !other.HasValue) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -398,8 +438,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(string other)
+        public int CompareTo(string? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -414,8 +457,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(StringBuilder other)
+        public int CompareTo(StringBuilder? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -430,8 +476,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(char[] other)
+        public int CompareTo(char[]? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -446,10 +495,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(object other)
+        public int CompareTo(object? other)
         {
-            if (this.Value == null) return -1;
-            if (other == null) return 1;
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
 
             return this.Value.CompareToOrdinal(other.ToString());
         }
@@ -464,8 +513,12 @@ namespace J2N.Text
         /// <param name="value">The UTF-16-encoded code unit to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.</exception>
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
         public StringBuilderCharSequence Append(char value)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             Value.Append(value);
             return this;
         }
@@ -476,8 +529,12 @@ namespace J2N.Text
         /// <param name="value">The string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.</exception>
-        public StringBuilderCharSequence Append(string value)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(string? value)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             Value.Append(value);
             return this;
         }
@@ -506,8 +563,12 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public StringBuilderCharSequence Append(string value, int startIndex, int count)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(string? value, int startIndex, int count)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             Value.Append(value, startIndex, count);
             return this;
         }
@@ -518,8 +579,12 @@ namespace J2N.Text
         /// <param name="value">The <see cref="StringBuilder"/> that contains the string to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.</exception>
-        public StringBuilderCharSequence Append(StringBuilder value)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(StringBuilder? value)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             if (value != null)
                 Value.Append(value.ToString());
             return this;
@@ -549,8 +614,12 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public StringBuilderCharSequence Append(StringBuilder value, int startIndex, int count)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(StringBuilder? value, int startIndex, int count)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             if (value != null)
                 Value.Append(value.ToString(startIndex, count));
             return this;
@@ -562,8 +631,12 @@ namespace J2N.Text
         /// <param name="value">The array of characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.</exception>
-        public StringBuilderCharSequence Append(char[] value)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(char[]? value)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             Value.Append(value);
             return this;
         }
@@ -592,8 +665,12 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public StringBuilderCharSequence Append(char[] value, int startIndex, int count)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(char[]? value, int startIndex, int count)
         {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
             Value.Append(value, startIndex, count);
             return this;
         }
@@ -604,17 +681,21 @@ namespace J2N.Text
         /// <param name="value">The <see cref="ICharSequence"/> containing the characters to append.</param>
         /// <returns>A reference to this instance after the append operation has completed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.</exception>
-        public StringBuilderCharSequence Append(ICharSequence value)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(ICharSequence? value)
         {
             // For null values, this is a no-op
             if (value != null && value.HasValue)
             {
-                if (value is StringCharSequence)
-                    Value.Append(((StringCharSequence)value).Value);
-                else if (value is StringBuilderCharSequence)
-                    Value.Append(((StringBuilderCharSequence)value).Value.ToString());
-                else if (value is CharArrayCharSequence)
-                    Value.Append(((CharArrayCharSequence)value).Value);
+                if (Value is null)
+                    throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
+                if (value is StringCharSequence stringCharSequence)
+                    Value.Append(stringCharSequence.Value); // Already checked for null above, but StringBuilder is fine with null anyway
+                else if (value is StringBuilderCharSequence stringBuilderCharSequence)
+                    Value.Append(stringBuilderCharSequence.Value); // Already checked for null above, but StringBuilder is fine with null anyway. This is the object overload prior to .NET Standard 2.1.
+                else if (value is CharArrayCharSequence charArrayCharSequence)
+                    Value.Append(charArrayCharSequence.Value); // Already checked for null above, but StringBuilder is fine with null anyway
                 else
                     Value.Append(value.ToString());
             }
@@ -645,17 +726,21 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public StringBuilderCharSequence Append(ICharSequence value, int startIndex, int count)
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(ICharSequence? value, int startIndex, int count)
         {
             // For null values, this is a no-op
             if (value != null && value.HasValue)
             {
-                if (value is StringCharSequence)
-                    Value.Append(((StringCharSequence)value).Value, startIndex, count);
-                else if (value is StringBuilderCharSequence)
-                    Value.Append(((StringBuilderCharSequence)value).Value.ToString(), startIndex, count);
-                else if (value is CharArrayCharSequence)
-                    Value.Append(((CharArrayCharSequence)value).Value);
+                if (Value is null)
+                    throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
+                if (value is StringCharSequence stringCharSequence)
+                    Value.Append(stringCharSequence.Value, startIndex, count); // Already checked for null above
+                else if (value is StringBuilderCharSequence stringBuilderCharSequence)
+                    Value.Append(stringBuilderCharSequence.Value, startIndex, count); // Already checked for null above
+                else if (value is CharArrayCharSequence charArrayCharSequence)
+                    Value.Append(charArrayCharSequence.Value, startIndex, count); // Already checked for null above
                 else
                     Value.Append(value.ToString());
             }
@@ -664,21 +749,21 @@ namespace J2N.Text
 
         IAppendable IAppendable.Append(char value) => this.Append(value);
 
-        IAppendable IAppendable.Append(string value) => this.Append(value);
+        IAppendable IAppendable.Append(string? value) => this.Append(value);
 
-        IAppendable IAppendable.Append(string value, int startIndex, int count) => this.Append(value, startIndex, count);
+        IAppendable IAppendable.Append(string? value, int startIndex, int count) => this.Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(StringBuilder value) => this.Append(value);
+        IAppendable IAppendable.Append(StringBuilder? value) => this.Append(value);
 
-        IAppendable IAppendable.Append(StringBuilder value, int startIndex, int count) => this.Append(value, startIndex, count);
+        IAppendable IAppendable.Append(StringBuilder? value, int startIndex, int count) => this.Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(char[] value) => this.Append(value);
+        IAppendable IAppendable.Append(char[]? value) => this.Append(value);
 
-        IAppendable IAppendable.Append(char[] value, int startIndex, int count) => this.Append(value, startIndex, count);
+        IAppendable IAppendable.Append(char[]? value, int startIndex, int count) => this.Append(value, startIndex, count);
 
-        IAppendable IAppendable.Append(ICharSequence value) => this.Append(value);
+        IAppendable IAppendable.Append(ICharSequence? value) => this.Append(value);
 
-        IAppendable IAppendable.Append(ICharSequence value, int startIndex, int count) => this.Append(value, startIndex, count);
+        IAppendable IAppendable.Append(ICharSequence? value, int startIndex, int count) => this.Append(value, startIndex, count);
 
         #endregion
     }

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -24,9 +25,9 @@ namespace J2N.Text
         /// <param name="charSequence">The <see cref="ICharSequence"/> to append.</param>
         /// <returns>This <see cref="StringBuilder"/>, for chaining.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static StringBuilder Append(this StringBuilder text, ICharSequence charSequence)
+        public static StringBuilder Append(this StringBuilder text, ICharSequence? charSequence)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             // For null values, this is a no-op
@@ -65,11 +66,11 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="charCount"/> is less than zero.
         /// </exception>
-        public static StringBuilder Append(this StringBuilder text, ICharSequence charSequence, int startIndex, int charCount)
+        public static StringBuilder Append(this StringBuilder text, ICharSequence? charSequence, int startIndex, int charCount)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (charSequence == null && (startIndex != 0 || charCount != 0))
+            if (charSequence is null && (startIndex != 0 || charCount != 0))
                 throw new ArgumentNullException(nameof(charSequence)); // J2N: Unlike Java, we are throwing an exception (to match .NET Core 3) rather than writing "null" to the StringBuilder
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -143,11 +144,11 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="charCount"/> is less than zero.
         /// </exception>
-        public static StringBuilder Append(this StringBuilder text, StringBuilder charSequence, int startIndex, int charCount)
+        public static StringBuilder Append(this StringBuilder text, StringBuilder? charSequence, int startIndex, int charCount)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (charSequence == null && (startIndex != 0 || charCount != 0))
+            if (charSequence is null && (startIndex != 0 || charCount != 0))
                 throw new ArgumentNullException(nameof(charSequence)); // J2N: Unlike Java, we are throwing an exception (to match .NET Core 3) rather than writing "null" to the StringBuilder
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -186,7 +187,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
         public static StringBuilder AppendCodePoint(this StringBuilder text, int codePoint)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             text.Append(Character.ToChars(codePoint));
@@ -201,7 +202,7 @@ namespace J2N.Text
         /// Convenience method to wrap a string in a <see cref="StringBuilderCharSequence"/>
         /// so a <see cref="StringBuilder"/> can be used as <see cref="ICharSequence"/> in .NET.
         /// </summary>
-        public static ICharSequence AsCharSequence(this StringBuilder text)
+        public static ICharSequence AsCharSequence(this StringBuilder? text)
         {
             return new StringBuilderCharSequence(text);
         }
@@ -228,12 +229,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this StringBuilder text, ICharSequence value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this StringBuilder? text, ICharSequence? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (value is StringBuilderCharSequence && object.ReferenceEquals(text, value)) return 0;
-            if (text == null) return -1;
-            if (value == null) return 1;
-            if (!value.HasValue) return 1;
+            if (text is null) return (value is null || !value.HasValue) ? 0 : -1;
+            if (value is null || !value.HasValue) return 1;
 
             int length = Math.Min(text.Length, value.Length);
             int result;
@@ -266,10 +266,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this StringBuilder text, char[] value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this StringBuilder? text, char[]? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null) return -1;
-            if (value == null) return 1;
+            if (text is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             int length = Math.Min(text.Length, value.Length);
             int result;
@@ -302,11 +302,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this StringBuilder text, StringBuilder value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this StringBuilder? text, StringBuilder? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (object.ReferenceEquals(text, value)) return 0;
-            if (text == null) return -1;
-            if (value == null) return 1;
+            if (text is null) return -1;
+            if (value is null) return 1;
 
             // Materialize the string. It is faster to loop through
             // a string than a StringBuilder.
@@ -331,10 +331,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this StringBuilder text, string value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this StringBuilder? text, string? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null) return -1;
-            if (value == null) return 1;
+            if (text is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             int length = Math.Min(text.Length, value.Length);
             int result;
@@ -376,9 +376,9 @@ namespace J2N.Text
         /// <paramref name="startIndex"/> is greater than <see cref="StringBuilder.Length"/>.
         /// </exception>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static StringBuilder Delete(this StringBuilder text, int startIndex, int count)
+        public static StringBuilder Delete(this StringBuilder? text, int startIndex, int count)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (startIndex < 0 || startIndex > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
@@ -463,9 +463,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static int IndexOf(this StringBuilder text, string value, int startIndex, StringComparison comparisonType)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (value == null)
+            if (value is null)
                 throw new ArgumentNullException(nameof(value));
             if (startIndex < 0 || startIndex > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
@@ -566,9 +566,9 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public static StringBuilder Insert(this StringBuilder text, int index, ICharSequence charSequence)
+        public static StringBuilder Insert(this StringBuilder text, int index, ICharSequence? charSequence)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (index < 0 || index > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -622,9 +622,9 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public static StringBuilder Insert(this StringBuilder text, int index, ICharSequence charSequence, int startIndex, int charCount) // J2N TODO: API - extension method for StringBuilder
+        public static StringBuilder Insert(this StringBuilder text, int index, ICharSequence? charSequence, int startIndex, int charCount) // J2N TODO: API - extension method for StringBuilder
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (index < 0 || index > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -632,9 +632,9 @@ namespace J2N.Text
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (charCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (charSequence == null && (startIndex != 0 || charCount != 0))
+            if (charSequence is null && (startIndex != 0 || charCount != 0))
                 throw new ArgumentNullException(nameof(charSequence)); // J2N: Unlike Java, we are throwing an exception (to match .NET Core 3) rather than writing "null" to the StringBuilder
-            if (charSequence == null || !charSequence.HasValue)
+            if (charSequence is null || !charSequence.HasValue)
                 return text;
             if (startIndex > charSequence.Length - charCount) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_IndexLength);
@@ -660,13 +660,13 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public static StringBuilder Insert(this StringBuilder text, int index, StringBuilder charSequence)
+        public static StringBuilder Insert(this StringBuilder text, int index, StringBuilder? charSequence)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (index < 0 || index > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
-            if (charSequence == null)
+            if (charSequence is null)
                 return text;
            
             // NOTE: This method will not be used for .NET Standard 2.1+ because
@@ -708,9 +708,9 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public static StringBuilder Insert(this StringBuilder text, int index, StringBuilder charSequence, int startIndex, int charCount)
+        public static StringBuilder Insert(this StringBuilder text, int index, StringBuilder? charSequence, int startIndex, int charCount)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (index < 0 || index > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -718,9 +718,9 @@ namespace J2N.Text
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (charCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (charSequence == null && (startIndex != 0 || charCount != 0))
+            if (charSequence is null && (startIndex != 0 || charCount != 0))
                 throw new ArgumentNullException(nameof(charSequence)); // J2N: Unlike Java, we are throwing an exception (to match .NET Core 3) rather than writing "null" to the StringBuilder
-            if (charSequence == null)
+            if (charSequence is null)
                 return text;
             if (startIndex > charSequence.Length - charCount) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_IndexLength);
@@ -762,9 +762,9 @@ namespace J2N.Text
         /// <para/>
         /// Enlarging the value of this instance would exceed <see cref="StringBuilder.MaxCapacity"/>.
         /// </exception>
-        public static StringBuilder Insert(this StringBuilder text, int index, string value, int startIndex, int charCount)
+        public static StringBuilder Insert(this StringBuilder text, int index, string? value, int startIndex, int charCount)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
             if (index < 0 || index > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(index));
@@ -772,9 +772,9 @@ namespace J2N.Text
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (charCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (value == null && (startIndex != 0 || charCount != 0))
+            if (value is null && (startIndex != 0 || charCount != 0))
                 throw new ArgumentNullException(nameof(value)); // J2N: Unlike Java, we are throwing an exception (to match .NET Core 3) rather than writing "null" to the StringBuilder
-            if (value == null)
+            if (value is null)
                 return text;
             if (startIndex > value.Length - charCount) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_IndexLength);
@@ -801,7 +801,7 @@ namespace J2N.Text
         ///// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="value"/> is <c>null</c>.</exception>
         //public static int LastIndexOf(this StringBuilder text, string value)
         //{
-        //    if (text == null)
+        //    if (text is null)
         //        throw new ArgumentNullException(nameof(text));
 
         //    return LastIndexOf(text, value, text.Length, StringComparison.CurrentCulture);
@@ -823,7 +823,7 @@ namespace J2N.Text
         ///// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="value"/> is <c>null</c>.</exception>
         //public static int LastIndexOf(this StringBuilder text, string value, int startIndex)
         //{
-        //    if (text == null)
+        //    if (text is null)
         //        throw new ArgumentNullException(nameof(text));
 
         //    return LastIndexOf(text, value, startIndex, StringComparison.CurrentCulture);
@@ -841,7 +841,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static int LastIndexOf(this StringBuilder text, string value, StringComparison comparisonType)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             return LastIndexOf(text, value, text.Length, comparisonType);
@@ -861,9 +861,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static int LastIndexOf(this StringBuilder text, string value, int startIndex, StringComparison comparisonType)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (value == null)
+            if (value is null)
                 throw new ArgumentNullException(nameof(value));
             if (startIndex < 0 || startIndex > text.Length)
                 throw new ArgumentOutOfRangeException(nameof(startIndex));
@@ -1023,9 +1023,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="newValue"/> is <c>null</c>.</exception>
         public static StringBuilder Replace(this StringBuilder text, int startIndex, int count, string newValue)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (newValue == null)
+            if (newValue is null)
                 throw new ArgumentNullException(nameof(newValue));
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -1097,8 +1097,12 @@ namespace J2N.Text
         /// </summary>
         /// <param name="text">this <see cref="StringBuilder"/></param>
         /// <returns>A reference to this <see cref="StringBuilder"/>, for chaining.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
         public static StringBuilder Reverse(this StringBuilder text)
         {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
             bool hasSurrogate = false;
             int n = text.Length - 1;
             // Tradeoff: materializing the string is generally faster,
@@ -1106,11 +1110,11 @@ namespace J2N.Text
             // to take up more than 16KB, we index into the StringBuilder
             // rather than a string.
             bool materializeString = text.Length <= 16384;
-            string readOnlyText = materializeString ? text.ToString() : null;
+            string? readOnlyText = materializeString ? text.ToString() : null;
             for (int j = (n - 1) >> 1; j >= 0; --j)
             {
-                char temp = materializeString ? readOnlyText[j] : text[j];
-                char temp2 = materializeString ? readOnlyText[n - j] : text[n - j];
+                char temp = materializeString ? readOnlyText![j] : text[j];
+                char temp2 = materializeString ? readOnlyText![n - j] : text[n - j];
                 if (!hasSurrogate)
                 {
                     hasSurrogate = (temp >= Character.MinSurrogate && temp <= Character.MaxSurrogate)
@@ -1125,10 +1129,10 @@ namespace J2N.Text
                 // Reverse back all valid surrogate pairs
                 for (int i = 0; i < text.Length - 1; i++)
                 {
-                    char c2 = materializeString ? readOnlyText[i] : text[i];
+                    char c2 = materializeString ? readOnlyText![i] : text[i];
                     if (char.IsLowSurrogate(c2))
                     {
-                        char c1 = materializeString ? readOnlyText[i + 1] : text[i];
+                        char c1 = materializeString ? readOnlyText![i + 1] : text[i];
                         if (char.IsHighSurrogate(c1))
                         {
                             text[i++] = c1;
@@ -1166,10 +1170,10 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static ICharSequence Subsequence(this StringBuilder text, int startIndex, int length)
+        public static ICharSequence Subsequence(this StringBuilder? text, int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (text == null || (startIndex == 0 && length == text.Length))
+            if (text is null || (startIndex == 0 && length == text.Length))
             {
                 return text.AsCharSequence();
             }

--- a/src/J2N/Text/StringCharSequence.cs
+++ b/src/J2N/Text/StringCharSequence.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -19,7 +20,7 @@ namespace J2N.Text
         /// Initializes a new instance of <see cref="StringCharSequence"/> with the provided <paramref name="value"/>.
         /// </summary>
         /// <param name="value">A <see cref="T:char[]"/> to wrap in a <see cref="ICharSequence"/>. The value may be <c>null</c>.</param>
-        public StringCharSequence(string value)
+        public StringCharSequence(string? value)
         {
             this.Value = value;
             this.HasValue = (value != null);
@@ -28,7 +29,7 @@ namespace J2N.Text
         /// <summary>
         /// Gets the current <see cref="string"/> value.
         /// </summary>
-        public string Value { get; }
+        public string? Value { get; }
 
         #region ICharSequence Members
 
@@ -55,7 +56,7 @@ namespace J2N.Text
         {
             get
             {
-                if (Value == null)
+                if (Value is null)
                     throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotIndexNullObject, nameof(StringCharSequence)));
                 return Value[index];
             }
@@ -66,7 +67,7 @@ namespace J2N.Text
         /// </summary>
         public int Length
         {
-            get { return (Value == null) ? 0 : Value.Length; }
+            get { return (Value is null) ? 0 : Value.Length; }
         }
 
         /// <summary>
@@ -93,7 +94,7 @@ namespace J2N.Text
         public ICharSequence Subsequence(int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (Value == null || (startIndex == 0 && length == Value.Length))
+            if (Value is null || (startIndex == 0 && length == Value.Length))
             {
                 return new StringCharSequence(Value);
             }
@@ -129,8 +130,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StringCharSequence csq1, StringCharSequence csq2)
+        public static bool operator ==(StringCharSequence? csq1, StringCharSequence? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq1.Equals(csq2);
         }
 
@@ -142,7 +148,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StringCharSequence csq1, StringCharSequence csq2)
+        public static bool operator !=(StringCharSequence? csq1, StringCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -155,8 +161,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(StringCharSequence csq1, string csq2)
+        public static bool operator ==(StringCharSequence? csq1, string? csq2)
         {
+            if (csq1 is null || !csq1.HasValue)
+                return csq2 is null;
+            else if (csq2 is null)
+                return !csq1.HasValue;
+
             return csq1.Equals(csq2);
         }
 
@@ -168,7 +179,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(StringCharSequence csq1, string csq2)
+        public static bool operator !=(StringCharSequence? csq1, string? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -181,8 +192,13 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator ==(string csq1, StringCharSequence csq2)
+        public static bool operator ==(string? csq1, StringCharSequence? csq2)
         {
+            if (csq1 is null)
+                return csq2 is null || !csq2.HasValue;
+            else if (csq2 is null || !csq2.HasValue)
+                return false;
+
             return csq2.Equals(csq1);
         }
 
@@ -194,7 +210,7 @@ namespace J2N.Text
         /// <param name="csq1">The first sequence.</param>
         /// <param name="csq2">The second sequence.</param>
         /// <returns><c>true</c> if <paramref name="csq1"/> and <paramref name="csq2"/> do not represent to the same instance; otherwise, <c>false</c>.</returns>
-        public static bool operator !=(string csq1, StringCharSequence csq2)
+        public static bool operator !=(string? csq1, StringCharSequence? csq2)
         {
             return !(csq1 == csq2);
         }
@@ -208,11 +224,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An <see cref="ICharSequence"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(ICharSequence other)
+        public bool Equals(ICharSequence? other)
         {
-            if (this.Value == null)
-                return other == null || !other.HasValue;
-            if (other == null)
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
                 return false;
 
             if (other is StringCharSequence stringCharSequence)
@@ -232,8 +248,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringCharSequence"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringCharSequence other)
+        public bool Equals(StringCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -242,8 +263,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="CharArrayCharSequence"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(CharArrayCharSequence other)
+        public bool Equals(CharArrayCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -252,8 +278,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilderCharSequence"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilderCharSequence other)
+        public bool Equals(StringBuilderCharSequence? other)
         {
+            if (this.Value is null)
+                return other is null || !other.HasValue;
+            if (other is null || !other.HasValue)
+                return false;
+
             return this.Equals(other.Value);
         }
 
@@ -262,10 +293,13 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="string"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(string other)
+        public bool Equals(string? other)
         {
-            if (this.Value == null)
-                return other == null;
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
+                return false;
+
             return this.Value.Equals(other, StringComparison.Ordinal);
         }
 
@@ -274,11 +308,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="StringBuilder"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(StringBuilder other)
+        public bool Equals(StringBuilder? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = other.Length;
@@ -298,11 +332,11 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">A <see cref="T:char[]"/> to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public bool Equals(char[] other)
+        public bool Equals(char[]? other)
         {
-            if (this.Value == null)
-                return other == null;
-            if (other == null)
+            if (this.Value is null)
+                return other is null;
+            if (other is null)
                 return false;
 
             int len = other.Length;
@@ -319,22 +353,25 @@ namespace J2N.Text
         /// </summary>
         /// <param name="other">An object to compare to the current <see cref="StringCharSequence"/>.</param>
         /// <returns><c>true</c> if <paramref name="other"/> is equal to the current <see cref="StringCharSequence"/>; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
-            if (other is string)
-                return Equals(other as string);
-            else if (other is StringBuilder)
-                return Equals(other as StringBuilder);
-            else if (other is char[])
-                return Equals(other as char[]);
-            else if (other is StringCharSequence)
-                return Equals((StringCharSequence)other);
-            else if (other is CharArrayCharSequence)
-                return Equals((CharArrayCharSequence)other);
-            else if (other is StringBuilderCharSequence)
-                return Equals((StringBuilderCharSequence)other);
-            else if (other is ICharSequence)
-                return Equals((ICharSequence)other);
+            if (other is null)
+                return !HasValue;
+
+            if (other is string otherString)
+                return Equals(otherString);
+            else if (other is StringBuilder otherStringBuilder)
+                return Equals(otherStringBuilder);
+            else if (other is char[] otherCharArray)
+                return Equals(otherCharArray);
+            else if (other is StringCharSequence otherStringCharSequence)
+                return Equals(otherStringCharSequence);
+            else if (other is CharArrayCharSequence otherCharArrayCharSequence)
+                return Equals(otherCharArrayCharSequence);
+            else if (other is StringBuilderCharSequence otherStringBuilderCharSequence)
+                return Equals(otherStringBuilderCharSequence);
+            else if (other is ICharSequence otherCharSequence)
+                return Equals(otherCharSequence);
 
             return false;
         }
@@ -367,8 +404,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(ICharSequence other)
+        public int CompareTo(ICharSequence? other)
         {
+            if (this.Value is null) return (other is null || !other.HasValue) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -383,8 +423,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(string other)
+        public int CompareTo(string? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -399,8 +442,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(StringBuilder other)
+        public int CompareTo(StringBuilder? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -415,8 +461,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(char[] other)
+        public int CompareTo(char[]? other)
         {
+            if (this.Value is null) return (other is null) ? 0 : -1;
+            if (other is null) return 1;
+
             return this.Value.CompareToOrdinal(other);
         }
 
@@ -431,12 +480,19 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public int CompareTo(object other)
+        public int CompareTo(object? other)
         {
-            if (this.Value == null) return -1;
-            if (other == null) return 1;
+            bool otherIsNull = other is null;
+            if (!otherIsNull && other is ICharSequence csq)
+            {
+                if (this.Value is null) return !csq.HasValue ? 0 : -1;
+                if (!csq.HasValue) return 1;
+            }
 
-            return this.Value.CompareToOrdinal(other.ToString());
+            if (this.Value is null) return otherIsNull ? 0 : -1;
+            if (otherIsNull) return 1;
+
+            return this.Value.CompareToOrdinal(other!.ToString());
         }
 
         #endregion

--- a/src/J2N/Text/StringCharacterEnumerator.cs
+++ b/src/J2N/Text/StringCharacterEnumerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -20,7 +21,9 @@ namespace J2N.Text
         /// </summary>
         /// <param name="value">The source string to iterate over.</param>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public StringCharacterEnumerator(string value)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             => Reset(value);
 
         /// <summary>
@@ -37,7 +40,9 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="position"/> is greater than the length of <paramref name="value"/>.
         /// </exception>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public StringCharacterEnumerator(string value, int position)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             => Reset(value, position);
 
         /// <summary>
@@ -68,7 +73,9 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="position"/> is greater than <paramref name="startIndex"/> + <paramref name="length"/>.
         /// </exception>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         public StringCharacterEnumerator(string value, int startIndex, int length, int position)
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             => Reset(value, startIndex, length, position);
 
         /// <summary>
@@ -203,6 +210,7 @@ namespace J2N.Text
         /// Usage Note: This corresponds to the setText(String) method in the JDK.
         /// </summary>
         /// <param name="value">The new source string.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
         public void Reset(string value)
             => Reset(value, 0);
 
@@ -211,6 +219,7 @@ namespace J2N.Text
         /// </summary>
         /// <param name="value">The new source string.</param>
         /// <param name="position">The current index.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="position"/> is less than 0.
         /// <para/>
@@ -250,7 +259,7 @@ namespace J2N.Text
         /// </exception>
         public void Reset(string value, int startIndex, int length, int position)
         {
-            if (value == null)
+            if (value is null)
                 throw new ArgumentNullException(nameof(value));
             if (startIndex < 0)
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -276,8 +285,9 @@ namespace J2N.Text
         /// <param name="obj">The object to compare with this object.</param>
         /// <returns><c>true</c> if the specified object is equal to this <see cref="StringCharacterEnumerator"/>; <c>false</c> otherwise.</returns>
         /// <seealso cref="GetHashCode()"/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
+            if (obj is null) return false;
             if (!(obj is StringCharacterEnumerator other))
             {
                 return false;

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -19,7 +20,7 @@ namespace J2N.Text
         /// Convenience method to wrap a string in a <see cref="StringCharSequence"/>
         /// so a <see cref="string"/> can be used as <see cref="ICharSequence"/> in .NET.
         /// </summary>
-        public static ICharSequence AsCharSequence(this string text)
+        public static ICharSequence AsCharSequence(this string? text)
         {
             return new StringCharSequence(text);
         }
@@ -46,12 +47,11 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this string str, ICharSequence value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this string? str, ICharSequence? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (value is StringCharSequence && object.ReferenceEquals(str, value)) return 0;
-            if (str == null) return -1;
-            if (value == null) return 1;
-            if (!value.HasValue) return 1;
+            if (str is null) return (value is null || !value.HasValue) ? 0 : -1;
+            if (value is null || !value.HasValue) return 1;
 
             int length = Math.Min(str.Length, value.Length);
             int result;
@@ -84,10 +84,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this string str, char[] value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this string? str, char[]? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (str == null) return -1;
-            if (value == null) return 1;
+            if (str is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             int length = Math.Min(str.Length, value.Length);
             int result;
@@ -120,10 +120,10 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this string str, StringBuilder value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this string? str, StringBuilder? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (str == null) return -1;
-            if (value == null) return 1;
+            if (str is null) return (value is null) ? 0 : -1;
+            if (value is null) return 1;
 
             // Materialize the string. It is faster to loop through
             // a string than a StringBuilder.
@@ -160,7 +160,7 @@ namespace J2N.Text
         /// Zero indicates the strings are equal.
         /// Greater than zero indicates the comparison value is less than the current string.
         /// </returns>
-        public static int CompareToOrdinal(this string str, string value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CompareToOrdinal(this string? str, string? value) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return string.CompareOrdinal(str, value);
         }
@@ -205,7 +205,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException"><paramref name="input"/> is <c>null</c>.</exception>
         public static bool Contains(this string input, char value) // For compatibility with < .NET Standard 2.1
         {
-            if (input == null)
+            if (input is null)
                 throw new ArgumentNullException(nameof(input));
 
             for (int i = 0; i < input.Length; i++)
@@ -237,7 +237,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string text, ICharSequence charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, ICharSequence? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -259,7 +259,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string text, char[] charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, char[]? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -281,7 +281,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string text, StringBuilder charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, StringBuilder? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -303,7 +303,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string text, string charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, string? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -322,11 +322,11 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string text, ICharSequence charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, ICharSequence? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
-                return charSequence == null;
-            if (charSequence == null)
+            if (text is null)
+                return charSequence is null || !charSequence.HasValue;
+            if (charSequence is null || !charSequence.HasValue)
                 return false;
 
             int len = charSequence.Length;
@@ -352,11 +352,11 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string text, char[] charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, char[]? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
-                return charSequence == null;
-            if (charSequence == null)
+            if (text is null)
+                return charSequence is null;
+            if (charSequence is null)
                 return false;
 
             int len = charSequence.Length;
@@ -382,11 +382,11 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string text, StringBuilder charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, StringBuilder? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
-                return charSequence == null;
-            if (charSequence == null)
+            if (text is null)
+                return charSequence is null;
+            if (charSequence is null)
                 return false;
 
             int len = charSequence.Length;
@@ -412,11 +412,11 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string text, string charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, string? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
-                return charSequence == null;
-            if (charSequence == null)
+            if (text is null)
+                return charSequence is null;
+            if (charSequence is null)
                 return false;
 
             int len = charSequence.Length;
@@ -439,11 +439,12 @@ namespace J2N.Text
         /// <param name="text">This <see cref="string"/>.</param>
         /// <param name="encoding">A supported <see cref="Encoding"/>.</param>
         /// <returns>The resultant byte array.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="encoding"/> is <c>null</c>.</exception>
         public static byte[] GetBytes(this string text, Encoding encoding)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (encoding == null)
+            if (encoding is null)
                 throw new ArgumentNullException(nameof(encoding));
 
             return encoding.GetBytes(text);
@@ -527,7 +528,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
         public static int IndexOf(this string text, int codePoint, int startIndex)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             if (startIndex < 0)
@@ -600,7 +601,7 @@ namespace J2N.Text
 #if FEATURE_STRINGINTERN
             return string.Intern(text);
 #else
-            return interner.Intern(text);
+            return interner.Intern(text); // J2N: This is for compatibility with .NET flavors that don't support string interning (.NET Standard 1.x)
 #endif
         }
 
@@ -621,7 +622,7 @@ namespace J2N.Text
             {
                 internal /*private*/ string str;
                 internal /*private*/ int hash;
-                internal /*private*/ Entry next;
+                internal /*private*/ Entry? next;
                 internal Entry(string str, int hash, Entry next)
                 {
                     this.str = str;
@@ -666,11 +667,11 @@ namespace J2N.Text
                 int slot = h & (cache.Length - 1);
 
                 Entry first = this.cache[slot];
-                Entry nextToLast = null;
+                Entry? nextToLast = null;
 
                 int chainLength = 0;
 
-                for (Entry e = first; e != null; e = e.next)
+                for (Entry? e = first; e != null; e = e.next)
                 {
                     if (ReferenceEquals(e.str, s) || (e.hash == h && string.CompareOrdinal(e.str, s) == 0))
                     {
@@ -687,7 +688,7 @@ namespace J2N.Text
 
                 // insertion-order cache: add new entry at head
                 this.cache[slot] = new Entry(s, h, first);
-                if (chainLength >= maxChainLength)
+                if (chainLength >= maxChainLength && nextToLast != null)
                 {
                     // prune last entry
                     nextToLast.next = null;
@@ -730,7 +731,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
         public static int LastIndexOf(this string text, int codePoint)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             return LastIndexOf(text, codePoint, text.Length - 1);
@@ -771,7 +772,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
         public static int LastIndexOf(this string text, int codePoint, int startIndex)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
             if (codePoint < Character.MinSupplementaryCodePoint)
@@ -830,9 +831,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool RegionMatches(this string text, int thisStartIndex, ICharSequence other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
             if (other.Length - otherStartIndex < length || otherStartIndex < 0)
@@ -891,9 +892,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool RegionMatches(this string text, int thisStartIndex, char[] other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
             if (other.Length - otherStartIndex < length || otherStartIndex < 0)
@@ -952,9 +953,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool RegionMatches(this string text, int thisStartIndex, StringBuilder other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
             if (other.Length - otherStartIndex < length || otherStartIndex < 0)
@@ -1013,9 +1014,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool RegionMatches(this string text, int thisStartIndex, string other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 
             if (other.Length - otherStartIndex < length || otherStartIndex < 0)
@@ -1075,9 +1076,9 @@ namespace J2N.Text
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool StartsWith(this string text, string prefix, int startIndex, StringComparison comparisonType)
         {
-            if (text == null)
+            if (text is null)
                 throw new ArgumentNullException(nameof(text));
-            if (prefix == null)
+            if (prefix is null)
                 throw new ArgumentNullException(nameof(prefix));
 
             return RegionMatches(text, startIndex, prefix, 0, prefix.Length, comparisonType);
@@ -1108,10 +1109,10 @@ namespace J2N.Text
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static ICharSequence Subsequence(this string text, int startIndex, int length)
+        public static ICharSequence Subsequence(this string? text, int startIndex, int length)
         {
             // From Apache Harmony String class
-            if (text == null || (startIndex == 0 && length == text.Length))
+            if (text is null || (startIndex == 0 && length == text.Length))
             {
                 return text.AsCharSequence();
             }

--- a/src/J2N/Text/StringFormatter.cs
+++ b/src/J2N/Text/StringFormatter.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-#nullable enable
+
 
 namespace J2N.Text
 {

--- a/src/J2N/Text/StringTokenizer.cs
+++ b/src/J2N/Text/StringTokenizer.cs
@@ -133,6 +133,7 @@ namespace J2N.Text
             this.returnDelimiters = returnDelimiters;
             this.position = 0;
             this.remainingTokens = CountTokens();
+            Current = string.Empty; // J2N specific - don't leave Current null, so we can get by the nullability declaration in IEnumerable<string>
         }
 
         /// <summary>

--- a/src/J2N/Threading/Atomic/AtomicBoolean.cs
+++ b/src/J2N/Threading/Atomic/AtomicBoolean.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading.Atomic
 {

--- a/src/J2N/Threading/Atomic/AtomicInt32.cs
+++ b/src/J2N/Threading/Atomic/AtomicInt32.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading.Atomic
 {

--- a/src/J2N/Threading/Atomic/AtomicInt64.cs
+++ b/src/J2N/Threading/Atomic/AtomicInt64.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading.Atomic
 {

--- a/src/J2N/Threading/Atomic/AtomicReference.cs
+++ b/src/J2N/Threading/Atomic/AtomicReference.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading.Atomic
 {

--- a/src/J2N/Threading/Atomic/AtomicReferenceArray.cs
+++ b/src/J2N/Threading/Atomic/AtomicReferenceArray.cs
@@ -1,7 +1,7 @@
 ﻿using J2N.Collections;
 using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading.Atomic
 {

--- a/src/J2N/Threading/ThreadJob.cs
+++ b/src/J2N/Threading/ThreadJob.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-#nullable enable
+
 
 namespace J2N.Threading
 {

--- a/src/J2N/Time.cs
+++ b/src/J2N/Time.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/TypeExtensions.cs
+++ b/src/J2N/TypeExtensions.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N
 {

--- a/src/J2N/TypeInfoExtensions.cs
+++ b/src/J2N/TypeInfoExtensions.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
-#nullable enable
+
 
 namespace J2N
 {

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -8,7 +8,7 @@
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>
 

--- a/tests/J2N.Tests/Startup.cs
+++ b/tests/J2N.Tests/Startup.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+using System.Text;
+
+namespace J2N
+{
+    [SetUpFixture]
+    public class Startup
+    {
+        /// <summary>
+        /// This method is automatically called
+        /// by NUnit one time before all tests run.
+        /// </summary>
+        [OneTimeSetUp]
+        protected void OneTimeSetUpBeforeTests()
+        {
+#if FEATURE_ENCODINGPROVIDERS
+            // Support for 8859-1 and IBM01047 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+#endif
+        }
+
+        /// <summary>
+        /// This method is automatically called
+        /// by NUnit one time after all tests run.
+        /// </summary>
+        [OneTimeTearDown]
+        protected void OneTimeTearDownAfterTests()
+        {
+
+        }
+    }
+}

--- a/tests/J2N.Tests/Text/CharSequenceTestBase.cs
+++ b/tests/J2N.Tests/Text/CharSequenceTestBase.cs
@@ -127,6 +127,12 @@ namespace J2N.Text
             Assert.IsFalse(target.Equals(new StringBuilderCharSequence(new StringBuilder(String2))));
             Assert.IsFalse(target.Equals(new CharArrayCharSequence(String2.ToCharArray())));
 
+            Assert.IsTrue(nullTarget.Equals((string)null));
+            Assert.IsTrue(nullTarget.Equals((char[])null));
+            Assert.IsTrue(nullTarget.Equals(new StringCharSequence(null)));
+            Assert.IsTrue(nullTarget.Equals(new StringBuilderCharSequence(null)));
+            Assert.IsTrue(nullTarget.Equals(new CharArrayCharSequence(null)));
+
 
             Assert.IsTrue(target.Equals((object)String1));
             Assert.IsTrue(target.Equals((object)String1.ToCharArray()));
@@ -141,6 +147,13 @@ namespace J2N.Text
             Assert.IsFalse(target.Equals((object)new StringCharSequence(String2)));
             Assert.IsFalse(target.Equals((object)new StringBuilderCharSequence(new StringBuilder(String2))));
             Assert.IsFalse(target.Equals((object)new CharArrayCharSequence(String2.ToCharArray())));
+
+            Assert.IsTrue(nullTarget.Equals((object)null));
+            Assert.IsTrue(nullTarget.Equals((object)(string)null));
+            Assert.IsTrue(nullTarget.Equals((object)(char[])null));
+            Assert.IsTrue(nullTarget.Equals((object)new StringCharSequence(null)));
+            Assert.IsTrue(nullTarget.Equals((object)new StringBuilderCharSequence(null)));
+            Assert.IsTrue(nullTarget.Equals((object)new CharArrayCharSequence(null)));
         }
 
         [Test]
@@ -193,6 +206,16 @@ namespace J2N.Text
             Assert.Less(0, target.CompareTo((string)null));
             Assert.Less(0, target.CompareTo((StringBuilder)null));
             Assert.Less(0, target.CompareTo((char[])null));
+
+            Assert.AreEqual(0, nullTarget.CompareTo((string)null));
+            Assert.AreEqual(0, nullTarget.CompareTo((StringBuilder)null));
+            Assert.AreEqual(0, nullTarget.CompareTo((StringBuffer)null));
+            Assert.AreEqual(0, nullTarget.CompareTo((char[])null));
+            Assert.AreEqual(0, nullTarget.CompareTo((ICharSequence)null));
+            Assert.AreEqual(0, nullTarget.CompareTo(new StringBuilderCharSequence(null)));
+            Assert.AreEqual(0, nullTarget.CompareTo(new StringCharSequence(null)));
+            Assert.AreEqual(0, nullTarget.CompareTo(new CharArrayCharSequence(null)));
+            Assert.AreEqual(0, nullTarget.CompareTo((object)null));
         }
     }
 }

--- a/tests/J2N.Tests/Text/TestCharArrayExtensions.cs
+++ b/tests/J2N.Tests/Text/TestCharArrayExtensions.cs
@@ -87,6 +87,15 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(null)));
+
+            target = null;
+
+            Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
+            Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
+            Assert.AreEqual(0, target.CompareToOrdinal((string)null));
+            Assert.AreEqual(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringCharSequence(null)));
         }
     }
 }

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -126,6 +126,15 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(null)));
+
+            target = null;
+
+            Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
+            Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
+            Assert.AreEqual(0, target.CompareToOrdinal((string)null));
+            Assert.AreEqual(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringCharSequence(null)));
         }
 
         [Test]

--- a/tests/J2N.Tests/Text/TestStringExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringExtensions.cs
@@ -8,15 +8,8 @@ namespace J2N.Text
 {
     public class TestStringExtensions : TestCase
     {
-#if FEATURE_ENCODINGPROVIDERS
-        static TestStringExtensions()
-        {
-            // Support for 8859-1 and IBM01047 encoding. See: https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-            var encodingProvider = System.Text.CodePagesEncodingProvider.Instance;
-            System.Text.Encoding.RegisterProvider(encodingProvider);
-        }
-#endif
-
+        // Depends on System.Text.Encoding.EncodingProivers being loaded for 8859-1 and IBM01047 encoding.
+        // This is done in Startup.cs.
 
         const string hw1 = "HelloWorld";
         const string hw2 = "HelloWorld";

--- a/tests/J2N.Tests/Text/TestStringExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringExtensions.cs
@@ -61,6 +61,15 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(null)));
+
+            target = null;
+
+            Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
+            Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
+            Assert.AreEqual(0, target.CompareToOrdinal((string)null));
+            Assert.AreEqual(0, target.CompareToOrdinal(new CharArrayCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilderCharSequence(null)));
+            Assert.AreEqual(0, target.CompareToOrdinal(new StringCharSequence(null)));
         }
 
         // This is a compatibility API for < .NET Standard 2.1
@@ -208,7 +217,7 @@ namespace J2N.Text
             // if the target is null and string is not.
             assertFalse(s.ContentEquals((StringBuilder)null));
             assertTrue(((string)null).ContentEquals((StringBuilder)null));
-            assertFalse(((string)null).ContentEquals((StringBuilder) new StringBuilder("")));
+            assertFalse(((string)null).ContentEquals((StringBuilder)new StringBuilder("")));
             assertTrue("".ContentEquals((StringBuilder)new StringBuilder("")));
         }
 
@@ -638,9 +647,9 @@ namespace J2N.Text
 
             using (var context = new CultureContext("tr"))
             {
-                assertTrue("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in tr culture", 
+                assertTrue("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in tr culture",
                     input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
-                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in tr culture", 
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in tr culture",
                     input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
             }
             using (var context = new CultureContext("en"))

--- a/tests/J2N.Tests/Text/TestStringFormatter.cs
+++ b/tests/J2N.Tests/Text/TestStringFormatter.cs
@@ -132,6 +132,14 @@ namespace J2N.Text
         }
 
         [Test]
+        public void Test_StandardFormat_Double()
+        {
+            assertEquals("22.0000000", string.Format(StringFormatter.InvariantCulture, "{0:F7}", 22d));
+            assertEquals("22.0", string.Format(StringFormatter.InvariantCulture, "{0:N1}", 22d));
+            assertEquals("22.5", string.Format(StringFormatter.InvariantCulture, "{0:N1}", 22.45678d));
+        }
+
+        [Test]
         public void TestBoolean()
         {
             assertEquals("true", string.Format(StringFormatter.InvariantCulture, "{0}", true));


### PR DESCRIPTION
Closes #10. Supercedes #21, which targeted the wrong branch.

Completed nullable reference type support and fixed issues that could lead to `NullReferenceExeption` as well as problems with `null` comparisons and equality.

Also removed dependency on `System.Text.Encoding.CodePages`, since it is only for `ISO-8859-1` in `PropertyExtensions` and  [.NET Core already includes this encoding](https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider). So, the odds that someone will run into the dreaded "encoding not supported" error that means they will have to add the dependency and configure the encoding provider are very remote.