### PR TITLE
J2N.Text.StringFormatter: Added constructor overload for IFormatProvider

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,7 +22,8 @@
 
   <!-- Features in .NET 5.x and .NET 6.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
-    
+
+    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_PREDEFINEDONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HASHSET_MODIFY_CONTINUEENUMERATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ICU</DefineConstants>
   

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -132,8 +132,6 @@
   <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
 
-    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTUICULTURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>

--- a/src/J2N/Text/StringFormatter.cs
+++ b/src/J2N/Text/StringFormatter.cs
@@ -52,16 +52,6 @@ namespace J2N.Text
         /// </summary>
         public static StringFormatter CurrentUICulture { get; } = new StringFormatter(CultureType.CurrentUICulture);
 
-        ///// <summary>
-        ///// Gets a <see cref="StringFormatter"/> that uses the default culture for threads in the current application domain to format values.
-        ///// </summary>
-        //public static StringFormatter DefaultThreadCurrentCulture { get; } = new StringFormatter(CultureType.DefaultThreadCurrentCulture);
-
-        ///// <summary>
-        ///// Gets a <see cref="StringFormatter"/> that uses the default UI culture for threads in the current application domain to format values.
-        ///// </summary>
-        //public static StringFormatter DefaultThreadCurrentUICulture { get; } = new StringFormatter(CultureType.DefaultThreadCurrentUICulture);
-
         /// <summary>
         /// Gets a <see cref="StringFormatter"/> that uses the invariant culture to format values.
         /// This is the default setting in Java.
@@ -116,14 +106,6 @@ namespace J2N.Text
                         return CultureInfo.CurrentCulture;
                     case CultureType.CurrentUICulture:
                         return CultureInfo.CurrentUICulture;
-#if FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE
-                    case CultureType.DefaultThreadCurrentCulture:
-                        return CultureInfo.DefaultThreadCurrentCulture ?? CultureInfo.CurrentCulture;
-#endif
-#if FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTUICULTURE
-                    case CultureType.DefaultThreadCurrentUICulture:
-                        return CultureInfo.DefaultThreadCurrentUICulture ?? CultureInfo.CurrentUICulture;
-#endif
                     default:
                         return CultureInfo.CurrentCulture;
                 }
@@ -134,8 +116,6 @@ namespace J2N.Text
         {
             CurrentCulture,
             CurrentUICulture,
-            DefaultThreadCurrentCulture,
-            DefaultThreadCurrentUICulture,
             InvariantCulture,
             CustomCulture
         }

--- a/tests/J2N.Tests/Text/TestStringFormatter.cs
+++ b/tests/J2N.Tests/Text/TestStringFormatter.cs
@@ -131,6 +131,16 @@ namespace J2N.Text
         public void TestDecimalPlaces_Double()
         {
             assertEquals("22.0", string.Format(StringFormatter.InvariantCulture, "{0}", 22d));
+
+            assertEquals("22,0", string.Format(new StringFormatter(new CultureInfo("fr-FR")), "{0}", 22d));
+        }
+
+        [Test]
+        public void TestIFormatProvider_Double()
+        {
+            assertEquals("22.0", string.Format((IFormatProvider)StringFormatter.InvariantCulture, "{0}", 22d));
+
+            assertEquals("22,0", string.Format(new StringFormatter((IFormatProvider)new CultureInfo("fr-FR")), "{0}", 22d));
         }
 
         [Test]


### PR DESCRIPTION
This supersedes #44, which targeted the wrong branch.

This adds a constructor overload accepting `IFormatProvider` to `StringFormatter`. Note that while `StringFormatter` is marked as `[Serializable]`, in .NET Core and newer platforms, none of the `IFormatProvider` implementations are serializable.

Since in Java, `Locale` is often used as a field and may be a field of a serializable class, we recommend refactoring the class to accept an `IFormatProvider` as a method argument rather than using a field, where possible. If that is not possible and serialization is required, it is recommended to create a custom `IFormatProvider` that wraps the .NET type in order to serialize and deserialize its state. Note that the `formatProvider` field in `StringFormatter` will automatically be serialized if serialization is supported by the class.

This also removes `FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE` and `FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTUICULTURE`, as these were not being used, anyway.