### PR TITLE
Fixed enum support in StringFormatter

### DIFF
--- a/src/J2N/Text/StringFormatter.cs
+++ b/src/J2N/Text/StringFormatter.cs
@@ -150,10 +150,10 @@ namespace J2N.Text
         public virtual string Format(string? format, object? arg, IFormatProvider? formatProvider)
         {
             if (!this.Equals(formatProvider))
-                return HandleOtherFormats(format, arg, formatProvider);
+                return null!; // Not handled by this formatter
 
             if (!(string.IsNullOrEmpty(format) || format == "J" || format == "j"))
-                return HandleOtherFormats(format, arg, formatProvider);
+                return null!; // Not handled by this formatter
 
             if (arg is null)
                 return "null";
@@ -178,21 +178,7 @@ namespace J2N.Text
                 return CollectionUtil.ToStringImpl(arg, argType, this);
             }
 
-            return HandleOtherFormats(format, arg, formatProvider);
-        }
-
-        private string HandleOtherFormats(string? format, object? arg, IFormatProvider? formatProvider)
-        {
-            if (formatProvider is ICustomFormatter customFormatter && !(formatProvider is StringFormatter))
-                return customFormatter.Format(format, arg, formatProvider);
-
-            // This is from the Microsoft example: https://docs.microsoft.com/en-us/dotnet/api/system.icustomformatter
-            if (arg is IFormattable formattableArg)
-                return formattableArg.ToString(format ?? "0", formatProvider);
-            else if (arg != null)
-                return arg.ToString() ?? string.Empty;
-            else
-                return string.Empty;
+            return null!; // Not handled by this formatter
         }
 
         private NumberFormatInfo? GetNumberFormatInfo(IFormatProvider provider)

--- a/tests/J2N.Tests/Text/TestStringFormatter.cs
+++ b/tests/J2N.Tests/Text/TestStringFormatter.cs
@@ -153,5 +153,25 @@ namespace J2N.Text
             assertEquals("[1, 2, 3, 4, 5, 6, 7]", string.Format(StringFormatter.InvariantCulture, "{0}", new int[] { 1, 2, 3, 4, 5, 6, 7 }));
             assertEquals("[1, 2, 3, 4, 5, 6, 7]", string.Format(StringFormatter.InvariantCulture, "{0}", (System.Array)new string[] { "1", "2", "3", "4", "5", "6", "7" }));
         }
+
+        private enum State
+        {
+            SETREADER, // consumer set a reader input either via ctor or via reset(Reader)
+            RESET, // consumer has called reset()
+            INCREMENT, // consumer is consuming, has called IncrementToken() == true
+            INCREMENT_FALSE, // consumer has called IncrementToken() which returned false
+            END, // consumer has called end() to perform end of stream operations
+            CLOSE // consumer has called close() to release any resources
+        }
+
+        [Test]
+        public void TestEnum()
+        {
+            var state = State.RESET;
+
+            var actual = string.Format(StringFormatter.InvariantCulture, "IncrementToken() called while in wrong state: {0}", state);
+
+            assertEquals("IncrementToken() called while in wrong state: RESET", actual);
+        }
     }
 }


### PR DESCRIPTION
`StringFormatter` had been changed to use nullable reference types in #23, however it appears that the feedback provided by the nullable support of `ICustomFormatter` was incorrect and doesn't match the documentation. `null` values are valid and allowed to be returned from `ICustomFormatter.Format()` to specify that the custom formatter couldn't handle the formatting and also `IFormattable.ToString(string, IFormatProvider)` allows (and requires) a `null` format to be passed in certain scenarios, such as when the type is an `enum`.

This reverts the implementation to returning `null` in cases we don't handle.