### PR TITLE
J2N.Character: Added code point overloads of Digit() and GetNumericValue()

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup Label="NuGet Package Reference Versions">
+    <ICU4NPackageReferenceVersion>60.1.0-alpha.354</ICU4NPackageReferenceVersion>
     <MicrosoftCSharpPackageReferenceVersion>4.4.0</MicrosoftCSharpPackageReferenceVersion>
     <MicrosoftNETTestSdkPackageReferenceVersion>16.1.1</MicrosoftNETTestSdkPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.3.37]</NerdBankGitVersioningPackageReferenceVersion>

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -96,55 +96,373 @@ namespace J2N
         /// </summary>
         public const int MaxCodePoint = 0x10FFFF;
 
-        // Unicode 10.0
+        /// <summary>Map from an ASCII char to its digit value (up to radix 36), e.g. arr['b'] == 11. 0xff means it's not a digit.</summary>
+        private static readonly sbyte[] ASCIIDigits = unchecked(new sbyte[] {
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff,
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 15
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff,
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 31
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff,
+            (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 47
+            (sbyte)0x00, (sbyte)0x01, (sbyte)0x02, (sbyte)0x03, (sbyte)0x04, (sbyte)0x05, (sbyte)0x06, (sbyte)0x07,
+            (sbyte)0x08, (sbyte)0x09, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 63
+            (sbyte)0xff, (sbyte)0x0a, (sbyte)0x0b, (sbyte)0x0c, (sbyte)0x0d, (sbyte)0x0e, (sbyte)0x0f, (sbyte)0x10,
+            (sbyte)0x11, (sbyte)0x12, (sbyte)0x13, (sbyte)0x14, (sbyte)0x15, (sbyte)0x16, (sbyte)0x17, (sbyte)0x18, // 79
+            (sbyte)0x19, (sbyte)0x1a, (sbyte)0x1b, (sbyte)0x1c, (sbyte)0x1d, (sbyte)0x1e, (sbyte)0x1f, (sbyte)0x20,
+            (sbyte)0x21, (sbyte)0x22, (sbyte)0x23, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 95
+            (sbyte)0xff, (sbyte)0x0a, (sbyte)0x0b, (sbyte)0x0c, (sbyte)0x0d, (sbyte)0x0e, (sbyte)0x0f, (sbyte)0x10,
+            (sbyte)0x11, (sbyte)0x12, (sbyte)0x13, (sbyte)0x14, (sbyte)0x15, (sbyte)0x16, (sbyte)0x17, (sbyte)0x18, // 111
+            (sbyte)0x19, (sbyte)0x1a, (sbyte)0x1b, (sbyte)0x1c, (sbyte)0x1d, (sbyte)0x1e, (sbyte)0x1f, (sbyte)0x20,
+            (sbyte)0x21, (sbyte)0x22, (sbyte)0x23, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, (sbyte)0xff, // 127
+        });
+
+        // Implementation Note:
+
+        // The approach used with these values was to store 3 values for each range. This approach to storage
+        // is used in all of the ranges of different characters whether they are stored as strings, or arrays
+        // of various types.
+        // 
+        // The stored values:
+        // 1. The beginning of the range (stored in the "keys")
+        // 2. The end of the range (stored in "values" in the location key index * 2).
+        // 3. The offset of the first character, which is subtracted from the beginning character of the range
+        //    (stored in "values" in the location key index * 2 + 1).
+        //
+        // This allows the return value to be skewed from the actual numerical value of the code point and allows
+        // for various rules by adding additional "ranges" of single characters. Some of the characters in an actual
+        // range increment by a numerical value of 10 or 100, so these numbers, although contiguous in character value
+        // can have a wildly varying numerical value.
+        //
+        // This is the original approach used in Apache Harmony, which has been carried over into J2N and extended
+        // so we could upgrade the Unicode version.
+
+
+        // Unicode 10.0 (Harmony was at 3.0.0)
         private const string digitKeys = "\u0660\u06f0\u07c0\u0966\u09e6\u0a66\u0ae6\u0b66\u0be6\u0c66\u0ce6\u0d66\u0de6\u0e50\u0ed0\u0f20\u1040\u1090\u17e0\u1810\u1946\u19d0\u1a80\u1a90\u1b50\u1bb0\u1c40\u1c50\ua620\ua8d0\ua900\ua9d0\ua9f0\uaa50\uabf0\uff10\uff21\uff41";
 
-        // J2N NOTE: This is the string that came directly out of UnicodeSet. For some reason the last 2 ranges didn't match the original Harmony values.
-        // However, reverting back to those Harmony values makes the tests pass when compared against ICU4N.
-        // There were also Ethiopian digits (\u1368 - \u1371) in Harmony that don't conform to Unicode and the behavior both of ICU4N
+        // J2N NOTE: There were Ethiopian digits (\u1368 - \u1371) in Harmony that don't conform to Unicode and the behavior both of ICU4N
         // and the JDK do not recognize them as digits. Unlike recognizable digits, they are categorized as UUnicodeCategory.OtherNumber.
-        //private static readonly char[] digitValues = "\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1099\u1090\u17e9\u17e0\u1819\u1810\u194f\u1946\u19d9\u19d0\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\ua629\ua620\ua8d9\ua8d0\ua909\ua900\ua9d9\ua9d0\ua9f9\ua9f0\uaa59\uaa50\uabf9\uabf0\uff19\uff10\uff3a\uff21\uff5a\uff41".ToCharArray();
-        private static readonly char[] digitValues = "\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1099\u1090\u17e9\u17e0\u1819\u1810\u194f\u1946\u19d9\u19d0\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\ua629\ua620\ua8d9\ua8d0\ua909\ua900\ua9d9\ua9d0\ua9f9\ua9f0\uaa59\uaa50\uabf9\uabf0\uff19\uff10\uff3a\uff17\uff5a\uff37".ToCharArray();
+        // These have been omitted from J2N.
+        private static readonly char[] digitValues = "\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1099\u1090\u17e9\u17e0\u1819\u1810\u194f\u1946\u19d9\u19d0\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\ua629\ua620\ua8d9\ua8d0\ua909\ua900\ua9d9\ua9d0\ua9f9\ua9f0\uaa59\uaa50\uabf9\uabf0\uff19\uff10\uff3a\uff17\uff5a\uff37"
+            .ToCharArray();
 
         /// <summary>
         /// Supplemental characters (surrogates) for digits. Implements Unicode 10.0.
+        /// <para/>
+        /// This class is strictly to lazy-load the range of values if and only if they are required.
         /// </summary>
         private static class DigitSupplemental
         {
-            public static readonly int[] Keys = new int[] {
-                0x000104a0, 0x00011066, 0x000110f0, 0x00011136, 0x000111d0, 0x000112f0, 0x00011450, 0x000114d0,
-                0x00011650, 0x000116c0, 0x00011730, 0x000118e0, 0x00011c50, 0x00011d50, 0x00016a60, 0x00016b50,
-
-                // J2N: The 5 ranges here didn't come directly out of the UnicodeSet class, but these
-                // were one contiguous range. However, they comprise 5 different numeric sets, so they were
-                // broken apart manually.
-                0x0001d7ce, 0x0001d7d8, 0x0001d7e2, 0x0001d7ec, 0x0001d7f6, 
-
-                0x0001e950
+            public static readonly uint[] Keys = new uint[] {
+                0x000104a0, 0x00011066, 0x000110f0, 0x00011136,
+                0x000111d0, 0x000112f0, 0x00011450, 0x000114d0,
+                0x00011650, 0x000116c0, 0x00011730, 0x000118e0,
+                0x00011c50, 0x00011d50, 0x00016a60, 0x00016b50,
+                0x0001d7ce, 0x0001d7d8, 0x0001d7e2, 0x0001d7ec,
+                0x0001d7f6, 0x0001e950
             };
 
-            public static readonly int[] Values = new int[] {
+            public static readonly uint[] Values = new uint[] {
                 0x000104a9, 0x000104a0, 0x0001106f, 0x00011066, 0x000110f9, 0x000110f0, 0x0001113f, 0x00011136,
                 0x000111d9, 0x000111d0, 0x000112f9, 0x000112f0, 0x00011459, 0x00011450, 0x000114d9, 0x000114d0,
                 0x00011659, 0x00011650, 0x000116c9, 0x000116c0, 0x00011739, 0x00011730, 0x000118e9, 0x000118e0,
                 0x00011c59, 0x00011c50, 0x00011d59, 0x00011d50, 0x00016a69, 0x00016a60, 0x00016b59, 0x00016b50,
-
-                // J2N: The 5 ranges here didn't come directly out of the UnicodeSet class, but these
-                // were one contiguous range. However, they comprise 5 different numeric sets, so they were
-                // broken apart manually.
-                //0x0001d7ff, 0x0001d7ce,
                 0x0001d7d7, 0x0001d7ce, 0x0001d7e1, 0x0001d7d8, 0x0001d7eb, 0x0001d7e2, 0x0001d7f5, 0x0001d7ec,
-                0x0001d7ff, 0x0001d7f6,
-
-                0x0001e959, 0x0001e950
+                0x0001d7ff, 0x0001d7f6, 0x0001e959, 0x0001e950
             };
         }
 
-        // Unicode 3.0.0 (NOT the same as Unicode 3.0.1)
-        private const string numericKeys = "0Aa\u00b2\u00b9\u00bc\u0660\u06f0\u0966\u09e6\u09f4\u09f9\u0a66\u0ae6\u0b66\u0be7\u0bf1\u0bf2\u0c66\u0ce6\u0d66\u0e50\u0ed0\u0f20\u1040\u1369\u1373\u1374\u1375\u1376\u1377\u1378\u1379\u137a\u137b\u137c\u16ee\u17e0\u1810\u2070\u2074\u2080\u2153\u215f\u2160\u216c\u216d\u216e\u216f\u2170\u217c\u217d\u217e\u217f\u2180\u2181\u2182\u2460\u2474\u2488\u24ea\u2776\u2780\u278a\u3007\u3021\u3038\u3039\u303a\u3280\uff10\uff21\uff41";
 
-        private static readonly char[] numericValues = "90Z7zW\u00b3\u00b0\u00b9\u00b8\u00be\u0000\u0669\u0660\u06f9\u06f0\u096f\u0966\u09ef\u09e6\u09f7\u09f3\u09f9\u09e9\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bf0\u0be6\u0bf1\u0b8d\u0bf2\u080a\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1372\u1368\u1373\u135f\u1374\u1356\u1375\u134d\u1376\u1344\u1377\u133b\u1378\u1332\u1379\u1329\u137a\u1320\u137b\u1317\u137c\uec6c\u16f0\u16dd\u17e9\u17e0\u1819\u1810\u2070\u2070\u2079\u2070\u2089\u2080\u215e\u0000\u215f\u215e\u216b\u215f\u216c\u213a\u216d\u2109\u216e\u1f7a\u216f\u1d87\u217b\u216f\u217c\u214a\u217d\u2119\u217e\u1f8a\u217f\u1d97\u2180\u1d98\u2181\u0df9\u2182\ufa72\u2473\u245f\u2487\u2473\u249b\u2487\u24ea\u24ea\u277f\u2775\u2789\u277f\u2793\u2789\u3007\u3007\u3029\u3020\u3038\u302e\u3039\u3025\u303a\u301c\u3289\u327f\uff19\uff10\uff3a\uff17\uff5a\uff37"
+        // Unicode 10.0 (Harmony was at 3.0.0)
+        private const string numericKeys = "\u00b2\u00b9\u00bc\u0660\u06f0\u07c0\u0966\u09e6\u09f4\u09f9\u0a66\u0ae6\u0b66\u0b72\u0be6\u0bf1\u0bf2\u0c66\u0c78\u0c7b\u0c7c\u0ce6\u0d58\u0d66\u0d71\u0d72\u0d73\u0de6\u0e50\u0ed0\u0f20\u0f2a\u1040\u1090\u1369\u1373\u1374\u1375\u1376\u1377\u1378\u1379\u137a\u137b\u137c\u16ee\u17e0\u17f0\u1810\u1946\u19d0\u19da\u1a80\u1a90\u1b50\u1bb0\u1c40\u1c50\u2070\u2074\u2080\u2150\u215f\u2160\u216c\u216d\u216e\u216f\u2170\u217c\u217d\u217e\u217f\u2180\u2181\u2182\u2185\u2186";
+
+        private static readonly char[] numericValues = "\u00b3\u00b0\u00b9\u00b8\u00be\u0000\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u09f8\u0000\u09f9\u09e9\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0b77\u0000\u0bf0\u0be6\u0bf1\u0b8d\u0bf2\u080a\u0c6f\u0c66\u0c7e\u0c78\u0c7b\u0c78\u0c7e\u0c7b\u0cef\u0ce6\u0d5e\u0000\u0d70\u0d66\u0d71\u0d0d\u0d72\u098a\u0d78\u0000\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u0f33\u0000\u1049\u1040\u1099\u1090\u1372\u1368\u1373\u135f\u1374\u1356\u1375\u134d\u1376\u1344\u1377\u133b\u1378\u1332\u1379\u1329\u137a\u1320\u137b\u1317\u137c\uec6c\u16f0\u16dd\u17e9\u17e0\u17f9\u17f0\u1819\u1810\u194f\u1946\u19d9\u19d0\u19da\u19d9\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\u2070\u2070\u2079\u2070\u2089\u2080\u215e\u0000\u2182\u215e\u216b\u215f\u216c\u213a\u216d\u2109\u216e\u1f7a\u216f\u1d87\u217b\u216f\u217c\u214a\u217d\u2119\u217e\u1f8a\u217f\u1d97\u2180\u1d98\u2181\u0df9\u2182\ufa72\u2185\u217f\u2186\u2154"
             .ToCharArray();
+
+        /// <summary>
+        /// Intermediate range of characters with starting point 0x2187 because it is the first character
+        /// that requires a value larger than <see cref="char"/> to calculate the result. Implements Unicode 10.0.
+        /// <para/>
+        /// This class is strictly to lazy-load the range of values if and only if they are required.
+        /// </summary>
+        private static class NumericIntermediate
+        {
+            public static readonly ushort[] Keys = new ushort[] {
+                0x2187, 0x2188, 0x2189, 0x2460,
+                0x2474, 0x2488, 0x24ea, 0x24eb,
+                0x24f5, 0x24ff, 0x2776, 0x2780,
+                0x278a, 0x2cfd, 0x3007, 0x3021,
+                0x3038, 0x3039, 0x303a, 0x3192,
+                0x3220, 0x3248, 0x3249, 0x324a,
+                0x324b, 0x324c, 0x324d, 0x324e,
+                0x324f, 0x3251, 0x3280, 0x32b1,
+                0x3405, 0x3483, 0x382a, 0x3b4d,
+                0x4e00, 0x4e03, 0x4e07, 0x4e09,
+                0x4e5d, 0x4e8c, 0x4e94, 0x4e96,
+                0x4ebf, 0x4ec0, 0x4edf, 0x4ee8,
+                0x4f0d, 0x4f70, 0x5104, 0x5146,
+                0x5169, 0x516b, 0x516d, 0x5341,
+                0x5343, 0x5344, 0x5345, 0x534c,
+                0x53c1, 0x53c2, 0x53c3, 0x53c4,
+                0x56db, 0x58f1, 0x58f9, 0x5e7a,
+                0x5efe, 0x5eff, 0x5f0c, 0x5f10,
+                0x62fe, 0x634c, 0x67d2, 0x6f06,
+                0x7396, 0x767e, 0x8086, 0x842c,
+                0x8cae, 0x8cb3, 0x8d30, 0x9621,
+                0x9646, 0x964c, 0x9678, 0x96f6,
+                0xa620, 0xa6e6, 0xa6ef, 0xa830,
+                0xa8d0, 0xa900, 0xa9d0, 0xa9f0,
+                0xaa50, 0xabf0, 0xf96b, 0xf973,
+                0xf978, 0xf9b2, 0xf9d1, 0xf9d3,
+                0xf9fd, 0xff10, 0xff21, 0xff41,
+            };
+
+            public static readonly uint[] Values = new uint[] {
+                0x2187, 0xffff5e37, 0x2188, 0xfffe9ae8, 0x2189, 0x2189, 0x249b, 0x245f,
+                0x2487, 0x2473, 0x249b, 0x2487, 0x24ea, 0x24ea, 0x24f4, 0x24e0,
+                0x24fe, 0x24f4, 0x24ff, 0x24ff, 0x277f, 0x2775, 0x2789, 0x277f,
+                0x2793, 0x2789, 0x2cfd, 0x0000, 0x3007, 0x3007, 0x3029, 0x3020,
+                0x3038, 0x302e, 0x3039, 0x3025, 0x303a, 0x301c, 0x3195, 0x3191,
+                0x3229, 0x321f, 0x3248, 0x323e, 0x3249, 0x3235, 0x324a, 0x322c,
+                0x324b, 0x3223, 0x324c, 0x321a, 0x324d, 0x3211, 0x324e, 0x3208,
+                0x324f, 0x31ff, 0x325f, 0x323c, 0x3289, 0x327f, 0x32bf, 0x328d,
+                0x3405, 0x3400, 0x3483, 0x3481, 0x382a, 0x3825, 0x3b4d, 0x3b46,
+                0x4e00, 0x4dff, 0x4e03, 0x4dfc, 0x4e07, 0x26f7, 0x4e09, 0x4e06,
+                0x4e5d, 0x4e54, 0x4e8c, 0x4e8a, 0x4e94, 0x4e8f, 0x4e96, 0x4e92,
+                0x4ebf, 0xfa0a6dbf, 0x4ec0, 0x4eb6, 0x4edf, 0x4af7, 0x4ee8, 0x4ee5,
+                0x4f0d, 0x4f08, 0x4f70, 0x4f0c, 0x5104, 0xfa0a7004, 0x5146, 0x0000,
+                0x5169, 0x5167, 0x516b, 0x5163, 0x516d, 0x5167, 0x5341, 0x5337,
+                0x5343, 0x4f5b, 0x5344, 0x5330, 0x5345, 0x5327, 0x534c, 0x5324,
+                0x53c1, 0x53be, 0x53c2, 0x53bf, 0x53c3, 0x53c0, 0x53c4, 0x53c1,
+                0x56db, 0x56d7, 0x58f1, 0x58f0, 0x58f9, 0x58f8, 0x5e7a, 0x5e79,
+                0x5efe, 0x5ef5, 0x5eff, 0x5eeb, 0x5f0e, 0x5f0b, 0x5f10, 0x5f0e,
+                0x62fe, 0x62f4, 0x634c, 0x6344, 0x67d2, 0x67cb, 0x6f06, 0x6eff,
+                0x7396, 0x738d, 0x767e, 0x761a, 0x8086, 0x8082, 0x842c, 0x5d1c,
+                0x8cae, 0x8cac, 0x8cb3, 0x8cb1, 0x8d30, 0x8d2e, 0x9621, 0x9239,
+                0x9646, 0x9640, 0x964c, 0x95e8, 0x9678, 0x9672, 0x96f6, 0x96f6,
+                0xa629, 0xa620, 0xa6ee, 0xa6e5, 0xa6ef, 0xa6ef, 0xa835, 0x0000,
+                0xa8d9, 0xa8d0, 0xa909, 0xa900, 0xa9d9, 0xa9d0, 0xa9f9, 0xa9f0,
+                0xaa59, 0xaa50, 0xabf9, 0xabf0, 0xf96b, 0xf968, 0xf973, 0xf969,
+                0xf978, 0xf976, 0xf9b2, 0xf9b2, 0xf9d1, 0xf9cb, 0xf9d3, 0xf9cd,
+                0xf9fd, 0xf9f3, 0xff19, 0xff10, 0xff3a, 0xff17, 0xff5a, 0xff37,
+            };
+        }
+
+        /// <summary>
+        /// Supplemental characters (surrogates) for numeric characters. Implements Unicode 10.0.
+        /// <para/>
+        /// This class is strictly to lazy-load the range of values if and only if they are required.
+        /// </summary>
+        private static class NumericSupplemental
+        {
+            public static readonly uint[] Keys = new uint[] {
+                0x00010107, 0x00010111, 0x00010112, 0x00010113,
+                0x00010114, 0x00010115, 0x00010116, 0x00010117,
+                0x00010118, 0x00010119, 0x0001011a, 0x0001011b,
+                0x0001011c, 0x0001011d, 0x0001011e, 0x0001011f,
+                0x00010120, 0x00010121, 0x00010122, 0x00010123,
+                0x00010124, 0x00010125, 0x00010126, 0x00010127,
+                0x00010128, 0x00010129, 0x0001012a, 0x0001012b,
+                0x0001012c, 0x0001012d, 0x0001012e, 0x0001012f,
+                0x00010130, 0x00010131, 0x00010132, 0x00010133,
+                0x00010140, 0x00010142, 0x00010143, 0x00010144,
+                0x00010145, 0x00010146, 0x00010147, 0x00010148,
+                0x00010149, 0x0001014a, 0x0001014b, 0x0001014c,
+                0x0001014d, 0x0001014e, 0x0001014f, 0x00010150,
+                0x00010151, 0x00010152, 0x00010153, 0x00010154,
+                0x00010155, 0x00010156, 0x00010157, 0x00010158,
+                0x00010159, 0x0001015a, 0x0001015c, 0x0001015d,
+                0x0001015e, 0x0001015f, 0x00010160, 0x00010161,
+                0x00010162, 0x00010163, 0x00010164, 0x00010165,
+                0x00010166, 0x00010167, 0x00010168, 0x00010169,
+                0x0001016a, 0x0001016b, 0x0001016c, 0x0001016d,
+                0x0001016e, 0x0001016f, 0x00010170, 0x00010171,
+                0x00010172, 0x00010173, 0x00010174, 0x00010175,
+                0x00010176, 0x00010177, 0x00010178, 0x0001018a,
+                0x0001018b, 0x000102e1, 0x000102eb, 0x000102ec,
+                0x000102ed, 0x000102ee, 0x000102ef, 0x000102f0,
+                0x000102f1, 0x000102f2, 0x000102f3, 0x000102f4,
+                0x000102f5, 0x000102f6, 0x000102f7, 0x000102f8,
+                0x000102f9, 0x000102fa, 0x000102fb, 0x00010320,
+                0x00010321, 0x00010322, 0x00010323, 0x00010341,
+                0x0001034a, 0x000103d1, 0x000103d3, 0x000103d4,
+                0x000103d5, 0x000104a0, 0x00010858, 0x0001085b,
+                0x0001085c, 0x0001085d, 0x0001085e, 0x0001085f,
+                0x00010879, 0x0001087e, 0x0001087f, 0x000108a7,
+                0x000108ab, 0x000108ad, 0x000108ae, 0x000108af,
+                0x000108fb, 0x000108fc, 0x000108fd, 0x000108fe,
+                0x000108ff, 0x00010916, 0x00010917, 0x00010918,
+                0x00010919, 0x0001091a, 0x000109bc, 0x000109c0,
+                0x000109ca, 0x000109cb, 0x000109cc, 0x000109cd,
+                0x000109ce, 0x000109cf, 0x000109d2, 0x000109d3,
+                0x000109d4, 0x000109d5, 0x000109d6, 0x000109d7,
+                0x000109d8, 0x000109d9, 0x000109da, 0x000109db,
+                0x000109dc, 0x000109dd, 0x000109de, 0x000109df,
+                0x000109e0, 0x000109e1, 0x000109e2, 0x000109e3,
+                0x000109e4, 0x000109e5, 0x000109e6, 0x000109e7,
+                0x000109e8, 0x000109e9, 0x000109ea, 0x000109eb,
+                0x000109ec, 0x000109ed, 0x000109ee, 0x000109ef,
+                0x000109f0, 0x000109f1, 0x000109f2, 0x000109f3,
+                0x000109f4, 0x000109f5, 0x000109f6, 0x000109f7,
+                0x000109f8, 0x000109f9, 0x000109fa, 0x000109fb,
+                0x000109fc, 0x000109fd, 0x000109fe, 0x000109ff,
+                0x00010a40, 0x00010a44, 0x00010a45, 0x00010a46,
+                0x00010a47, 0x00010a7d, 0x00010a7e, 0x00010a9d,
+                0x00010a9e, 0x00010a9f, 0x00010aeb, 0x00010aec,
+                0x00010aed, 0x00010aee, 0x00010aef, 0x00010b58,
+                0x00010b5c, 0x00010b5d, 0x00010b5e, 0x00010b5f,
+                0x00010b78, 0x00010b7c, 0x00010b7d, 0x00010b7e,
+                0x00010b7f, 0x00010ba9, 0x00010bad, 0x00010bae,
+                0x00010baf, 0x00010cfa, 0x00010cfb, 0x00010cfc,
+                0x00010cfd, 0x00010cfe, 0x00010cff, 0x00010e60,
+                0x00010e6a, 0x00010e6b, 0x00010e6c, 0x00010e6d,
+                0x00010e6e, 0x00010e6f, 0x00010e70, 0x00010e71,
+                0x00010e72, 0x00010e73, 0x00010e74, 0x00010e75,
+                0x00010e76, 0x00010e77, 0x00010e78, 0x00010e79,
+                0x00010e7a, 0x00010e7b, 0x00010e7c, 0x00010e7d,
+                0x00010e7e, 0x00011052, 0x0001105c, 0x0001105d,
+                0x0001105e, 0x0001105f, 0x00011060, 0x00011061,
+                0x00011062, 0x00011063, 0x00011064, 0x00011065,
+                0x00011066, 0x000110f0, 0x00011136, 0x000111d0,
+                0x000111e1, 0x000111eb, 0x000111ec, 0x000111ed,
+                0x000111ee, 0x000111ef, 0x000111f0, 0x000111f1,
+                0x000111f2, 0x000111f3, 0x000111f4, 0x000112f0,
+                0x00011450, 0x000114d0, 0x00011650, 0x000116c0,
+                0x00011730, 0x0001173b, 0x000118e0, 0x000118eb,
+                0x000118ec, 0x000118ed, 0x000118ee, 0x000118ef,
+                0x000118f0, 0x000118f1, 0x000118f2, 0x00011c50,
+                0x00011c5a, 0x00011c64, 0x00011c65, 0x00011c66,
+                0x00011c67, 0x00011c68, 0x00011c69, 0x00011c6a,
+                0x00011c6b, 0x00011c6c, 0x00011d50, 0x00012400,
+                0x00012408, 0x0001240f, 0x00012415, 0x0001241e,
+                0x00012423, 0x00012425, 0x0001242c, 0x0001242f,
+                0x00012432, 0x00012433, 0x00012434, 0x00012437,
+                0x0001243a, 0x0001243b, 0x0001243d, 0x0001243e,
+                0x0001243f, 0x00012440, 0x00012442, 0x00012443,
+                0x00012445, 0x00012447, 0x00012448, 0x00012449,
+                0x0001244a, 0x0001244f, 0x00012453, 0x00012455,
+                0x00012456, 0x00012458, 0x0001245a, 0x0001245b,
+                0x0001245c, 0x0001245d, 0x0001245e, 0x0001245f,
+                0x00012460, 0x00012461, 0x00012462, 0x00012463,
+                0x00012464, 0x00012465, 0x00012466, 0x00012467,
+                0x00012468, 0x00012469, 0x00016a60, 0x00016b50,
+                0x00016b5b, 0x00016b5c, 0x00016b5d, 0x00016b5e,
+                0x00016b5f, 0x00016b60, 0x00016b61, 0x0001d360,
+                0x0001d36a, 0x0001d36b, 0x0001d36c, 0x0001d36d,
+                0x0001d36e, 0x0001d36f, 0x0001d370, 0x0001d371,
+                0x0001d7ce, 0x0001d7d8, 0x0001d7e2, 0x0001d7ec,
+                0x0001d7f6, 0x0001e8c7, 0x0001e950, 0x0001f100,
+                0x0001f101, 0x0001f10b, 0x0001f10c, 0x00020001,
+                0x00020064, 0x000200e2, 0x00020121, 0x0002092a,
+                0x00020983, 0x0002098c, 0x0002099c, 0x00020aea,
+                0x00020afd, 0x00020b19, 0x00022390, 0x00022998,
+                0x00023b1b, 0x0002626d, 0x0002f890,
+            };
+
+            public static readonly uint[] Values = new uint[] {
+                0x00010110, 0x00010106, 0x00010111, 0x000100fd, 0x00010112, 0x000100f4, 0x00010113, 0x000100eb,
+                0x00010114, 0x000100e2, 0x00010115, 0x000100d9, 0x00010116, 0x000100d0, 0x00010117, 0x000100c7,
+                0x00010118, 0x000100be, 0x00010119, 0x000100b5, 0x0001011a, 0x00010052, 0x0001011b, 0x0000ffef,
+                0x0001011c, 0x0000ff8c, 0x0001011d, 0x0000ff29, 0x0001011e, 0x0000fec6, 0x0001011f, 0x0000fe63,
+                0x00010120, 0x0000fe00, 0x00010121, 0x0000fd9d, 0x00010122, 0x0000fd3a, 0x00010123, 0x0000f953,
+                0x00010124, 0x0000f56c, 0x00010125, 0x0000f185, 0x00010126, 0x0000ed9e, 0x00010127, 0x0000e9b7,
+                0x00010128, 0x0000e5d0, 0x00010129, 0x0000e1e9, 0x0001012a, 0x0000de02, 0x0001012b, 0x0000da1b,
+                0x0001012c, 0x0000b30c, 0x0001012d, 0x00008bfd, 0x0001012e, 0x000064ee, 0x0001012f, 0x00003ddf,
+                0x00010130, 0x000016d0, 0x00010131, 0xffffefc1, 0x00010132, 0xffffc8b2, 0x00010133, 0xffffa1a3,
+                0x00010141, 0x00000000, 0x00010142, 0x00010141, 0x00010143, 0x0001013e, 0x00010144, 0x00010112,
+                0x00010145, 0x0000ff51, 0x00010146, 0x0000edbe, 0x00010147, 0x00003df7, 0x00010148, 0x00010143,
+                0x00010149, 0x0001013f, 0x0001014a, 0x00010118, 0x0001014b, 0x000100e7, 0x0001014c, 0x0000ff58,
+                0x0001014d, 0x0000fd65, 0x0001014e, 0x0000edc6, 0x0001014f, 0x0001014a, 0x00010150, 0x00010146,
+                0x00010151, 0x0001011f, 0x00010152, 0x000100ee, 0x00010153, 0x0000ff5f, 0x00010154, 0x0000fd6c,
+                0x00010155, 0x0000da45, 0x00010156, 0x00003e06, 0x00010157, 0x0001014d, 0x00010158, 0x00010157,
+                0x00010159, 0x00010158, 0x0001015b, 0x00010159, 0x0001015c, 0x0001015a, 0x0001015d, 0x0001015b,
+                0x0001015e, 0x0001015c, 0x0001015f, 0x0001015a, 0x00010160, 0x00010156, 0x00010161, 0x00010157,
+                0x00010162, 0x00010158, 0x00010163, 0x00010159, 0x00010164, 0x0001015a, 0x00010165, 0x00010147,
+                0x00010166, 0x00010134, 0x00010167, 0x00010135, 0x00010168, 0x00010136, 0x00010169, 0x00010137,
+                0x0001016a, 0x00010106, 0x0001016b, 0x0001003f, 0x0001016c, 0x0000ff78, 0x0001016d, 0x0000ff79,
+                0x0001016e, 0x0000ff7a, 0x0001016f, 0x0000ff7b, 0x00010170, 0x0000ff7c, 0x00010171, 0x0000fd89,
+                0x00010172, 0x0000edea, 0x00010173, 0x0001016e, 0x00010174, 0x00010142, 0x00010175, 0x00000000,
+                0x00010176, 0x00000000, 0x00010177, 0x00000000, 0x00010178, 0x00000000, 0x0001018a, 0x0001018a,
+                0x0001018b, 0x00000000, 0x000102ea, 0x000102e0, 0x000102eb, 0x000102d7, 0x000102ec, 0x000102ce,
+                0x000102ed, 0x000102c5, 0x000102ee, 0x000102bc, 0x000102ef, 0x000102b3, 0x000102f0, 0x000102aa,
+                0x000102f1, 0x000102a1, 0x000102f2, 0x00010298, 0x000102f3, 0x0001028f, 0x000102f4, 0x0001022c,
+                0x000102f5, 0x000101c9, 0x000102f6, 0x00010166, 0x000102f7, 0x00010103, 0x000102f8, 0x000100a0,
+                0x000102f9, 0x0001003d, 0x000102fa, 0x0000ffda, 0x000102fb, 0x0000ff77, 0x00010320, 0x0001031f,
+                0x00010321, 0x0001031c, 0x00010322, 0x00010318, 0x00010323, 0x000102f1, 0x00010341, 0x000102e7,
+                0x0001034a, 0x0000ffc6, 0x000103d2, 0x000103d0, 0x000103d3, 0x000103c9, 0x000103d4, 0x000103c0,
+                0x000103d5, 0x00010371, 0x000104a9, 0x000104a0, 0x0001085a, 0x00010857, 0x0001085b, 0x00010851,
+                0x0001085c, 0x00010848, 0x0001085d, 0x000107f9, 0x0001085e, 0x00010476, 0x0001085f, 0x0000e14f,
+                0x0001087d, 0x00010878, 0x0001087e, 0x00010874, 0x0001087f, 0x0001086b, 0x000108aa, 0x000108a6,
+                0x000108ac, 0x000108a7, 0x000108ad, 0x000108a3, 0x000108ae, 0x0001089a, 0x000108af, 0x0001084b,
+                0x000108fb, 0x000108fa, 0x000108fc, 0x000108f7, 0x000108fd, 0x000108f3, 0x000108fe, 0x000108ea,
+                0x000108ff, 0x0001089b, 0x00010916, 0x00010915, 0x00010917, 0x0001090d, 0x00010918, 0x00010904,
+                0x00010919, 0x000108b5, 0x0001091b, 0x00010918, 0x000109bd, 0x00000000, 0x000109c9, 0x000109bf,
+                0x000109ca, 0x000109b6, 0x000109cb, 0x000109ad, 0x000109cc, 0x000109a4, 0x000109cd, 0x0001099b,
+                0x000109ce, 0x00010992, 0x000109cf, 0x00010989, 0x000109d2, 0x0001096e, 0x000109d3, 0x0001090b,
+                0x000109d4, 0x000108a8, 0x000109d5, 0x00010845, 0x000109d6, 0x000107e2, 0x000109d7, 0x0001077f,
+                0x000109d8, 0x0001071c, 0x000109d9, 0x000106b9, 0x000109da, 0x00010656, 0x000109db, 0x000105f3,
+                0x000109dc, 0x0001020c, 0x000109dd, 0x0000fe25, 0x000109de, 0x0000fa3e, 0x000109df, 0x0000f657,
+                0x000109e0, 0x0000f270, 0x000109e1, 0x0000ee89, 0x000109e2, 0x0000eaa2, 0x000109e3, 0x0000e6bb,
+                0x000109e4, 0x0000e2d4, 0x000109e5, 0x0000bbc5, 0x000109e6, 0x000094b6, 0x000109e7, 0x00006da7,
+                0x000109e8, 0x00004698, 0x000109e9, 0x00001f89, 0x000109ea, 0xfffff87a, 0x000109eb, 0xffffd16b,
+                0x000109ec, 0xffffaa5c, 0x000109ed, 0xffff834d, 0x000109ee, 0xfffdfcae, 0x000109ef, 0xfffc760f,
+                0x000109f0, 0xfffaef70, 0x000109f1, 0xfff968d1, 0x000109f2, 0xfff7e232, 0x000109f3, 0xfff65b93,
+                0x000109f4, 0xfff4d4f4, 0x000109f5, 0xfff34e55, 0x000109f6, 0x00000000, 0x000109f7, 0x00000000,
+                0x000109f8, 0x00000000, 0x000109f9, 0x00000000, 0x000109fa, 0x00000000, 0x000109fb, 0x00000000,
+                0x000109fc, 0x00000000, 0x000109fd, 0x00000000, 0x000109fe, 0x00000000, 0x000109ff, 0x00000000,
+                0x00010a43, 0x00010a3f, 0x00010a44, 0x00010a3a, 0x00010a45, 0x00010a31, 0x00010a46, 0x000109e2,
+                0x00010a47, 0x0001065f, 0x00010a7d, 0x00010a7c, 0x00010a7e, 0x00010a4c, 0x00010a9d, 0x00010a9c,
+                0x00010a9e, 0x00010a94, 0x00010a9f, 0x00010a8b, 0x00010aeb, 0x00010aea, 0x00010aec, 0x00010ae7,
+                0x00010aed, 0x00010ae3, 0x00010aee, 0x00010ada, 0x00010aef, 0x00010a8b, 0x00010b5b, 0x00010b57,
+                0x00010b5c, 0x00010b52, 0x00010b5d, 0x00010b49, 0x00010b5e, 0x00010afa, 0x00010b5f, 0x00010777,
+                0x00010b7b, 0x00010b77, 0x00010b7c, 0x00010b72, 0x00010b7d, 0x00010b69, 0x00010b7e, 0x00010b1a,
+                0x00010b7f, 0x00010797, 0x00010bac, 0x00010ba8, 0x00010bad, 0x00010ba3, 0x00010bae, 0x00010b9a,
+                0x00010baf, 0x00010b4b, 0x00010cfa, 0x00010cf9, 0x00010cfb, 0x00010cf6, 0x00010cfc, 0x00010cf2,
+                0x00010cfd, 0x00010ccb, 0x00010cfe, 0x00010c9a, 0x00010cff, 0x00010917, 0x00010e69, 0x00010e5f,
+                0x00010e6a, 0x00010e56, 0x00010e6b, 0x00010e4d, 0x00010e6c, 0x00010e44, 0x00010e6d, 0x00010e3b,
+                0x00010e6e, 0x00010e32, 0x00010e6f, 0x00010e29, 0x00010e70, 0x00010e20, 0x00010e71, 0x00010e17,
+                0x00010e72, 0x00010e0e, 0x00010e73, 0x00010dab, 0x00010e74, 0x00010d48, 0x00010e75, 0x00010ce5,
+                0x00010e76, 0x00010c82, 0x00010e77, 0x00010c1f, 0x00010e78, 0x00010bbc, 0x00010e79, 0x00010b59,
+                0x00010e7a, 0x00010af6, 0x00010e7b, 0x00000000, 0x00010e7c, 0x00000000, 0x00010e7d, 0x00000000,
+                0x00010e7e, 0x00000000, 0x0001105b, 0x00011051, 0x0001105c, 0x00011048, 0x0001105d, 0x0001103f,
+                0x0001105e, 0x00011036, 0x0001105f, 0x0001102d, 0x00011060, 0x00011024, 0x00011061, 0x0001101b,
+                0x00011062, 0x00011012, 0x00011063, 0x00011009, 0x00011064, 0x00011000, 0x00011065, 0x00010c7d,
+                0x0001106f, 0x00011066, 0x000110f9, 0x000110f0, 0x0001113f, 0x00011136, 0x000111d9, 0x000111d0,
+                0x000111ea, 0x000111e0, 0x000111eb, 0x000111d7, 0x000111ec, 0x000111ce, 0x000111ed, 0x000111c5,
+                0x000111ee, 0x000111bc, 0x000111ef, 0x000111b3, 0x000111f0, 0x000111aa, 0x000111f1, 0x000111a1,
+                0x000111f2, 0x00011198, 0x000111f3, 0x0001118f, 0x000111f4, 0x00010e0c, 0x000112f9, 0x000112f0,
+                0x00011459, 0x00011450, 0x000114d9, 0x000114d0, 0x00011659, 0x00011650, 0x000116c9, 0x000116c0,
+                0x0001173a, 0x00011730, 0x0001173b, 0x00011727, 0x000118ea, 0x000118e0, 0x000118eb, 0x000118d7,
+                0x000118ec, 0x000118ce, 0x000118ed, 0x000118c5, 0x000118ee, 0x000118bc, 0x000118ef, 0x000118b3,
+                0x000118f0, 0x000118aa, 0x000118f1, 0x000118a1, 0x000118f2, 0x00011898, 0x00011c59, 0x00011c50,
+                0x00011c63, 0x00011c59, 0x00011c64, 0x00011c50, 0x00011c65, 0x00011c47, 0x00011c66, 0x00011c3e,
+                0x00011c67, 0x00011c35, 0x00011c68, 0x00011c2c, 0x00011c69, 0x00011c23, 0x00011c6a, 0x00011c1a,
+                0x00011c6b, 0x00011c11, 0x00011c6c, 0x00011c08, 0x00011d59, 0x00011d50, 0x00012407, 0x000123fe,
+                0x0001240e, 0x00012405, 0x00012414, 0x0001240b, 0x0001241d, 0x00012414, 0x00012422, 0x0001241d,
+                0x00012424, 0x00012421, 0x0001242b, 0x00012422, 0x0001242e, 0x0001242b, 0x00012431, 0x0001242c,
+                0x00012432, 0xfffdd872, 0x00012433, 0xfffa8cb3, 0x00012436, 0x00012433, 0x00012439, 0x00012434,
+                0x0001243a, 0x00012437, 0x0001243c, 0x00012438, 0x0001243d, 0x00012439, 0x0001243e, 0x0001243a,
+                0x0001243f, 0x0001243b, 0x00012441, 0x0001243a, 0x00012442, 0x0001243b, 0x00012444, 0x0001243c,
+                0x00012446, 0x0001243d, 0x00012447, 0x0001243e, 0x00012448, 0x0001243f, 0x00012449, 0x00012440,
+                0x0001244e, 0x00012448, 0x00012452, 0x0001244e, 0x00012454, 0x0001244f, 0x00012455, 0x00012450,
+                0x00012457, 0x00012454, 0x00012459, 0x00012457, 0x0001245a, 0x00000000, 0x0001245b, 0x00000000,
+                0x0001245c, 0x00000000, 0x0001245d, 0x00000000, 0x0001245e, 0x00000000, 0x0001245f, 0x00000000,
+                0x00012460, 0x00000000, 0x00012461, 0x00000000, 0x00012462, 0x00000000, 0x00012463, 0x00000000,
+                0x00012464, 0x00000000, 0x00012465, 0x00000000, 0x00012466, 0x00000000, 0x00012467, 0x0001243f,
+                0x00012468, 0x00012436, 0x0001246e, 0x00012465, 0x00016a69, 0x00016a60, 0x00016b59, 0x00016b50,
+                0x00016b5b, 0x00016b51, 0x00016b5c, 0x00016af8, 0x00016b5d, 0x0001444d, 0x00016b5e, 0xfff2291e,
+                0x00016b5f, 0xfa0b8a5f, 0x00016b60, 0x00000000, 0x00016b61, 0x00000000, 0x0001d369, 0x0001d35f,
+                0x0001d36a, 0x0001d356, 0x0001d36b, 0x0001d34d, 0x0001d36c, 0x0001d344, 0x0001d36d, 0x0001d33b,
+                0x0001d36e, 0x0001d332, 0x0001d36f, 0x0001d329, 0x0001d370, 0x0001d320, 0x0001d371, 0x0001d317,
+                0x0001d7d7, 0x0001d7ce, 0x0001d7e1, 0x0001d7d8, 0x0001d7eb, 0x0001d7e2, 0x0001d7f5, 0x0001d7ec,
+                0x0001d7ff, 0x0001d7f6, 0x0001e8cf, 0x0001e8c6, 0x0001e959, 0x0001e950, 0x0001f100, 0x0001f100,
+                0x0001f10a, 0x0001f101, 0x0001f10b, 0x0001f10b, 0x0001f10c, 0x0001f10c, 0x00020001, 0x0001fffa,
+                0x00020064, 0x00020060, 0x000200e2, 0x000200de, 0x00020121, 0x0002011c, 0x0002092a, 0x00020929,
+                0x00020983, 0x00020965, 0x0002098c, 0x00020964, 0x0002099c, 0x00020974, 0x00020aea, 0x00020ae4,
+                0x00020afd, 0x00020afa, 0x00020b19, 0x00020b16, 0x00022390, 0x0002238e, 0x00022998, 0x00022995,
+                0x00023b1b, 0x00023b18, 0x0002626d, 0x00026269, 0x0002f890, 0x0002f887,
+            };
+        }
 
         /// <summary>
         /// Indicates whether <paramref name="codePoint"/> is a valid Unicode code point.
@@ -1279,25 +1597,18 @@ namespace J2N
         /// </returns>
         public static int Digit(char c, int radix)
         {
-            int result = -1;
+            int result;
             if (radix >= MinRadix && radix <= MaxRadix)
             {
+                // Optimized for ASCII
                 if (c < 128)
                 {
-                    // Optimized for ASCII
-                    if ('0' <= c && c <= '9')
-                    {
-                        result = c - '0';
-                    }
-                    else if ('a' <= c && c <= 'z')
-                    {
-                        result = c - ('a' - 10);
-                    }
-                    else if ('A' <= c && c <= 'Z')
-                    {
-                        result = c - ('A' - 10);
-                    }
+                    result = ASCIIDigits[c];
                     return result < radix ? result : -1;
+                }
+                if (c < 256)
+                {
+                    return -1;
                 }
                 result = BinarySearchRange(digitKeys, c);
                 if (result >= 0 && c <= digitValues[result * 2])
@@ -1327,25 +1638,18 @@ namespace J2N
         /// </returns>
         public static int Digit(int codePoint, int radix)
         {
-            int result = -1;
+            int result;
             if (radix >= MinRadix && radix <= MaxRadix)
             {
+                // Optimized for ASCII
                 if (codePoint < 128)
                 {
-                    // Optimized for ASCII
-                    if ('0' <= codePoint && codePoint <= '9')
-                    {
-                        result = codePoint - '0';
-                    }
-                    else if ('a' <= codePoint && codePoint <= 'z')
-                    {
-                        result = codePoint - ('a' - 10);
-                    }
-                    else if ('A' <= codePoint && codePoint <= 'Z')
-                    {
-                        result = codePoint - ('A' - 10);
-                    }
+                    result = ASCIIDigits[codePoint];
                     return result < radix ? result : -1;
+                }
+                if (codePoint < 256)
+                {
+                    return -1;
                 }
                 int value = -1;
                 if (codePoint < MinSupplementaryCodePoint)
@@ -1379,6 +1683,9 @@ namespace J2N
         /// <param name="data">The String to search.</param>
         /// <param name="c">The character to search for.</param>
         /// <returns>The nearest index.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static int BinarySearchRange(string data, char c)
         {
             char value = (char)0;
@@ -1403,9 +1710,39 @@ namespace J2N
         /// <param name="data">The String to search.</param>
         /// <param name="codePoint">The character to search for.</param>
         /// <returns>The nearest index.</returns>
-        private static int BinarySearchRange(int[] data, int codePoint)
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static int BinarySearchRange(uint[] data, int codePoint)
         {
-            int value = 0;
+            uint value = 0;
+            int low = 0, mid = -1, high = data.Length - 1;
+            while (low <= high)
+            {
+                mid = (low + high) >> 1;
+                value = data[mid];
+                if (codePoint > value)
+                    low = mid + 1;
+                else if (codePoint == value)
+                    return mid;
+                else
+                    high = mid - 1;
+            }
+            return mid - (codePoint < value ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Search the sorted characters in the string and return the nearest index.
+        /// </summary>
+        /// <param name="data">The String to search.</param>
+        /// <param name="codePoint">The character to search for.</param>
+        /// <returns>The nearest index.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static int BinarySearchRange(ushort[] data, int codePoint)
+        {
+            ushort value = 0;
             int low = 0, mid = -1, high = data.Length - 1;
             while (low <= high)
             {
@@ -1463,42 +1800,107 @@ namespace J2N
         /// -2 if the numeric value can not be represented with an integer.</returns>
         public static int GetNumericValue(char c)
         {
+            // Optimized for ASCII
             if (c < 128)
             {
-                // Optimized for ASCII
-                if (c >= '0' && c <= '9')
-                {
-                    return c - '0';
-                }
-                if (c >= 'a' && c <= 'z')
-                {
-                    return c - ('a' - 10);
-                }
-                if (c >= 'A' && c <= 'Z')
-                {
-                    return c - ('A' - 10);
-                }
-                return -1;
+                return ASCIIDigits[c];
             }
-            int result = BinarySearchRange(numericKeys, c);
-            if (result >= 0 && c <= numericValues[result * 2])
+            int result;
+            if (c < 0x2187) // Normal
             {
-                char difference = numericValues[result * 2 + 1];
-                if (difference == 0)
+                result = BinarySearchRange(numericKeys, c);
+                if (result >= 0 && c <= numericValues[result * 2])
                 {
-                    return -2;
+                    char difference = numericValues[result * 2 + 1];
+                    if (difference == 0)
+                    {
+                        return -2;
+                    }
+                    // Value is always positive, must be negative value
+                    if (difference > c)
+                    {
+                        return c - (short)difference;
+                    }
+                    return c - difference;
                 }
-                // Value is always positive, must be negative value
-                if (difference > c)
+            }
+            else //if (c < MinSupplementaryCodePoint) // Intermediate
+            {
+                result = BinarySearchRange(NumericIntermediate.Keys, c);
+                if (result >= 0 && c <= NumericIntermediate.Values[result * 2])
                 {
-                    return c - (short)difference;
+                    uint difference = NumericIntermediate.Values[result * 2 + 1];
+                    if (difference == 0)
+                    {
+                        return -2;
+                    }
+                    return (int)(c - difference);
                 }
-                return c - difference;
             }
             return -1;
         }
 
-        // TODO: GetNumericValue(int)
+        /// <summary>
+        /// Gets the numeric value of the specified Unicode code point.
+        /// </summary>
+        /// <param name="codePoint">The Unicode character to get the numeric value of.</param>
+        /// <returns>A non-negative numeric integer value if a numeric value for
+        /// <paramref name="codePoint"/> exists, -1 if there is no numeric value for <paramref name="codePoint"/>,
+        /// -2 if the numeric value can not be represented with an integer.</returns>
+        public static int GetNumericValue(int codePoint)
+        {
+            // Optimized for ASCII
+            if (codePoint < 128)
+            {
+                return ASCIIDigits[codePoint];
+            }
+            int result;
+            if (codePoint < 0x2187) // Normal
+            {
+                result = BinarySearchRange(numericKeys, (char)codePoint);
+                if (result >= 0 && codePoint <= numericValues[result * 2])
+                {
+                    char difference = numericValues[result * 2 + 1];
+                    if (difference == 0)
+                    {
+                        return -2;
+                    }
+                    // Value is always positive, must be negative value
+                    if (difference > codePoint)
+                    {
+                        return codePoint - (short)difference;
+                    }
+                    return codePoint - difference;
+                }
+            }
+            else if (codePoint < MinSupplementaryCodePoint) // Intermediate (difference variable of type char not big enough to support all subtraction)
+            {
+                result = BinarySearchRange(NumericIntermediate.Keys, codePoint);
+                if (result >= 0 && codePoint <= NumericIntermediate.Values[result * 2])
+                {
+                    uint difference = NumericIntermediate.Values[result * 2 + 1];
+                    if (difference == 0)
+                    {
+                        return -2;
+                    }
+                    return (int)(codePoint - difference);
+                }
+            }
+            else // Supplementary
+            {
+                result = BinarySearchRange(NumericSupplemental.Keys, codePoint);
+                if (result >= 0 && codePoint <= NumericSupplemental.Values[result * 2])
+                {
+                    uint difference = NumericSupplemental.Values[result * 2 + 1];
+                    if (difference == 0)
+                    {
+                        return -2;
+                    }
+                    return (int)(codePoint - difference);
+                }
+            }
+            return -1;
+        }
 
         /// <summary>
         /// Gets the general Unicode category of the specified character.
@@ -1560,7 +1962,7 @@ namespace J2N
         /// not <see cref="UnicodeCategory.OtherNotAssigned"/>; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsDefined(char c)
         {
             return GetType(c) != UnicodeCategory.OtherNotAssigned;
@@ -1575,7 +1977,7 @@ namespace J2N
         /// not <see cref="UnicodeCategory.OtherNotAssigned"/>; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsDefined(int codePoint)
         {
             return GetType(codePoint) != UnicodeCategory.OtherNotAssigned;
@@ -1588,7 +1990,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is a digit; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsDigit(char c)
         {
             return char.IsDigit(c);
@@ -1621,7 +2023,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is ignorable; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsIdentifierIgnorable(char c)
         {
             return (c >= 0 && c <= 8) || (c >= 0xe && c <= 0x1b)
@@ -1636,7 +2038,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="codePoint"/> is ignorable; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsIdentifierIgnorable(int codePoint)
         {
             return (codePoint >= 0 && codePoint <= 8) || (codePoint >= 0xe && codePoint <= 0x1b)
@@ -1650,7 +2052,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is an ISO control character; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsISOControl(char c)
         {
             return (c >= 0 && c <= 0x1f) || (c >= 0x7f && c <= 0x9f);
@@ -1663,7 +2065,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="codePoint"/> is an ISO control character; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsISOControl(int codePoint)
         {
             return (codePoint >= 0 && codePoint <= 0x1f) || (codePoint >= 0x7f && codePoint <= 0x9f);
@@ -1687,7 +2089,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is a letter; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsLetter(char c)
         {
             return char.IsLetter(c);
@@ -1720,7 +2122,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is a letter or a digit; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsLetterOrDigit(char c)
         {
             return char.IsLetterOrDigit(c);
@@ -1754,7 +2156,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is a lower case letter; <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsLower(char c)
         {
             return char.IsLower(c);
@@ -1963,7 +2365,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is an upper case letter, <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsUpper(char c)
         {
             return char.IsUpper(c);
@@ -1997,7 +2399,7 @@ namespace J2N
         /// <returns><c>true</c> if <paramref name="c"/> is a whitespace character, <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool IsWhiteSpace(char c)
         {
             return char.IsWhiteSpace(c);
@@ -2030,7 +2432,7 @@ namespace J2N
         /// <returns>The character with reordered bytes.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static char ReverseBytes(char c)
         {
             return (char)((c << 8) | (c >> 8));
@@ -2049,7 +2451,7 @@ namespace J2N
         /// <exception cref="ArgumentException">If the <paramref name="codePoint"/> is invalid.</exception>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static int ToLower(int codePoint) => ToLower(codePoint, CultureInfo.CurrentCulture);
 
         /// <summary>
@@ -2087,7 +2489,7 @@ namespace J2N
         /// <exception cref="ArgumentException">If the <paramref name="codePoint"/> is invalid.</exception>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static int ToUpper(int codePoint) => ToUpper(codePoint, CultureInfo.CurrentCulture);
 
         /// <summary>

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -96,10 +96,49 @@ namespace J2N
         /// </summary>
         public const int MaxCodePoint = 0x10FFFF;
 
-        private const string digitKeys = "0Aa\u0660\u06f0\u0966\u09e6\u0a66\u0ae6\u0b66\u0be7\u0c66\u0ce6\u0d66\u0e50\u0ed0\u0f20\u1040\u1369\u17e0\u1810\uff10\uff21\uff41";
+        // Unicode 10.0
+        private const string digitKeys = "\u0660\u06f0\u07c0\u0966\u09e6\u0a66\u0ae6\u0b66\u0be6\u0c66\u0ce6\u0d66\u0de6\u0e50\u0ed0\u0f20\u1040\u1090\u17e0\u1810\u1946\u19d0\u1a80\u1a90\u1b50\u1bb0\u1c40\u1c50\ua620\ua8d0\ua900\ua9d0\ua9f0\uaa50\uabf0\uff10\uff21\uff41";
 
-        private static readonly char[] digitValues = "90Z7zW\u0669\u0660\u06f9\u06f0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1371\u1368\u17e9\u17e0\u1819\u1810\uff19\uff10\uff3a\uff17\uff5a\uff37"
-            .ToCharArray();
+        // J2N NOTE: This is the string that came directly out of UnicodeSet. For some reason the last 2 ranges didn't match the original Harmony values.
+        // However, reverting back to those Harmony values makes the tests pass when compared against ICU4N.
+        // There were also Ethiopian digits (\u1368 - \u1371) in Harmony that don't conform to Unicode and the behavior both of ICU4N
+        // and the JDK do not recognize them as digits. Unlike recognizable digits, they are categorized as UUnicodeCategory.OtherNumber.
+        //private static readonly char[] digitValues = "\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1099\u1090\u17e9\u17e0\u1819\u1810\u194f\u1946\u19d9\u19d0\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\ua629\ua620\ua8d9\ua8d0\ua909\ua900\ua9d9\ua9d0\ua9f9\ua9f0\uaa59\uaa50\uabf9\uabf0\uff19\uff10\uff3a\uff21\uff5a\uff41".ToCharArray();
+        private static readonly char[] digitValues = "\u0669\u0660\u06f9\u06f0\u07c9\u07c0\u096f\u0966\u09ef\u09e6\u0a6f\u0a66\u0aef\u0ae6\u0b6f\u0b66\u0bef\u0be6\u0c6f\u0c66\u0cef\u0ce6\u0d6f\u0d66\u0def\u0de6\u0e59\u0e50\u0ed9\u0ed0\u0f29\u0f20\u1049\u1040\u1099\u1090\u17e9\u17e0\u1819\u1810\u194f\u1946\u19d9\u19d0\u1a89\u1a80\u1a99\u1a90\u1b59\u1b50\u1bb9\u1bb0\u1c49\u1c40\u1c59\u1c50\ua629\ua620\ua8d9\ua8d0\ua909\ua900\ua9d9\ua9d0\ua9f9\ua9f0\uaa59\uaa50\uabf9\uabf0\uff19\uff10\uff3a\uff17\uff5a\uff37".ToCharArray();
+
+        /// <summary>
+        /// Supplemental characters (surrogates) for digits. Implements Unicode 10.0.
+        /// </summary>
+        private static class DigitSupplemental
+        {
+            public static readonly int[] Keys = new int[] {
+                0x000104a0, 0x00011066, 0x000110f0, 0x00011136, 0x000111d0, 0x000112f0, 0x00011450, 0x000114d0,
+                0x00011650, 0x000116c0, 0x00011730, 0x000118e0, 0x00011c50, 0x00011d50, 0x00016a60, 0x00016b50,
+
+                // J2N: The 5 ranges here didn't come directly out of the UnicodeSet class, but these
+                // were one contiguous range. However, they comprise 5 different numeric sets, so they were
+                // broken apart manually.
+                0x0001d7ce, 0x0001d7d8, 0x0001d7e2, 0x0001d7ec, 0x0001d7f6, 
+
+                0x0001e950
+            };
+
+            public static readonly int[] Values = new int[] {
+                0x000104a9, 0x000104a0, 0x0001106f, 0x00011066, 0x000110f9, 0x000110f0, 0x0001113f, 0x00011136,
+                0x000111d9, 0x000111d0, 0x000112f9, 0x000112f0, 0x00011459, 0x00011450, 0x000114d9, 0x000114d0,
+                0x00011659, 0x00011650, 0x000116c9, 0x000116c0, 0x00011739, 0x00011730, 0x000118e9, 0x000118e0,
+                0x00011c59, 0x00011c50, 0x00011d59, 0x00011d50, 0x00016a69, 0x00016a60, 0x00016b59, 0x00016b50,
+
+                // J2N: The 5 ranges here didn't come directly out of the UnicodeSet class, but these
+                // were one contiguous range. However, they comprise 5 different numeric sets, so they were
+                // broken apart manually.
+                //0x0001d7ff, 0x0001d7ce,
+                0x0001d7d7, 0x0001d7ce, 0x0001d7e1, 0x0001d7d8, 0x0001d7eb, 0x0001d7e2, 0x0001d7f5, 0x0001d7ec,
+                0x0001d7ff, 0x0001d7f6,
+
+                0x0001e959, 0x0001e950
+            };
+        }
 
         // Unicode 3.0.0 (NOT the same as Unicode 3.0.1)
         private const string numericKeys = "0Aa\u00b2\u00b9\u00bc\u0660\u06f0\u0966\u09e6\u09f4\u09f9\u0a66\u0ae6\u0b66\u0be7\u0bf1\u0bf2\u0c66\u0ce6\u0d66\u0e50\u0ed0\u0f20\u1040\u1369\u1373\u1374\u1375\u1376\u1377\u1378\u1379\u137a\u137b\u137c\u16ee\u17e0\u1810\u2070\u2074\u2080\u2153\u215f\u2160\u216c\u216d\u216e\u216f\u2170\u217c\u217d\u217e\u217f\u2180\u2181\u2182\u2460\u2474\u2488\u24ea\u2776\u2780\u278a\u3007\u3021\u3038\u3039\u303a\u3280\uff10\uff21\uff41";
@@ -1234,8 +1273,9 @@ namespace J2N
         /// <param name="c">The character to determine the value of.</param>
         /// <param name="radix">The radix.</param>
         /// <returns>
-        /// The value of <paramref name="c"/> in <paramref name="radix"/> if <paramref name="radix"/> lies
-        /// between <see cref="MinRadix"/> and <see cref="MaxRadix"/>; -1 otherwise.
+        /// The numeric value of <paramref name="c"/> in the specified <paramref name="radix"/>. Returns -1
+        /// if the <paramref name="radix"/> lies between <see cref="MinRadix"/> and <see cref="MaxRadix"/> or
+        /// if <paramref name="c"/> is not a decimal digit.
         /// </returns>
         public static int Digit(char c, int radix)
         {
@@ -1273,7 +1313,65 @@ namespace J2N
             return -1;
         }
 
-        // TODO: Digit(int, int)
+        /// <summary>
+        /// Convenience method to determine the value of the specified character
+        /// <paramref name="codePoint"/> in the supplied radix. The value of <paramref name="radix"/> must be
+        /// between <see cref="MinRadix"/> and <see cref="MaxRadix"/>.
+        /// </summary>
+        /// <param name="codePoint">The character to determine the value of.</param>
+        /// <param name="radix">The radix.</param>
+        /// <returns>
+        /// The numeric value of <paramref name="codePoint"/> in the specified <paramref name="radix"/>. Returns -1
+        /// if the <paramref name="radix"/> lies between <see cref="MinRadix"/> and <see cref="MaxRadix"/> or
+        /// if <paramref name="codePoint"/> is not a decimal digit.
+        /// </returns>
+        public static int Digit(int codePoint, int radix)
+        {
+            int result = -1;
+            if (radix >= MinRadix && radix <= MaxRadix)
+            {
+                if (codePoint < 128)
+                {
+                    // Optimized for ASCII
+                    if ('0' <= codePoint && codePoint <= '9')
+                    {
+                        result = codePoint - '0';
+                    }
+                    else if ('a' <= codePoint && codePoint <= 'z')
+                    {
+                        result = codePoint - ('a' - 10);
+                    }
+                    else if ('A' <= codePoint && codePoint <= 'Z')
+                    {
+                        result = codePoint - ('A' - 10);
+                    }
+                    return result < radix ? result : -1;
+                }
+                int value = -1;
+                if (codePoint < MinSupplementaryCodePoint)
+                {
+                    result = BinarySearchRange(digitKeys, (char)codePoint);
+                    if (result >= 0 && codePoint <= digitValues[result * 2])
+                    {
+                        value = (char)(codePoint - digitValues[result * 2 + 1]);
+                    }
+                }
+                else
+                {
+                    result = BinarySearchRange(DigitSupplemental.Keys, codePoint);
+                    if (result >= 0 && codePoint <= DigitSupplemental.Values[result * 2])
+                    {
+                        value = (char)(codePoint - DigitSupplemental.Values[result * 2 + 1]);
+                    }
+                }
+                if (value >= radix)
+                {
+                    return -1;
+                }
+                return value;
+            }
+            return -1;
+        }
 
         /// <summary>
         /// Search the sorted characters in the string and return the nearest index.
@@ -1297,6 +1395,30 @@ namespace J2N
                     high = mid - 1;
             }
             return mid - (c < value ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Search the sorted characters in the string and return the nearest index.
+        /// </summary>
+        /// <param name="data">The String to search.</param>
+        /// <param name="codePoint">The character to search for.</param>
+        /// <returns>The nearest index.</returns>
+        private static int BinarySearchRange(int[] data, int codePoint)
+        {
+            int value = 0;
+            int low = 0, mid = -1, high = data.Length - 1;
+            while (low <= high)
+            {
+                mid = (low + high) >> 1;
+                value = data[mid];
+                if (codePoint > value)
+                    low = mid + 1;
+                else if (codePoint == value)
+                    return mid;
+                else
+                    high = mid - 1;
+            }
+            return mid - (codePoint < value ? 1 : 0);
         }
 
         /// <summary>

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -8,6 +8,10 @@
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ICU4N" Version="$(ICU4NPackageReferenceVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1509,6 +1509,7 @@ namespace J2N
         }
 
         [Test]
+        //[Ignore("Run Manually - ICU4N's Digit method is slow with surrogates")]
         public void Test_Digit_II_Against_ICU4N()
         {
             for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
@@ -1525,7 +1526,7 @@ namespace J2N
 
         [Test]
         [Ignore("For debugging")]
-        public void Test_Digit_II_Against_ICU4N_2()
+        public void Test_Digit_II_Against_ICU4N_Debug()
         {
             int c = 0x1d7e2; // 0x1d7d8; // 0x1d7ce; //0x1d7f6; // 0x1d7ec; // 0x1d7e2; // 0x1d7d8;
             int radix = 2;
@@ -1594,41 +1595,92 @@ namespace J2N
                     .GetNumericValue('\uff12'));
         }
 
-        /////**
-        //// * @tests java.lang.Character#getNumericValue(int)
-        //// */
-        ////[Test]
-        ////public void Test_getNumericValue_I()
-        ////{
-        ////    assertEquals(1, Character.GetNumericValue((int)'1'));
-        ////    assertEquals(15, Character.GetNumericValue((int)'F'));
-        ////    assertEquals(-1, Character.GetNumericValue((int)'\u221e'));
-        ////    assertEquals(-2, Character.GetNumericValue((int)'\u00be'));
-        ////    assertEquals(10000, Character.GetNumericValue((int)'\u2182'));
-        ////    assertEquals(2, Character.GetNumericValue((int)'\uff12'));
-        ////    assertEquals(-1, Character.GetNumericValue(0xFFFF));
+        [Test]
+        public void Test_GetNumericValueC_Against_ICU4N()
+        {
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                if (c >= Character.MinSupplementaryCodePoint)
+                    continue;
 
-        ////    assertEquals(-1, Character.GetNumericValue(0xFFFF));
-        ////    assertEquals(0, Character.GetNumericValue(0x1D7CE));
-        ////    assertEquals(0, Character.GetNumericValue(0x1D7D8));
-        ////    assertEquals(-1, Character.GetNumericValue(0x2F800));
-        ////    assertEquals(-1, Character.GetNumericValue(0x10FFFD));
-        ////    assertEquals(-1, Character.GetNumericValue(0x110000));
+                int expected = UChar.GetNumericValue(c);
+                int actual = Character.GetNumericValue((char)c);
 
-        ////    assertEquals(50, Character.GetNumericValue(0x216C));
+                assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
+            }
+        }
 
-        ////    assertEquals(10, Character.GetNumericValue(0x0041));
-        ////    assertEquals(35, Character.GetNumericValue(0x005A));
-        ////    assertEquals(10, Character.GetNumericValue(0x0061));
-        ////    assertEquals(35, Character.GetNumericValue(0x007A));
-        ////    assertEquals(10, Character.GetNumericValue(0xFF21));
+        [Test]
+        [Ignore("For debugging")]
+        public void Test_GetNumericValueC_Against_ICU4N_Debug()
+        {
+            int c = 0x2187; // 0xd58; //0xc7c; //0x9f9; //0x9f4; //0xb2;
 
-        ////    //FIXME depends on ICU4J
-        ////    //assertEquals(35, Character.GetNumericValue(0xFF3A));
+            int expected = UChar.GetNumericValue(c);
+            int actual = Character.GetNumericValue((char)c);
 
-        ////    assertEquals(10, Character.GetNumericValue(0xFF41));
-        ////    assertEquals(35, Character.GetNumericValue(0xFF5A));
-        ////}
+            assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
+        }
+
+        /**
+         * @tests java.lang.Character#getNumericValue(int)
+         */
+        [Test]
+        public void Test_getNumericValue_I()
+        {
+            assertEquals(1, Character.GetNumericValue((int)'1'));
+            assertEquals(15, Character.GetNumericValue((int)'F'));
+            assertEquals(-1, Character.GetNumericValue((int)'\u221e'));
+            assertEquals(-2, Character.GetNumericValue((int)'\u00be'));
+            assertEquals(10000, Character.GetNumericValue((int)'\u2182'));
+            assertEquals(2, Character.GetNumericValue((int)'\uff12'));
+            assertEquals(-1, Character.GetNumericValue(0xFFFF));
+
+            assertEquals(-1, Character.GetNumericValue(0xFFFF));
+            assertEquals(0, Character.GetNumericValue(0x1D7CE));
+            assertEquals(0, Character.GetNumericValue(0x1D7D8));
+            assertEquals(-1, Character.GetNumericValue(0x2F800));
+            assertEquals(-1, Character.GetNumericValue(0x10FFFD));
+            assertEquals(-1, Character.GetNumericValue(0x110000));
+
+            assertEquals(50, Character.GetNumericValue(0x216C));
+
+            assertEquals(10, Character.GetNumericValue(0x0041));
+            assertEquals(35, Character.GetNumericValue(0x005A));
+            assertEquals(10, Character.GetNumericValue(0x0061));
+            assertEquals(35, Character.GetNumericValue(0x007A));
+            assertEquals(10, Character.GetNumericValue(0xFF21));
+
+            //FIXME depends on ICU4J
+            //assertEquals(35, Character.GetNumericValue(0xFF3A));
+
+            assertEquals(10, Character.GetNumericValue(0xFF41));
+            assertEquals(35, Character.GetNumericValue(0xFF5A));
+        }
+
+        [Test]
+        public void Test_GetNumericValue_I_Against_ICU4N()
+        {
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                int expected = UChar.GetNumericValue(c);
+                int actual = Character.GetNumericValue(c);
+
+                assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
+            }
+        }
+
+        [Test]
+        [Ignore("For debugging")]
+        public void Test_GetNumericValue_I_Against_ICU4N_Debug()
+        {
+            int c = 0x0; //0x10131; // 0xd58; //0xc7c; //0x9f9; //0x9f4; //0xb2;
+
+            int expected = UChar.GetNumericValue(c);
+            int actual = Character.GetNumericValue(c);
+
+            assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
+        }
 
         /**
          * @tests java.lang.Character#getType(char)

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1,4 +1,7 @@
-﻿using J2N.Collections;
+﻿using ICU4N;
+using ICU4N.Globalization;
+using ICU4N.Text;
+using J2N.Collections;
 using J2N.Text;
 using NUnit.Framework;
 using System;
@@ -1465,25 +1468,73 @@ namespace J2N
         {
             assertEquals("Returned incorrect digit", 1, Character.Digit('1', 10));
             assertEquals("Returned incorrect digit", 15, Character.Digit('F', 16));
+
+            assertEquals("Returned incorrect digit", 1, Character.Digit('๑', 10));
         }
 
-        /////**
-        //// * @tests java.lang.Character#digit(int, int)
-        //// */
-        ////[Test]
-        ////public void Test_digit_II()
-        ////{
-        ////    assertEquals(1, Character.Digit((int)'1', 10));
-        ////    assertEquals(15, Character.Digit((int)'F', 16));
+        [Test]
+        public void Test_DigitCI_Against_ICU4N()
+        {
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                if (c >= Character.MinSupplementaryCodePoint)
+                    continue;
 
-        ////    assertEquals(-1, Character.Digit(0x0000, 37));
-        ////    assertEquals(-1, Character.Digit(0x0045, 10));
+                for (int radix = Character.MinRadix; radix <= Character.MaxRadix; radix++)
+                {
+                    int expected = UChar.Digit(c, radix);
+                    int actual = Character.Digit((char)c, radix);
 
-        ////    assertEquals(10, Character.Digit(0x0041, 20));
-        ////    assertEquals(10, Character.Digit(0x0061, 20));
+                    assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match for radix {radix}.", expected, actual);
+                }
+            }
+        }
 
-        ////    assertEquals(-1, Character.Digit(0x110000, 20));
-        ////}
+        /**
+         * @tests java.lang.Character#digit(int, int)
+         */
+        [Test]
+        public void Test_digit_II()
+        {
+            assertEquals(1, Character.Digit((int)'1', 10));
+            assertEquals(15, Character.Digit((int)'F', 16));
+
+            assertEquals(-1, Character.Digit(0x0000, 37));
+            assertEquals(-1, Character.Digit(0x0045, 10));
+
+            assertEquals(10, Character.Digit(0x0041, 20));
+            assertEquals(10, Character.Digit(0x0061, 20));
+
+            assertEquals(-1, Character.Digit(0x110000, 20));
+        }
+
+        [Test]
+        public void Test_Digit_II_Against_ICU4N()
+        {
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                for (int radix = Character.MinRadix; radix <= Character.MaxRadix; radix++)
+                {
+                    int expected = UChar.Digit(c, radix);
+                    int actual = Character.Digit(c, radix);
+
+                    assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match for radix {radix}.", expected, actual);
+                }
+            }
+        }
+
+        [Test]
+        [Ignore("For debugging")]
+        public void Test_Digit_II_Against_ICU4N_2()
+        {
+            int c = 0x1d7e2; // 0x1d7d8; // 0x1d7ce; //0x1d7f6; // 0x1d7ec; // 0x1d7e2; // 0x1d7d8;
+            int radix = 2;
+
+            int expected = UChar.Digit(c, radix);
+            int actual = Character.Digit(c, radix);
+
+            assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match for radix {radix}.", expected, actual);
+        }
 
         /////**
         //// * @tests java.lang.Character#equals(java.lang.Object)


### PR DESCRIPTION
- Added UTF-32 code point overloads of `Digit()` and `GetNumericValue()` to the `Character` class.
- Upgraded the existing methods from Unicode 3.0.0 to Unicode 10.0.
- Optimized ASCII digit lookups with a small (128 byte) static memory tradeoff.