### PR TITLE
Added ParseException + tests

### DIFF
--- a/src/J2N/Text/ParseException.cs
+++ b/src/J2N/Text/ParseException.cs
@@ -1,0 +1,94 @@
+﻿using System;
+
+namespace J2N.Text
+{
+    /// <summary>
+    /// A <see cref="ParseException"/> is thrown when elements are written
+    /// to a buffer but there is not enough remaining space in the buffer.
+    /// </summary>
+    // It is no longer good practice to use binary serialization. 
+    // See: https://github.com/dotnet/corefx/issues/23584#issuecomment-325724568
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+    [Serializable]
+#endif
+    public class ParseException : Exception
+    {
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+        // names for serialization
+        private const string ErrorOffsetName = "ErrorOffset"; // Do not rename (binary serialization)
+#endif
+
+        private readonly int errorOffset;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ParseException"/>
+        /// with the specified <paramref name="message"/> and <paramref name="errorOffset"/>.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="errorOffset">The position where the error is found while parsing.</param>
+        public ParseException(string message, int errorOffset) : base(message)
+        {
+            this.errorOffset = errorOffset;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ParseException"/>
+        /// with the specified <paramref name="message"/>, <paramref name="errorOffset"/> and <paramref name="innerException"/>.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="errorOffset">The position where the error is found while parsing.</param>
+        /// <param name="innerException">The original cause of this parse exception.</param>
+        public ParseException(string message, int errorOffset, Exception innerException) : base(message, innerException)
+        {
+            this.errorOffset = errorOffset;
+        }
+
+        // J2N: For testing purposes
+        internal ParseException()
+        {
+        }
+
+        // J2N: For testing purposes
+        internal ParseException(string message) : base(message)
+        {
+        }
+
+        // J2N: For testing purposes
+        internal ParseException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+        /// <summary>
+        /// Initializes a new instance of this class with serialized data.
+        /// </summary>
+        /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        private ParseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+            : base(info, context)
+        {
+            errorOffset = info.GetInt32(ErrorOffsetName);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="System.Runtime.Serialization.SerializationInfo"/> with information about the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+        {
+            if (info is null)
+                throw new ArgumentNullException(nameof(info));
+
+            info.AddValue(ErrorOffsetName, errorOffset);
+
+            base.GetObjectData(info, context);
+        }
+#endif
+
+        /// <summary>
+        /// Returns the position where the error was found.
+        /// </summary>
+        public int ErrorOffset => errorOffset;
+    }
+}

--- a/tests/J2N.Tests/Text/TestParseException.cs
+++ b/tests/J2N.Tests/Text/TestParseException.cs
@@ -1,0 +1,89 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace J2N.Text
+{
+    public class TestParseException : TestCase
+    {
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
+        /**
+         * @tests serialization/deserialization compatibility.
+         */
+        [Test]
+        public void TestSerializationSelf()
+        {
+
+            //SerializationTest.verifySelf(new BufferOverflowException());
+            var ex = new ParseException("testing", 1234, new IOException("testing12"));
+            var clone = Clone(ex);
+
+            assertNotSame(ex, clone);
+            assertNotSame(ex.InnerException, clone.InnerException);
+            assertEquals("testing", clone.Message);
+            assertEquals(1234, clone.ErrorOffset);
+            assertEquals("testing12", clone.InnerException.Message);
+        }
+
+        /////**
+        //// * @tests serialization/deserialization compatibility with RI.
+        //// */
+        ////public void testSerializationCompatibility() 
+        ////{
+
+        ////    SerializationTest.verifyGolden(this, new BufferOverflowException());
+        ////}
+#endif
+
+        /**
+         * @tests java.text.ParseException#ParseException(java.lang.String, int)
+         */
+        [Test]
+        public void test_ConstructorLjava_lang_StringI()
+        {
+            //try
+            //{
+            //    DateFormat df = DateFormat.getInstance();
+            //    df.parse("HelloWorld");
+            //    fail("ParseException not created/thrown.");
+            //}
+            //catch (ParseException e)
+            //{
+            //    // expected
+            //}
+
+            // J2N: We don't have anything that will throw this, so we just test
+            // the basic constructors to verify it works.
+            var target = new ParseException("foo", 43);
+            assertEquals("foo", target.Message);
+            assertEquals(43, target.ErrorOffset);
+
+            var target2 = new ParseException("bar", 67, new InvalidOperationException("Something bad happened."));
+            assertEquals("bar", target2.Message);
+            assertEquals(67, target2.ErrorOffset);
+            assertTrue(target2.InnerException is InvalidOperationException);
+            assertEquals("Something bad happened.", target2.InnerException.Message);
+        }
+
+        ///**
+        // * @tests java.text.ParseException#getErrorOffset()
+        // */
+        //[Test]
+        //public void test_getErrorOffset()
+        //{
+        //    //try
+        //    //{
+        //    //    DateFormat df = DateFormat.getInstance();
+        //    //    df.parse("1999HelloWorld");
+        //    //}
+        //    //catch (ParseException e)
+        //    //{
+        //    //    assertEquals("getErrorOffsetFailed.", 4, e.getErrorOffset());
+        //    //}
+        //}
+    }
+}


### PR DESCRIPTION
This supersedes #25, which targeted the wrong branch.

This is a checked exception in Java and `NumberFormatException` is unchecked. This isn't really a problem per se in .NET, but there is only 1 exception named `FormatException` that sort of maps to both cases. However, if you have an application where the exception handling is so complex that you need to have a `ParseException` that is different from `FormatException`, then here it is. This also can solve compatibility with throwing a platform exception named `ParseException` that needs to be passed between ported libraries as the same type.