### PR TITLE
BREAKING: Fixed Character.IsWhiteSpace() to match JDK

### DIFF
--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -2424,11 +2424,34 @@ namespace J2N
         }
 
         /// <summary>
-        /// Indicates whether the specified character is a whitespace character in
-        /// .NET.
+        /// Indicates whether the specified character (Unicode code point) is a whitespace character according to Java.
+        /// A character is a Java whitespace character if and only if it satisfies one of the following criteria:
+        /// <list type="bullet">
+        ///     <item><description>It is a Unicode space character (<see cref="UnicodeCategory.SpaceSeparator"/>,
+        ///     <see cref="UnicodeCategory.LineSeparator"/>, or <see cref="UnicodeCategory.ParagraphSeparator"/>)
+        ///     but it is not also a non-breaking space ('\u00A0', '\u2007', '\u202F').</description></item>
+        ///     <item><description>It is '\t', U+0009 HORIZONTAL TABULATION.</description></item>
+        ///     <item><description>It is '\n', U+000A LINE FEED.</description></item>
+        ///     <item><description>It is '\u000B', U+000B VERTICAL TABULATION.</description></item>
+        ///     <item><description>It is '\f', U+000C FORM FEED.</description></item>
+        ///     <item><description>It is '\r', U+000D CARRIAGE RETURN.</description></item>
+        ///     <item><description>It is '\u001C', U+001C FILE SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001D', U+001D GROUP SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001E', U+001E RECORD SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001F', U+001F UNIT SEPARATOR.</description></item>
+        /// </list>
+        /// <para/>
+        /// Usage Note: This method differs from <see cref="char.IsWhiteSpace(char)"/> in that it returns <c>false</c>
+        /// for the following characters:
+        /// <list type="bullet">
+        ///     <item><description>'\u0085', NEXT LINE</description></item>
+        ///     <item><description>'\u00A0', NO-BREAK SPACE</description></item>
+        ///     <item><description>'\u2007', FIGURE SPACE</description></item>
+        ///     <item><description>'\u202F', NARROW NO-BREAK SPACE</description></item>
+        /// </list>
         /// </summary>
         /// <param name="c">The character to check.</param>
-        /// <returns><c>true</c> if <paramref name="c"/> is a whitespace character, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if <paramref name="c"/> is a Java whitespace character, <c>false</c> otherwise.</returns>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -2438,11 +2461,34 @@ namespace J2N
         }
 
         /// <summary>
-        /// Indicates whether the specified character is a whitespace character in
-        /// .NET.
+        /// Indicates whether the specified character (Unicode code point) is a whitespace character according to Java.
+        /// A character is a Java whitespace character if and only if it satisfies one of the following criteria:
+        /// <list type="bullet">
+        ///     <item><description>It is a Unicode space character (<see cref="UnicodeCategory.SpaceSeparator"/>,
+        ///     <see cref="UnicodeCategory.LineSeparator"/>, or <see cref="UnicodeCategory.ParagraphSeparator"/>)
+        ///     but it is not also a non-breaking space ('\u00A0', '\u2007', '\u202F').</description></item>
+        ///     <item><description>It is '\t', U+0009 HORIZONTAL TABULATION.</description></item>
+        ///     <item><description>It is '\n', U+000A LINE FEED.</description></item>
+        ///     <item><description>It is '\u000B', U+000B VERTICAL TABULATION.</description></item>
+        ///     <item><description>It is '\f', U+000C FORM FEED.</description></item>
+        ///     <item><description>It is '\r', U+000D CARRIAGE RETURN.</description></item>
+        ///     <item><description>It is '\u001C', U+001C FILE SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001D', U+001D GROUP SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001E', U+001E RECORD SEPARATOR.</description></item>
+        ///     <item><description>It is '\u001F', U+001F UNIT SEPARATOR.</description></item>
+        /// </list>
+        /// <para/>
+        /// Usage Note: This method differs from <see cref="char.IsWhiteSpace(string, int)"/> in that it returns <c>false</c>
+        /// for the following characters:
+        /// <list type="bullet">
+        ///     <item><description>'\u0085', NEXT LINE</description></item>
+        ///     <item><description>'\u00A0', NO-BREAK SPACE</description></item>
+        ///     <item><description>'\u2007', FIGURE SPACE</description></item>
+        ///     <item><description>'\u202F', NARROW NO-BREAK SPACE</description></item>
+        /// </list>
         /// </summary>
         /// <param name="codePoint">The character to check.</param>
-        /// <returns><c>true</c> if <paramref name="codePoint"/> is a whitespace character, <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> if <paramref name="codePoint"/> is a Java whitespace character, <c>false</c> otherwise.</returns>
         public static bool IsWhiteSpace(int codePoint)
         {
             // Optimized case for ASCII

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -2434,7 +2434,7 @@ namespace J2N
 #endif
         public static bool IsWhiteSpace(char c)
         {
-            return char.IsWhiteSpace(c);
+            return IsWhiteSpace((int)c);
         }
 
         /// <summary>
@@ -2452,8 +2452,7 @@ namespace J2N
                 return true;
             if (codePoint < 0x2000 || codePoint == 0x2007)
                 return false;
-            return codePoint <= 0x200b || codePoint == 0x2028 || codePoint == 0x2029 || codePoint == 0x3000;
-            // Port Note: char.IsWhiteSpace(char.ConvertFromUtf32(codePoint)) incorrectly returns true for codepoint 160 (and possibly other cases)
+            return codePoint < 0x200b || codePoint == 0x2028 || codePoint == 0x2029 || codePoint == 0x205f || codePoint == 0x3000;
         }
 
         /// <summary>

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -2502,8 +2502,67 @@ namespace J2N
         [Test]
         public void Test_isWhitespaceC()
         {
-            assertTrue("space returned false", Character.IsWhiteSpace('\n'));
-            assertTrue("non-space returned true", !Character.IsWhiteSpace('T'));
+            int[] javaGoodWhiteSpaceChars = new int[] {
+                0x0009,
+                0x000a, // '\n' 'T'
+                0x000b,
+                0x000c,
+                0x000d,
+                0x001c,
+                0x001d,
+                0x001e,
+                0x001f,
+                0x0020,
+                0x1680,
+                0x2000,
+                0x2001,
+                0x2002,
+                0x2003,
+                0x2004,
+                0x2005,
+                0x2006,
+                0x2008,
+                0x2009,
+                0x200a,
+                0x2028,
+                0x2029,
+                0x205f,
+                0x3000,
+            };
+
+            int[] javaBadWhiteSpaceChars = new int[] {
+                // These are official Unicode whitespace, but Java doesn't recognize them
+                0x0085,
+                0x00A0,
+                0x2007,
+                0x202F,
+
+                // From Harmony
+                'T',
+                0x110000, // Invalid Unicode code point
+                0xFEFF,
+
+                // Harmony bug
+                0x200b,
+            };
+
+            foreach (char c in javaGoodWhiteSpaceChars)
+            {
+                assertTrue($"0x{c:X4}", Character.IsWhiteSpace(c));
+            }
+
+            foreach (char c in javaBadWhiteSpaceChars)
+            {
+                assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
+            }
+
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                assertEquals($"0x{c:X4}", UChar.IsWhiteSpace((char)c), Character.IsWhiteSpace((char)c));
+            }
+
+            //assertTrue("space returned false", Character.IsWhiteSpace('\n'));
+            //assertTrue("non-space returned true", !Character.IsWhiteSpace('T'));
         }
 
         /**
@@ -2512,33 +2571,94 @@ namespace J2N
         [Test]
         public void Test_isWhitespace_I()
         {
-            assertTrue(Character.IsWhiteSpace((int)'\n'));
-            assertFalse(Character.IsWhiteSpace((int)'T'));
+            // J2N: Added more thorough tests because Harmony had differences from ICU4N
 
-            assertTrue(Character.IsWhiteSpace(0x0009));
-            assertTrue(Character.IsWhiteSpace(0x000A));
-            assertTrue(Character.IsWhiteSpace(0x000B));
-            assertTrue(Character.IsWhiteSpace(0x000C));
-            assertTrue(Character.IsWhiteSpace(0x000D));
-            assertTrue(Character.IsWhiteSpace(0x001C));
-            assertTrue(Character.IsWhiteSpace(0x001D));
-            assertTrue(Character.IsWhiteSpace(0x001F));
-            assertTrue(Character.IsWhiteSpace(0x001E));
+            int[] javaGoodWhiteSpaceChars = new int[] {
+                0x0009,
+                0x000a, // '\n' 'T'
+                0x000b,
+                0x000c,
+                0x000d,
+                0x001c,
+                0x001d,
+                0x001e,
+                0x001f,
+                0x0020,
+                0x1680,
+                0x2000,
+                0x2001,
+                0x2002,
+                0x2003,
+                0x2004,
+                0x2005,
+                0x2006,
+                0x2008,
+                0x2009,
+                0x200a,
+                0x2028,
+                0x2029,
+                0x205f,
+                0x3000,
+            };
 
-            assertTrue(Character.IsWhiteSpace(0x2000));
-            assertTrue(Character.IsWhiteSpace(0x200A));
+            int[] javaBadWhiteSpaceChars = new int[] {
+                // These are official Unicode whitespace, but Java doesn't recognize them
+                0x0085,
+                0x00A0,
+                0x2007,
+                0x202F,
 
-            assertTrue(Character.IsWhiteSpace(0x2028));
-            assertTrue(Character.IsWhiteSpace(0x2029));
+                // From Harmony
+                'T',
+                0x110000, // Invalid Unicode code point
+                0xFEFF,
 
-            assertFalse(Character.IsWhiteSpace(0x00A0));
-            assertFalse(Character.IsWhiteSpace(0x202F));
-            assertFalse(Character.IsWhiteSpace(0x110000));
+                // Harmony bug
+                0x200b,
+            };
 
-            assertFalse(Character.IsWhiteSpace(0xFEFF));
+            foreach (int c in javaGoodWhiteSpaceChars)
+            {
+                assertTrue($"0x{c:X4}", Character.IsWhiteSpace(c));
+            }
 
-            //FIXME depend on ICU4J
-            //assertFalse(Character.IsWhiteSpace(0x2007));
+            foreach (int c in javaBadWhiteSpaceChars)
+            {
+                assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
+            }
+
+            for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
+            {
+                assertEquals($"0x{c:X4}", UChar.IsWhiteSpace(c), Character.IsWhiteSpace(c));
+            }
+
+            //assertTrue(Character.IsWhiteSpace((int)'\n'));
+            //assertFalse(Character.IsWhiteSpace((int)'T'));
+
+            //assertTrue(Character.IsWhiteSpace(0x0009));
+            //assertTrue(Character.IsWhiteSpace(0x000A));
+            //assertTrue(Character.IsWhiteSpace(0x000B));
+            //assertTrue(Character.IsWhiteSpace(0x000C));
+            //assertTrue(Character.IsWhiteSpace(0x000D));
+            //assertTrue(Character.IsWhiteSpace(0x001C));
+            //assertTrue(Character.IsWhiteSpace(0x001D));
+            //assertTrue(Character.IsWhiteSpace(0x001F));
+            //assertTrue(Character.IsWhiteSpace(0x001E));
+
+            //assertTrue(Character.IsWhiteSpace(0x2000));
+            //assertTrue(Character.IsWhiteSpace(0x200A));
+
+            //assertTrue(Character.IsWhiteSpace(0x2028));
+            //assertTrue(Character.IsWhiteSpace(0x2029));
+
+            //assertFalse(Character.IsWhiteSpace(0x00A0));
+            //assertFalse(Character.IsWhiteSpace(0x202F));
+            //assertFalse(Character.IsWhiteSpace(0x110000));
+
+            //assertFalse(Character.IsWhiteSpace(0xFEFF));
+
+            ////FIXME depend on ICU4J
+            ////assertFalse(Character.IsWhiteSpace(0x2007));
 
         }
 


### PR DESCRIPTION
The JDK adds some Unicode whitespace characters, but doesn't follow the spec of any Unicode version. The .NET `System.Character.IsWhiteSpace()` method *does* follow the Unicode spec. This patches the method to behave like Java, although in most cases in practice it probably makes more sense to call `char.IsWhiteSpace()` and it is unlikely to make a difference in most cases.

Specifically, there are 4 Unicode characters that this method returns `false` on this method that return `true` in .NET, but otherwise it is an exact match:

1. 0x0085
2. 0x00A0
3. 0x2007
4. 0x202F
