### PR TITLE
Fixed BitSet documentation

### DIFF
--- a/src/J2N/Collections/BitSet.cs
+++ b/src/J2N/Collections/BitSet.cs
@@ -577,7 +577,7 @@ namespace J2N.Collections
         /// <paramref name="position"/> &gt; size.
         /// </summary>
         /// <param name="position">The index of the bit to flip.</param>
-        /// <exception cref="IndexOutOfRangeException">If <paramref name="position"/> is negative.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="position"/> is negative.</exception>
         /// <seealso cref="Flip(int, int)"/>
         public virtual void Flip(int position)
         {


### PR DESCRIPTION
Corrected documentation about `IndexOutOfRangeException`, which should be `ArgumentOutOfRangeException`