### PR TITLE
2021 July Miscellaneous Bug Fixes and Updates

### DIFF
--- a/src/J2N.TestFramework/TestCase.cs
+++ b/src/J2N.TestFramework/TestCase.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 #if FEATURE_SERIALIZABLE
 using System.Runtime.Serialization;
@@ -23,126 +24,151 @@ namespace J2N
         {
         }
 
+        [DebuggerStepThrough]
         public static void assertTrue(bool condition)
         {
             Assert.IsTrue(condition);
         }
 
+        [DebuggerStepThrough]
         public static void assertTrue(string message, bool condition)
         {
             Assert.IsTrue(condition, message);
         }
 
+        [DebuggerStepThrough]
         public static void assertFalse(bool condition)
         {
             Assert.IsFalse(condition);
         }
 
+        [DebuggerStepThrough]
         public static void assertFalse(string message, bool condition)
         {
             Assert.IsFalse(condition, message);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(object expected, object actual)
         {
             Assert.AreEqual(expected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(string message, object expected, object actual)
         {
             Assert.AreEqual(expected, actual, message);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(long expected, long actual)
         {
             Assert.AreEqual(expected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(string message, long expected, long actual)
         {
             Assert.AreEqual(expected, actual, message);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals<T>(ISet<T> expected, ISet<T> actual)
         {
             Assert.True(expected.SetEquals(actual));
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals<T>(string message, ISet<T> expected, ISet<T> actual)
         {
             Assert.True(expected.SetEquals(actual), message);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals<T, S>(IDictionary<T, S> expected, IDictionary<T, S> actual)
         {
             Assert.AreEqual(expected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(ICollection expected, ICollection actual)
         {
             Assert.AreEqual(expected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertNotSame(object unexpected, object actual)
         {
             Assert.AreNotSame(unexpected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertNotSame(string message, object unexpected, object actual)
         {
             Assert.AreNotSame(unexpected, actual, message);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(double d1, double d2, double delta)
         {
             Assert.AreEqual(d1, d2, delta);
         }
 
+        [DebuggerStepThrough]
         public static void assertEquals(string msg, double d1, double d2, double delta)
         {
             Assert.AreEqual(d1, d2, delta, msg);
         }
 
+        [DebuggerStepThrough]
         public static void assertNotNull(object o)
         {
             Assert.NotNull(o);
         }
 
+        [DebuggerStepThrough]
         public static void assertNotNull(string msg, object o)
         {
             Assert.NotNull(o, msg);
         }
 
+        [DebuggerStepThrough]
         public static void assertNull(object o)
         {
             Assert.Null(o);
         }
 
+        [DebuggerStepThrough]
         public static void assertNull(string msg, object o)
         {
             Assert.Null(o, msg);
         }
 
+        [DebuggerStepThrough]
         public static void assertArrayEquals<T>(T[] a1, T[] a2)
         {
             CollectionAssert.AreEqual(a1, a2);
         }
 
+        [DebuggerStepThrough]
         public static void assertSame(Object expected, Object actual)
         {
             Assert.AreSame(expected, actual);
         }
 
+        [DebuggerStepThrough]
         public static void assertSame(string message, Object expected, Object actual)
         {
             Assert.AreSame(expected, actual, message);
         }
 
+        [DebuggerStepThrough]
         public static void fail()
         {
             Assert.Fail();
         }
 
+        [DebuggerStepThrough]
         public static void fail(string message)
         {
             Assert.Fail(message);

--- a/src/J2N/Collections/Arrays.cs
+++ b/src/J2N/Collections/Arrays.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
-
+using SR2 = J2N.Resources.Strings;
 
 namespace J2N.Collections
 {
@@ -270,6 +270,38 @@ namespace J2N.Collections
         //    return array;
         //}
 
+        /// <summary>
+        /// Copies the specified array, truncating or padding with default values for <typeparamref name="T"/> (if necessary) so the
+        /// copy has the specified length. For all indices that are valid in both the original array and the copy,
+        /// the two arrays will contain identical values. For any indices that are valid in the copy but not the
+        /// original, the copy will contain the default value of <typeparamref name="T"/>. Such indices will exist if
+        /// and only if the specified length is greater than that of the original array.
+        /// </summary>
+        /// <typeparam name="T">The type of array.</typeparam>
+        /// <param name="original">The array to copy.</param>
+        /// <param name="newLength">The length of the copy to be returned.</param>
+        /// <returns>A copy of the original array, truncated or padded with zeros to obtain the specified length.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="original"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="newLength"/> is less than zero.</exception>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif 
+        public static T[] CopyOf<T>(T[] original, int newLength)
+        {
+            if (original is null)
+                throw new ArgumentNullException(nameof(original));
+            if (newLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(newLength), newLength, SR2.ArgumentOutOfRange_NeedNonNegNum);
+
+            T[] newArray = new T[newLength];
+
+            for (int i = 0; i < Math.Min(original.Length, newLength); i++)
+            {
+                newArray[i] = original[i];
+            }
+
+            return newArray;
+        }
 
         /// <summary>
         /// Returns an empty array.

--- a/src/J2N/Collections/Generic/EqualityComparer.cs
+++ b/src/J2N/Collections/Generic/EqualityComparer.cs
@@ -45,41 +45,58 @@ namespace J2N.Collections.Generic
 
         internal class DoubleComparer : System.Collections.Generic.EqualityComparer<double>, IComparer<double>
         {
-            /// <summary>
-            /// Accounts for signed zero (.NET does not, but Java does)
-            /// </summary>
-            private int CompareZero(double x, double y)
-            {
-                long a = BitConversion.DoubleToInt64Bits(x);
-                long b = BitConversion.DoubleToInt64Bits(y);
-                if (a > b)
-                    return 1;
-                else if (a < b)
-                    return -1;
-
-                return 0;
-            }
-
             public int Compare(double x, double y)
             {
-                if (double.IsNaN(x) && double.IsNaN(y))
+                // Non-zero, non-NaN checking.
+                if (x > y)
+                {
+                    return 1;
+                }
+                if (y > x)
+                {
+                    return -1;
+                }
+                if (x == y && 0.0d != x)
+                {
                     return 0;
+                }
 
-                if (x != 0 && y != 0)
-                    return x.CompareTo(y);
+                // NaNs are equal to other NaNs and larger than any other double
+                if (double.IsNaN(x))
+                {
+                    if (double.IsNaN(y)) return 0;
+                    return 1;
+                }
+                else if (double.IsNaN(y))
+                {
+                    return -1;
+                }
 
-                return CompareZero(x, y);
+                // Deal with +0.0 and -0.0
+                long d1 = BitConversion.DoubleToRawInt64Bits(x); // NaN already dealt with, so we can use "raw" here
+                long d2 = BitConversion.DoubleToRawInt64Bits(y);
+                // The below expression is equivalent to:
+                // (d1 == d2) ? 0 : (d1 < d2) ? -1 : 1
+                return (int)((d1 >> 63) - (d2 >> 63));
             }
 
             public override bool Equals(double x, double y)
             {
+                if (x < y || x > y)
+                    return false;
+
+                if (0.0d != x && x == y)
+                    return true;
+
                 if (double.IsNaN(x) && double.IsNaN(y))
                     return true;
 
-                if (x != 0 && y != 0)
-                    return x.Equals(y);
-
-                return CompareZero(x, y) == 0;
+                // Deal with +0.0 and -0.0
+                long d1 = BitConversion.DoubleToRawInt64Bits(x); // NaN already dealt with, so we can use "raw" here
+                long d2 = BitConversion.DoubleToRawInt64Bits(y);
+                // The below expression is equivalent to:
+                // (d1 == d2) ? 0 : (d1 < d2) ? -1 : 1
+                return (int)((d1 >> 63) - (d2 >> 63)) == 0;
             }
 
             public override int GetHashCode(double obj)
@@ -87,49 +104,67 @@ namespace J2N.Collections.Generic
                 if (obj != 0 && !double.IsNaN(obj))
                     return obj.GetHashCode();
 
-                // Make positive zero and negative zero have differnt hash codes,
-                // and NaN always have the same hash code
+                // Make positive zero and negative zero have different hash codes,
+                // and NaN always have the same hash code.
+                // We intentionlly call the non "raw" overload here to get that behavior.
                 return BitConversion.DoubleToInt64Bits(obj).GetHashCode();
             }
         }
 
         internal class SingleComparer : System.Collections.Generic.EqualityComparer<float>, IComparer<float>
         {
-            /// <summary>
-            /// Accounts for signed zero (.NET does not, but Java does)
-            /// </summary>
-            private int CompareZero(float x, float y)
-            {
-                int a = BitConversion.SingleToInt32Bits(x);
-                int b = BitConversion.SingleToInt32Bits(y);
-                if (a > b)
-                    return 1;
-                else if (a < b)
-                    return -1;
-
-                return 0;
-            }
-
             public int Compare(float x, float y)
             {
-                if (float.IsNaN(x) && float.IsNaN(y))
+                // Non-zero, non-NaN checking.
+                if (x > y)
+                {
+                    return 1;
+                }
+                if (y > x)
+                {
+                    return -1;
+                }
+                if (x == y && 0.0f != x)
+                {
                     return 0;
+                }
 
-                if (x != 0 && y != 0)
-                    return x.CompareTo(y);
+                // NaNs are equal to other NaNs and larger than any other float
+                if (float.IsNaN(x))
+                {
+                    if (float.IsNaN(y)) return 0;
+                    return 1;
+                }
+                else if (float.IsNaN(y))
+                {
+                    return -1;
+                }
 
-                return CompareZero(x, y);
+                // Deal with +0.0 and -0.0
+                int f1 = BitConversion.SingleToRawInt32Bits(x); // NaN already dealt with, so we can use "raw" here
+                int f2 = BitConversion.SingleToRawInt32Bits(y);
+                // The below expression is equivalent to:
+                // (f1 == f2) ? 0 : (f1 < f2) ? -1 : 1
+                return (f1 >> 31) - (f2 >> 31);
             }
 
             public override bool Equals(float x, float y)
             {
+                if (x < y || x > y)
+                    return false;
+
+                if (0.0f != x && x == y)
+                    return true;
+
                 if (float.IsNaN(x) && float.IsNaN(y))
                     return true;
 
-                if (x != 0 && y != 0)
-                    return x.Equals(y);
-
-                return CompareZero(x, y) == 0;
+                // Deal with +0.0 and -0.0
+                int f1 = BitConversion.SingleToRawInt32Bits(x); // NaN already dealt with, so we can use "raw" here
+                int f2 = BitConversion.SingleToRawInt32Bits(y);
+                // The below expression is equivalent to:
+                // (f1 == f2) ? 0 : (f1 < f2) ? -1 : 1
+                return (f1 >> 31) - (f2 >> 31) == 0;
             }
 
             public override int GetHashCode(float obj)
@@ -137,8 +172,9 @@ namespace J2N.Collections.Generic
                 if (obj != 0 && !float.IsNaN(obj))
                     return obj.GetHashCode();
 
-                // Make positive zero and negative zero have differnt hash codes,
-                // and NaN always have the same hash code
+                // Make positive zero and negative zero have different hash codes,
+                // and NaN always have the same hash code.
+                // We intentionlly call the non "raw" overload here to get that behavior.
                 return BitConversion.SingleToInt32Bits(obj).GetHashCode();
             }
         }

--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -442,5 +442,31 @@ namespace J2N
                                                 ((value > 0.0f) ? -1 : +1));
             }
         }
+
+        /// <summary>
+        /// Returns a value with the magnitude of <paramref name="x"/> and the sign of <paramref name="y"/>.
+        /// </summary>
+        /// <param name="x">A number whose magnitude is used in the result.</param>
+        /// <param name="y">A number whose sign is the used in the result.</param>
+        /// <returns>A value with the magnitude of <paramref name="x"/> and the sign of <paramref name="y"/>.</returns>
+        public static unsafe double CopySign(this double x, double y) // Cover .NET < .NET Standard 2.1
+        {
+            // This method is required to work for all inputs,
+            // including NaN, so we operate on the raw bits.
+
+            long xbits = BitConversion.DoubleToRawInt64Bits(x);
+            long ybits = BitConversion.DoubleToRawInt64Bits(y);
+
+            // If the sign bits of x and y are not the same,
+            // flip the sign bit of x and return the new value;
+            // otherwise, just return x
+
+            if ((xbits ^ ybits) < 0)
+            {
+                return BitConversion.Int64BitsToDouble(xbits ^ long.MinValue);
+            }
+
+            return x;
+        }
     }
 }

--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -154,7 +154,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If either argument is <see cref="double.NaN"/>, the result is <see cref="double.NaN"/>.</description></item>
         ///     <item><description>If both arguments are signed zeros, a value equivalent to <paramref name="direction"/> is returned.</description></item>
-        ///     <item><description>If <paramref name="start"/> is &#177;<see cref="double.MinValue"/> and <paramref name="direction"/> has a value
+        ///     <item><description>If <paramref name="start"/> is &#177;<see cref="double.Epsilon"/> and <paramref name="direction"/> has a value
         ///         such that the result should have a smaller magnitude, then a zero with the same sign as <paramref name="start"/> is returned.</description></item>
         ///     <item><description>If <paramref name="start"/> is infinite and <paramref name="direction"/> has a value such that the result
         ///     should have a smaller magnitude, <see cref="double.MaxValue"/> with the same sign as <paramref name="start"/> is returned.</description></item>
@@ -245,7 +245,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If either argument is <see cref="float.NaN"/>, the result is <see cref="float.NaN"/>.</description></item>
         ///     <item><description>If both arguments are signed zeros, a value equivalent to <paramref name="direction"/> is returned.</description></item>
-        ///     <item><description>If <paramref name="start"/> is &#177;<see cref="float.MinValue"/> and <paramref name="direction"/> has a value
+        ///     <item><description>If <paramref name="start"/> is &#177;<see cref="float.Epsilon"/> and <paramref name="direction"/> has a value
         ///         such that the result should have a smaller magnitude, then a zero with the same sign as <paramref name="start"/> is returned.</description></item>
         ///     <item><description>If <paramref name="start"/> is infinite and <paramref name="direction"/> has a value such that the result
         ///     should have a smaller magnitude, <see cref="float.MaxValue"/> with the same sign as <paramref name="start"/> is returned.</description></item>
@@ -337,7 +337,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If the argument is <see cref="double.NaN"/>, the result is <see cref="double.NaN"/>.</description></item>
         ///     <item><description>If the argument is <see cref="double.PositiveInfinity"/>, the result is <see cref="double.PositiveInfinity"/>.</description></item>
-        ///     <item><description>If the argument is zero, the result is <see cref="double.MinValue"/>.</description></item>
+        ///     <item><description>If the argument is zero, the result is <see cref="double.Epsilon"/>.</description></item>
         /// </list>
         /// </summary>
         /// <param name="value">The starting floating-point value.</param>
@@ -366,7 +366,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If the argument is <see cref="float.NaN"/>, the result is <see cref="float.NaN"/>.</description></item>
         ///     <item><description>If the argument is <see cref="float.PositiveInfinity"/>, the result is <see cref="float.PositiveInfinity"/>.</description></item>
-        ///     <item><description>If the argument is zero, the result is <see cref="float.MinValue"/>.</description></item>
+        ///     <item><description>If the argument is zero, the result is <see cref="float.Epsilon"/>.</description></item>
         /// </list>
         /// </summary>
         /// <param name="value">The starting floating-point value.</param>
@@ -394,7 +394,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If the argument is <see cref="double.NaN"/>, the result is <see cref="double.NaN"/>.</description></item>
         ///     <item><description>If the argument is <see cref="double.NegativeInfinity"/>, the result is <see cref="double.NegativeInfinity"/>.</description></item>
-        ///     <item><description>If the argument is zero, the result is <see cref="double.MinValue"/>.</description></item>
+        ///     <item><description>If the argument is zero, the result is <see cref="double.Epsilon"/>.</description></item>
         /// </list>
         /// </summary>
         /// <param name="value">The starting floating-point value.</param>
@@ -406,7 +406,7 @@ namespace J2N
             else
             {
                 if (value == 0.0)
-                    return -double.MinValue;
+                    return -double.Epsilon; // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
                 else
                     return BitConversion.Int64BitsToDouble(BitConversion.DoubleToRawInt64Bits(value) +
                                                    ((value > 0.0d) ? -1L : +1L));
@@ -424,7 +424,7 @@ namespace J2N
         /// <list type="bullet">
         ///     <item><description>If the argument is <see cref="float.NaN"/>, the result is <see cref="float.NaN"/>.</description></item>
         ///     <item><description>If the argument is <see cref="float.NegativeInfinity"/>, the result is <see cref="float.NegativeInfinity"/>.</description></item>
-        ///     <item><description>If the argument is zero, the result is <see cref="float.MinValue"/>.</description></item>
+        ///     <item><description>If the argument is zero, the result is <see cref="float.Epsilon"/>.</description></item>
         /// </list>
         /// </summary>
         /// <param name="value">The starting floating-point value.</param>
@@ -436,7 +436,7 @@ namespace J2N
             else
             {
                 if (value == 0.0f)
-                    return -float.MinValue;
+                    return -float.Epsilon; // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
                 else
                     return BitConversion.Int32BitsToSingle(BitConversion.SingleToRawInt32Bits(value) +
                                                 ((value > 0.0f) ? -1 : +1));

--- a/src/J2N/Time.cs
+++ b/src/J2N/Time.cs
@@ -1,6 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
-
 
 namespace J2N
 {
@@ -12,13 +12,30 @@ namespace J2N
         /// <summary>
         /// The number of milliseconds in one nanosecond.
         /// </summary>
-        public const long MillisecondsPerNanosecond = 1000000;
+        public const long MillisecondsPerNanosecond = 1000000L;
+
+        /// <summary>
+        /// The number or seconds in one nanosecond.
+        /// </summary>
+        public const long SecondsPerNanosecond = 1000000000L;
+
+        /// <summary>
+        /// The .NET ticks representing January 1, 1970 0:00:00, also known as the "epoch".
+        /// </summary>
+        private const long UnixEpochTicks = 621355968000000000L;
+
+        /// <summary>
+        /// The <see cref="DateTime"/> January 1, 1970 0:00:00 UTC, also known as the "epoch".
+        /// </summary>
+        public readonly static DateTime UnixEpoch = new DateTime(UnixEpochTicks, DateTimeKind.Utc);
 
         /// <summary>
         /// Returns the current value of the running framework's high-resolution time source, in nanoseconds.
-        /// <para/>
+        /// </summary>
+        /// <returns>The current value of the current framework's high resolution time source, in nanoseconds.</returns>
+        /// <remarks>
         /// This method can only be used to measure elapsed time and is not related to any other notion of system
-        /// or wall-clock time.The value returned represents nanoseconds since some fixed but arbitrary origin
+        /// or wall-clock time. The value returned represents nanoseconds since some fixed but arbitrary origin
         /// time (perhaps in the future, so values may be negative).
         /// <para/>
         /// This method provides nanosecond precision, but not necessarily nanosecond resolution (that is, how
@@ -27,14 +44,39 @@ namespace J2N
         /// <para/>
         /// This method relies on <see cref="System.Diagnostics.Stopwatch"/>, which is the most accurate
         /// timing mechanism in the .NET framework.
-        /// </summary>
-        /// <returns>The current value of the current framework's high resolution time source, in nanoseconds.</returns>
+        /// <para/>
+        /// For example, to measure how long some code takes to execute:
+        /// <code>
+        /// long startTime = Time.NanoTime();<br/>
+        /// // ... the code being measured ...<br/>
+        /// long estimatedTime = Time.NanoTime() - startTime;
+        /// </code>
+        /// To compare two nanoTime values
+        /// <code>
+        /// long t0 = Time.NanoTime();<br/>
+        /// ...<br/>
+        /// long t1 = Time.NanoTime();
+        /// </code>
+        /// one should use <c>t1 - t0 &lt; 0</c>, not <c>t1 &lt; t0</c>, because of the possibility
+        /// of numerical overflow.
+        /// <para/>
+        /// The elapsed time can be converted to milliseconds or seconds by using the <see cref="MillisecondsPerNanosecond"/>
+        /// and <see cref="SecondsPerNanosecond"/> constants.
+        /// <code>
+        /// long t0 = Time.NanoTime();<br/>
+        /// ...<br/>
+        /// long t1 = Time.NanoTime();<br/>
+        /// <br/>
+        /// double milliseconds = ((double)t1 - t0) / Time.MillisecondsPerNanosecond;<br/>
+        /// double seconds = ((dobule)t1 - t0) / Time.SecondsPerNanosecond;
+        /// </code>
+        /// </remarks>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static long NanoTime()
         {
-            return (Stopwatch.GetTimestamp() / Stopwatch.Frequency) * 1000000000;
+            return unchecked((long)(1_000_000_000.0d * Stopwatch.GetTimestamp() / Stopwatch.Frequency));
         }
 
         /// <summary>
@@ -43,16 +85,52 @@ namespace J2N
         /// operating system and may be larger. For example, many operating systems measure time in
         /// units of tens of milliseconds.
         /// <para/>
-        /// This method relies on <see cref="System.Diagnostics.Stopwatch"/>, which is the most accurate
-        /// timing mechanism in the .NET framework.
+        /// This value returned is based on <see cref="DateTime.UtcNow"/>, which is not the highest
+        /// resolution timer available. For a higher resolution measurment of elapsed time, use <see cref="NanoTime()"/>.
         /// </summary>
-        /// <returns>The current value of the current framework's high resolution time source, in milliseconds.</returns>
+        /// <returns>The difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
+        /// also known as the "epoch".</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static long CurrentTimeMilliseconds()
         {
-            return (Stopwatch.GetTimestamp() / Stopwatch.Frequency) * 1000;
+            return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds;
+        }
+
+        /// <summary>
+        /// Returns the number of milliseconds since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.
+        /// <para/>
+        /// Usage Note: This method corresponds to Date.getTime() in the JDK.
+        /// </summary>
+        /// <param name="dateTime">This <see cref="DateTime"/>.</param>
+        /// <returns>The number of milliseconds since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.</returns>
+        /// <seealso cref="GetTimeSpanSinceUnixEpoch(DateTime)"/>
+        /// <seealso cref="UnixEpoch"/>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static long GetMillisecondsSinceUnixEpoch(this DateTime dateTime)
+        {
+            return (long)(dateTime - UnixEpoch).TotalMilliseconds;
+        }
+
+        /// <summary>
+        /// Returns the <see cref="TimeSpan"/> since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.
+        /// <para/>
+        /// Usage Note: This method provides similar functionality to Date.getTime() in the JDK, however,
+        /// <see cref="GetMillisecondsSinceUnixEpoch(DateTime)"/> is an exact behavioral match.
+        /// </summary>
+        /// <param name="dateTime">This <see cref="DateTime"/>.</param>
+        /// <returns>The <see cref="TimeSpan"/> since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.</returns>
+        /// <seealso cref="GetMillisecondsSinceUnixEpoch(DateTime)"/>
+        /// <seealso cref="UnixEpoch"/>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static TimeSpan GetTimeSpanSinceUnixEpoch(this DateTime dateTime)
+        {
+            return dateTime - UnixEpoch;
         }
     }
 }

--- a/tests/J2N.Tests/Collections/TestArrays.cs
+++ b/tests/J2N.Tests/Collections/TestArrays.cs
@@ -16,7 +16,7 @@ namespace J2N.Collections
             double[] d = new double[100];
             double[] x = new double[100];
             ArrayExtensions.Fill(d, double.MaxValue);
-            ArrayExtensions.Fill(x, double.MinValue);
+            ArrayExtensions.Fill(x, double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
 
             assertTrue("Assert 0: Inequal arrays returned true", !Arrays.Equals(d, x));
 
@@ -41,7 +41,7 @@ namespace J2N.Collections
             float[] d = new float[100];
             float[] x = new float[100];
             ArrayExtensions.Fill(d, float.MaxValue);
-            ArrayExtensions.Fill(x, float.MinValue);
+            ArrayExtensions.Fill(x, float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
 
             assertTrue("Assert 0: Inequal arrays returned true", !Arrays.Equals(d, x));
 

--- a/tests/J2N.Tests/IO/TestByteBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestByteBuffer2.cs
@@ -215,12 +215,12 @@ namespace J2N.IO
             output.Write(" long");
 
             b.PutSingle((float)1);
-            b.PutSingle((float)float.MinValue);
+            b.PutSingle((float)float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
             b.PutSingle((float)float.MaxValue);
             output.Write(" float");
 
             b.PutDouble((double)1);
-            b.PutDouble((double)double.MinValue);
+            b.PutDouble((double)double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             b.PutDouble((double)double.MaxValue);
             output.Write(" double");
 
@@ -247,12 +247,12 @@ namespace J2N.IO
             output.Write(" long");
 
             ck(b, b.GetSingle(), 1);
-            ck(b, b.GetSingle(), float.MinValue);
+            ck(b, b.GetSingle(), float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
             ck(b, b.GetSingle(), float.MaxValue);
             output.Write(" float");
 
             ck(b, b.GetDouble(), 1);
-            ck(b, b.GetDouble(), double.MinValue);
+            ck(b, b.GetDouble(), double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             ck(b, b.GetDouble(), double.MaxValue);
             output.Write(" double");
 

--- a/tests/J2N.Tests/IO/TestDoubleBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestDoubleBuffer2.cs
@@ -10,14 +10,14 @@ namespace J2N.IO
     public class TestDoubleBuffer2 : BaseBufferTestCase
     {
         private static readonly double[] VALUES = {
-            Double.MinValue,
+            double.Epsilon, // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             (double) -1,
             (double) 0,
             (double) 1,
-            Double.MaxValue,
-            Double.NegativeInfinity,
-            Double.PositiveInfinity,
-            Double.NaN,
+            double.MaxValue,
+            double.NegativeInfinity,
+            double.PositiveInfinity,
+            double.NaN,
             (double) -0.0,
         };
 
@@ -262,9 +262,9 @@ namespace J2N.IO
             b.Put((double)-1);
             b.Put((double)1);
             b.Put(double.MaxValue);
-            b.Put(double.MinValue);
+            b.Put(double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             b.Put(-double.MaxValue);
-            b.Put(-double.MinValue);
+            b.Put(-double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             b.Put(double.NegativeInfinity);
             b.Put(double.PositiveInfinity);
             b.Put(double.NaN);
@@ -277,9 +277,9 @@ namespace J2N.IO
             ck(b, b.Get(), (double)-1);
             ck(b, b.Get(), 1);
             ck(b, b.Get(), double.MaxValue);
-            ck(b, b.Get(), double.MinValue);
+            ck(b, b.Get(), double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             ck(b, b.Get(), -double.MaxValue);
-            ck(b, b.Get(), -double.MinValue);
+            ck(b, b.Get(), -double.Epsilon); // J2N: In .NET double.Epsilon is the same as Double.MIN_VALUE in Java
             ck(b, b.Get(), double.NegativeInfinity);
             ck(b, b.Get(), double.PositiveInfinity);
             if (BitConversion.DoubleToRawInt64Bits(v = b.Get())

--- a/tests/J2N.Tests/IO/TestSingleBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestSingleBuffer2.cs
@@ -10,7 +10,7 @@ namespace J2N.IO
     public class TestSingleBuffer2 : BaseBufferTestCase
     {
         private static readonly float[] VALUES = {
-        float.MinValue,
+        float.Epsilon, // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
         (float) -1,
         (float) 0,
         (float) 1,
@@ -263,10 +263,10 @@ namespace J2N.IO
             b.Put((float)-1);
             b.Put((float)1);
             b.Put(float.MaxValue);
-            b.Put(float.MinValue);
+            b.Put(float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
 
             b.Put(-float.MaxValue);
-            b.Put(-float.MinValue);
+            b.Put(-float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
             b.Put(float.NegativeInfinity);
             b.Put(float.PositiveInfinity);
             b.Put(float.NaN);
@@ -278,11 +278,11 @@ namespace J2N.IO
             ck(b, b.Get(), (float)-1);
             ck(b, b.Get(), 1);
             ck(b, b.Get(), float.MaxValue);
-            ck(b, b.Get(), float.MinValue);
+            ck(b, b.Get(), float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
 
 
             ck(b, b.Get(), -float.MaxValue);
-            ck(b, b.Get(), -float.MinValue);
+            ck(b, b.Get(), -float.Epsilon); // J2N: In .NET float.Epsilon is the same as Float.MIN_VALUE in Java
             ck(b, b.Get(), float.NegativeInfinity);
             ck(b, b.Get(), float.PositiveInfinity);
             // J2N TODO: Investigate why this comparison fails in .NET and passes in Java

--- a/tests/J2N.Tests/TestTime.cs
+++ b/tests/J2N.Tests/TestTime.cs
@@ -1,0 +1,186 @@
+﻿#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace J2N
+{
+    public class TestTime : TestCase
+    {
+        public override void SetUp()
+        {
+            base.SetUp();
+            setDelays();
+        }
+
+
+        public static long SHORT_DELAY_MS;
+        public static long SMALL_DELAY_MS;
+        public static long MEDIUM_DELAY_MS;
+        public static long LONG_DELAY_MS;
+
+        /**
+         * Returns the shortest timed delay. This could
+         * be reimplemented to use for example a Property.
+         */
+        protected long getShortDelay()
+        {
+            return 50;
+        }
+
+
+        /**
+         * Sets delays as multiples of SHORT_DELAY.
+         */
+        protected void setDelays()
+        {
+            SHORT_DELAY_MS = getShortDelay();
+            SMALL_DELAY_MS = SHORT_DELAY_MS * 5;
+            MEDIUM_DELAY_MS = SHORT_DELAY_MS * 10;
+            LONG_DELAY_MS = SHORT_DELAY_MS * 50;
+        }
+
+        /**
+         * fail with message "Unexpected exception"
+         */
+        public void unexpectedException()
+        {
+            fail("Unexpected exception");
+        }
+
+
+        /** 
+         * Worst case rounding for millisecs; set for 60 cycle millis clock.
+         * This value might need to be changed os JVMs with coarser
+         *  System.currentTimeMillis clocks.
+         */
+        static readonly long MILLIS_ROUND = 17;
+
+        /**
+         * Nanos between readings of millis is no longer than millis (plus
+         * possible rounding).
+         * This shows only that nano timing not (much) worse than milli.
+         */
+        [Test]
+        public void TestNanoTime1()
+        {
+            try
+            {
+                long m1 = Time.CurrentTimeMilliseconds();
+                Thread.Sleep(1);
+                long n1 = Time.NanoTime();
+                Thread.Sleep(TimeSpan.FromMilliseconds(SHORT_DELAY_MS));
+                long n2 = Time.NanoTime();
+                Thread.Sleep(1);
+                long m2 = Time.CurrentTimeMilliseconds();
+                long millis = m2 - m1;
+                long nanos = n2 - n1;
+                assertTrue(nanos >= 0);
+                long nanosAsMillis = nanos / 1000000;
+                assertTrue(nanosAsMillis <= millis + MILLIS_ROUND);
+            }
+            catch (ThreadInterruptedException ie)
+            {
+                unexpectedException();
+            }
+        }
+
+        /**
+         * Millis between readings of nanos is less than nanos, adjusting
+         * for rounding.
+         * This shows only that nano timing not (much) worse than milli.
+         */
+        [Test]
+        public void TestNanoTime2()
+        {
+            try
+            {
+                long n1 = Time.NanoTime();
+                Thread.Sleep(1);
+                long m1 = Time.CurrentTimeMilliseconds();
+                Thread.Sleep(TimeSpan.FromMilliseconds(SHORT_DELAY_MS));
+                long m2 = Time.CurrentTimeMilliseconds();
+                Thread.Sleep(1);
+                long n2 = Time.NanoTime();
+                long millis = m2 - m1;
+                long nanos = n2 - n1;
+
+                assertTrue(nanos >= 0);
+                long nanosAsMillis = nanos / 1000000;
+                assertTrue(millis <= nanosAsMillis + MILLIS_ROUND);
+            }
+            catch (ThreadInterruptedException ie)
+            {
+                unexpectedException();
+            }
+        }
+
+        /**
+         * @tests java.lang.System#currentTimeMillis()
+         */
+        [Test]
+        public void Test_currentTimeMillis()
+        {
+            // Test for method long java.lang.System.currentTimeMillis()
+            long firstRead = Time.CurrentTimeMilliseconds();
+            try
+            {
+                Thread.Sleep(150);
+            }
+            catch (ThreadInterruptedException e)
+            {
+            }
+            long secondRead = Time.CurrentTimeMilliseconds();
+            assertTrue("Incorrect times returned: " + firstRead + ", "
+                            + secondRead, firstRead < secondRead);
+        }
+
+        
+        /**
+         * @tests java.util.Date#getTime()
+         */
+        [Test]
+        public void Test_getTime()
+        {
+            // Test for method long java.util.Date.getTime()
+            DateTime d1 = Time.UnixEpoch; //new Date(0);
+            DateTime d2 = Time.UnixEpoch + TimeSpan.FromMilliseconds(1900000); //new Date(1900000);
+            assertEquals("Returned incorrect time", 1900000, d2.GetMillisecondsSinceUnixEpoch());
+            assertEquals("Returned incorrect time", 0, d1.GetMillisecondsSinceUnixEpoch());
+        }
+
+        /**
+         * @tests java.util.Date#getTime()
+         */
+        [Test]
+        public void Test_GetTimeSpanSinceUnixEpoch()
+        {
+            // Test for method long java.util.Date.getTime()
+            DateTime d1 = Time.UnixEpoch; //new Date(0);
+            DateTime d2 = Time.UnixEpoch + TimeSpan.FromMilliseconds(1900000); //new Date(1900000);
+            assertEquals("Returned incorrect time", 1900000d, d2.GetTimeSpanSinceUnixEpoch().TotalMilliseconds, 0d);
+            assertEquals("Returned incorrect time", 0d, d1.GetTimeSpanSinceUnixEpoch().TotalMilliseconds, 0d);
+        }
+    }
+}


### PR DESCRIPTION
- BUG: Updated `float.MinValue` and `double.MinValue` to `float.Epsilon` and `double.Epsilon`, respectively (Epsilon is the corresponding constant in .NET)
- Added `DebuggerStepThrough` attribute in test framework assert methods
- Fixed floating point comparison logic in J2N.Collections.Generic.EqualityComparer
- Added `MathExtensions.CopySign()` method
- Added `J2N.Collections.Arrays.CopyOf()` method (internal)
-  BUG: J2N.Time: Fixed implementations of both `NanoTime()` and `CurrentTimeMilliseconds()` to match the JDK and added tests. Also added field for `UnixEpoch` and methods for `GetTimeSpanSinceUnixEpoch()` and `GetMillisecondsSinceUnixEpoch()`. See apache/lucenenet#492

