### PR TITLE
J2N.Numerics: Extended Span<char> support to net45 and netstandard2.0

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -11,6 +11,7 @@
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
     <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8-beta-0001</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <SystemMemoryPackageReferenceVersion>4.5.4</SystemMemoryPackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.5.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemTextEncodingCodePagesPackageReferenceVersion>4.3.0</SystemTextEncodingCodePagesPackageReferenceVersion>
     <XunitPackageReferenceVersion>2.4.1</XunitPackageReferenceVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <GitHubOrganization>NightOwl888</GitHubOrganization>
     <GitHubProject>J2N</GitHubProject>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,7 +70,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_OUTVALUE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRIMEXCESS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRYADD</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_NUMBER_PARSE_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_NUMBER_TRYFORMAT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_READONLYSPAN</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -65,16 +65,19 @@
     <!--<DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>-->
 
+    <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_CTOR_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_ENSURECAPACITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_OUTVALUE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRIMEXCESS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRYADD</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_NUMBER_PARSE_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPENDJOIN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_EQUALS_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_INSERT_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_WRITE_READONLYSPAN</DefineConstants>
 
   </PropertyGroup>
 
@@ -129,6 +132,9 @@
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -133,7 +133,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>

--- a/src/J2N/Collections/Generic/ArraySortHelper.cs
+++ b/src/J2N/Collections/Generic/ArraySortHelper.cs
@@ -31,7 +31,7 @@ namespace J2N.Collections.Generic
             // Add a try block here to detect bogus comparisons
             try
             {
-                IntrospectiveSort(keys, comparer);
+                IntrospectiveSort(keys, comparer!);
             }
             catch (IndexOutOfRangeException)
             {
@@ -71,7 +71,7 @@ namespace J2N.Collections.Generic
 
             if (keys.Length > 1)
             {
-                IntroSort(keys, 2 * (BitOperation.Log2((uint)keys.Length) + 1), comparer);
+                IntroSort(keys, 2 * (BitOperation.Log2((uint)keys.Length) + 1), comparer!);
             }
         }
 
@@ -89,33 +89,33 @@ namespace J2N.Collections.Generic
 
                     if (partitionSize == 2)
                     {
-                        SwapIfGreater(keys, comparer, 0, 1);
+                        SwapIfGreater(keys, comparer!, 0, 1);
                         return;
                     }
 
                     if (partitionSize == 3)
                     {
-                        SwapIfGreater(keys, comparer, 0, 1);
-                        SwapIfGreater(keys, comparer, 0, 2);
-                        SwapIfGreater(keys, comparer, 1, 2);
+                        SwapIfGreater(keys, comparer!, 0, 1);
+                        SwapIfGreater(keys, comparer!, 0, 2);
+                        SwapIfGreater(keys, comparer!, 1, 2);
                         return;
                     }
 
-                    InsertionSort(keys.Slice(0, partitionSize), comparer);
+                    InsertionSort(keys.Slice(0, partitionSize), comparer!);
                     return;
                 }
 
                 if (depthLimit == 0)
                 {
-                    HeapSort(keys.Slice(0, partitionSize), comparer);
+                    HeapSort(keys.Slice(0, partitionSize), comparer!);
                     return;
                 }
                 depthLimit--;
 
-                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), comparer);
+                int p = PickPivotAndPartition(keys.Slice(0, partitionSize), comparer!);
 
                 // Note we've already partitioned around the pivot and do not have to move the pivot again.
-                IntroSort(keys[(p + 1)..partitionSize], depthLimit, comparer);
+                IntroSort(keys[(p + 1)..partitionSize], depthLimit, comparer!);
                 partitionSize = p;
             }
         }
@@ -131,9 +131,9 @@ namespace J2N.Collections.Generic
             int middle = hi >> 1;
 
             // Sort lo, mid and hi appropriately, then pick mid as the pivot.
-            SwapIfGreater(keys, comparer, 0, middle);  // swap the low with the mid point
-            SwapIfGreater(keys, comparer, 0, hi);   // swap the low with the high
-            SwapIfGreater(keys, comparer, middle, hi); // swap the middle with the high
+            SwapIfGreater(keys, comparer!, 0, middle);  // swap the low with the mid point
+            SwapIfGreater(keys, comparer!, 0, hi);   // swap the low with the high
+            SwapIfGreater(keys, comparer!, middle, hi); // swap the middle with the high
 
             T pivot = keys[middle];
             Swap(keys, middle, hi - 1);
@@ -141,8 +141,8 @@ namespace J2N.Collections.Generic
 
             while (left < right)
             {
-                while (comparer(keys[++left], pivot) < 0) ;
-                while (comparer(pivot, keys[--right]) < 0) ;
+                while (comparer!(keys[++left], pivot) < 0) ;
+                while (comparer!(pivot, keys[--right]) < 0) ;
 
                 if (left >= right)
                     break;
@@ -166,13 +166,13 @@ namespace J2N.Collections.Generic
             int n = keys.Length;
             for (int i = n >> 1; i >= 1; i--)
             {
-                DownHeap(keys, i, n, 0, comparer);
+                DownHeap(keys, i, n, 0, comparer!);
             }
 
             for (int i = n; i > 1; i--)
             {
                 Swap(keys, 0, i - 1);
-                DownHeap(keys, 1, i - 1, 0, comparer);
+                DownHeap(keys, 1, i - 1, 0, comparer!);
             }
         }
 
@@ -186,12 +186,12 @@ namespace J2N.Collections.Generic
             while (i <= n >> 1)
             {
                 int child = 2 * i;
-                if (child < n && comparer(keys[lo + child - 1], keys[lo + child]) < 0)
+                if (child < n && comparer!(keys[lo + child - 1], keys[lo + child]) < 0)
                 {
                     child++;
                 }
 
-                if (!(comparer(d, keys[lo + child - 1]) < 0))
+                if (!(comparer!(d, keys[lo + child - 1]) < 0))
                     break;
 
                 keys[lo + i - 1] = keys[lo + child - 1];

--- a/src/J2N/DoubleExtensions.cs
+++ b/src/J2N/DoubleExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using J2N.Numerics;
+using J2N.Text;
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -323,7 +324,11 @@ namespace J2N
                     return string.Concat(negative ? info.NegativeSign : "", "0x0", info.NumberDecimalSeparator, "0p0"); //$NON-NLS-1$ //$NON-NLS-2$
             }
 
+#if FEATURE_SPAN
+            ValueStringBuilder hexString = new ValueStringBuilder(stackalloc char[32]);
+#else
             StringBuilder hexString = new StringBuilder(10);
+#endif
             if (negative)
             {
                 hexString.Append(info.NegativeSign);

--- a/src/J2N/Globalization/NumberStyle.cs
+++ b/src/J2N/Globalization/NumberStyle.cs
@@ -254,7 +254,7 @@ namespace J2N.Globalization
             // Check for undefined flags or invalid hex number flags.
             // Since we are cascading the call to .NET in this case, we must not allow any custom J2N flags here.
             if ((style & (~ValidNumberStyles | NumberStyle.AllowHexSpecifier)) != 0
-                && (style & ~NumberStyle.HexNumber) != 0)
+                && (style & ~NumberStyle.HexNumber) != 0) // J2N TODO: Allow AllowTypeSpecifier for integral types
             {
                 throwInvalid(style);
 

--- a/src/J2N/Globalization/NumberStyle.cs
+++ b/src/J2N/Globalization/NumberStyle.cs
@@ -132,12 +132,33 @@ namespace J2N.Globalization
 
         /// <summary>
         /// Indicates that the numeric string represents a number expressed as a
-        /// C# or Java literal string, such as <c>3.14159f</c> or <c>4.972135238332232d</c>.
-        /// This option only applies to floating point numbers <see cref="float"/> and <see cref="double"/>, however,
-        /// the real type suffix 'd', 'D', 'f', 'F', 'm' or 'M' are all valid for each floating point type.
-        /// If this option is used with <see cref="AllowHexSpecifier"/>, then 'd', 'D', 'f', or 'F' are all treated as
-        /// hexadecimal values unless an exponent (beginning with 'p') is also supplied (i.e. <c>0x1.8p1f</c>) so it must be
-        /// used in conjunction with <see cref="AllowExponent"/> for hexadecimal values.
+        /// C# or Java literal string, such as <c>3.14159f</c>, <c>145L</c> or <c>4.972135238332232d</c>.
+        /// This option applies to both floating point numbers and integral numbers.
+        /// The
+        /// <para/>
+        /// If this option is used without <see cref="AllowHexSpecifier"/>, the  type suffix
+        /// 'D', 'd', 'F', 'f', 'M', 'm', 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu'
+        /// are all valid for all numeric types.
+        /// <para/>
+        /// If this option is used with <see cref="AllowHexSpecifier"/>, the destination data type
+        /// determines the type specifiers that can be used.
+        /// <list type="table">
+        ///     <item>
+        ///         <term>Integral Types</term>
+        ///         <description>Only 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu' are allowed.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Floating Point Types</term>
+        ///         <description>'d', 'D', 'f', or 'F' are all treated as hexadecimal values unless an
+        ///         exponent (beginning with 'p') is also supplied (i.e. <c>0x1.8p1f</c>). In these cases,
+        ///         <see cref="AllowExponent"/> is also required.
+        ///         <para/>
+        ///         'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu' may be used as long as the
+        ///         numeric representation of the number does not contain a decimal point.
+        ///         </description>
+        ///     </item>
+        /// </list>
+        /// <para/>
         /// Note the type is simply ignored during the parse when you specify this option (which is how it works in Java).
         /// </summary>
         AllowTypeSpecifier = 0x00000400, // J2N specific
@@ -252,15 +273,14 @@ namespace J2N.Globalization
         internal static void ValidateParseStyleInteger(NumberStyle style)
         {
             // Check for undefined flags or invalid hex number flags.
-            // Since we are cascading the call to .NET in this case, we must not allow any custom J2N flags here.
-            if ((style & (~ValidNumberStyles | NumberStyle.AllowHexSpecifier)) != 0
-                && (style & ~NumberStyle.HexNumber) != 0) // J2N TODO: Allow AllowTypeSpecifier for integral types
+            if ((style & (~ValidNumberStyle | NumberStyle.AllowHexSpecifier)) != 0
+                && (style & ~(NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier)) != 0) // J2N: Note that we don't support AllowTypeSpecifier for hexadecimal integer types
             {
                 throwInvalid(style);
 
                 void throwInvalid(NumberStyle value)
                 {
-                    if ((value & ~ValidNumberStyles) != 0)
+                    if ((value & ~ValidNumberStyle) != 0)
                     {
                         throw new ArgumentException(J2N.SR.Format(SR.Argument_InvalidNumberStyle, value & ~ValidNumberStyles), nameof(style));
                     }

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -25,6 +25,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpPackageReferenceVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -3123,6 +3123,25 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatUInt32(value, format, provider, destination, out charsWritten);
+        }
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(byte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatUInt32(value, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region GetInstance (ValueOf)
 
         /// <summary>

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -469,7 +469,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -926,7 +926,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Byte
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1670,7 +1670,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1939,7 +1939,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -1961,7 +1961,7 @@ namespace J2N.Numerics
             return (byte)i;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="byte"/> equivalent.
         /// </summary>
@@ -2380,7 +2380,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
@@ -2396,7 +2396,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -1781,11 +1781,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1839,9 +1839,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -1900,6 +1920,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -1907,10 +1932,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -1992,11 +2019,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -2050,9 +2077,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2111,6 +2158,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -2118,10 +2170,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in style are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2209,11 +2263,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2265,8 +2319,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2327,7 +2401,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The type suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2353,10 +2428,12 @@ namespace J2N.Numerics
         /// The <see cref="NumberStyle"/> enum is a match in both symbol and value for the .NET <see cref="NumberStyles"/> enum.
         /// Therefore, simply casting the value will convert it properly between the two in both directions.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, s must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2436,11 +2513,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2492,8 +2569,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2554,7 +2651,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2582,10 +2680,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in <paramref name="style"/>
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -3126,14 +3126,36 @@ namespace J2N.Numerics
         #region TryFormat
 
 #if FEATURE_SPAN
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+
+        /// <summary>
+        /// Tries to format the value of the current 8-bit unsigned integer number instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatUInt32(value, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(byte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The 8-bit unsigned integer number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(byte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatUInt32(value, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -469,7 +469,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -926,7 +926,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Byte
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1670,7 +1670,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1938,7 +1938,7 @@ namespace J2N.Numerics
             NumberStyleExtensions.ValidateParseStyleInteger(style);
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
@@ -1961,7 +1961,7 @@ namespace J2N.Numerics
             return (byte)i;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="byte"/> equivalent.
         /// </summary>
@@ -2377,7 +2377,7 @@ namespace J2N.Numerics
                 return false;
             }
             // J2N: Allow negative sbyte values for compatibility, even though we return byte rather than sbyte
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
             if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
@@ -2396,7 +2396,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -1939,7 +1939,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -2380,7 +2380,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -469,7 +469,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -926,7 +926,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Byte
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="byte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1670,7 +1670,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1939,7 +1939,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -1961,7 +1961,7 @@ namespace J2N.Numerics
             return (byte)i;
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="byte"/> equivalent.
         /// </summary>
@@ -2380,7 +2380,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
@@ -2396,7 +2396,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit unsigned integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/DotNetNumber.Dragon4.cs
+++ b/src/J2N/Numerics/DotNetNumber.Dragon4.cs
@@ -113,8 +113,13 @@ namespace J2N.Numerics
         //  "Printing Floating-Point Numbers Quickly and Accurately"
         //    Burger and Dybvig
         //    http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.72.4656&rep=rep1&type=pdf
-        //private static unsafe uint Dragon4(ulong mantissa, int exponent, uint mantissaHighBitIdx, bool hasUnequalMargins, int cutoffNumber, bool isSignificantDigits, Span<byte> buffer, out int decimalExponent)
-        private static unsafe uint Dragon4(ulong mantissa, int exponent, uint mantissaHighBitIdx, bool hasUnequalMargins, int cutoffNumber, bool isSignificantDigits, byte[] buffer, out int decimalExponent)
+        private static unsafe uint Dragon4(ulong mantissa, int exponent, uint mantissaHighBitIdx, bool hasUnequalMargins, int cutoffNumber, bool isSignificantDigits,
+#if FEATURE_SPAN
+            Span<byte> buffer,
+#else
+            byte[] buffer,
+#endif
+            out int decimalExponent)
         {
             int curDigit = 0;
 

--- a/src/J2N/Numerics/DotNetNumber.Formatting.cs
+++ b/src/J2N/Numerics/DotNetNumber.Formatting.cs
@@ -429,7 +429,7 @@ namespace J2N.Numerics
             }
         }
 
-//#if FEATURE_READONLYSPAN
+//#if FEATURE_SPAN
 //        public static bool TryFormatDouble(double value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
 //        {
 //            //var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
@@ -679,7 +679,7 @@ namespace J2N.Numerics
             }
         }
 
-//#if FEATURE_READONLYSPAN
+//#if FEATURE_SPAN
 //        public static bool TryFormatSingle(float value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
 //        {
 //            //var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
@@ -852,7 +852,7 @@ namespace J2N.Numerics
         //        sb.TryCopyTo(destination, out charsWritten);
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         private static bool TryCopyTo(string source, Span<char> destination, out int charsWritten)
         {
             Debug.Assert(source != null);
@@ -1759,7 +1759,7 @@ namespace J2N.Numerics
         //    return true;
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
         {
             char c = default;
@@ -2816,7 +2816,7 @@ namespace J2N.Numerics
             }
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         private static unsafe int FindSection(ReadOnlySpan<char> format, int section)
         {
             int src;

--- a/src/J2N/Numerics/DotNetNumber.Formatting.cs
+++ b/src/J2N/Numerics/DotNetNumber.Formatting.cs
@@ -859,7 +859,7 @@ namespace J2N.Numerics
 
             if (source.AsSpan().TryCopyTo(destination))
             {
-                charsWritten = source.Length;
+                charsWritten = source!.Length;
                 return true;
             }
 
@@ -2055,6 +2055,7 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
             byte* dig = number.GetDigitsPointer();
+            {
 #else
             fixed (byte* digPtr = &number.Digits[0])
             {
@@ -2411,9 +2412,7 @@ namespace J2N.Numerics
                         }
                     }
                 }
-#if !FEATURE_SPAN
             }
-#endif
 
             if (number.IsNegative && (section == 0) && (number.Scale == 0) && (sb.Length > 0))
                 sb.Insert(0, info.NegativeSign);
@@ -2451,6 +2450,7 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
             byte* dig = number.GetDigitsPointer();
+            {
 #else
             fixed (byte* digPtr = &number.Digits[0])
             {
@@ -2566,9 +2566,7 @@ namespace J2N.Numerics
                         nMaxDigits--;
                     }
                 }
-#if !FEATURE_SPAN
             }
-#endif
         }
 
         private static void FormatNumber(ref ValueStringBuilder sb, ref NumberBuffer number, int nMaxDigits, NumberFormatInfo info)
@@ -2598,6 +2596,7 @@ namespace J2N.Numerics
         {
 #if FEATURE_SPAN
             byte* dig = number.GetDigitsPointer();
+            {
 #else
             fixed (byte* digPtr = &number.Digits[0])
             {
@@ -2611,9 +2610,7 @@ namespace J2N.Numerics
 
                 while (--nMaxDigits > 0)
                     sb.Append((*dig != 0) ? (char)(*dig++) : '0');
-#if !FEATURE_SPAN
             }
-#endif
 
             int e = number.Digits[0] == 0 ? 0 : number.Scale - 1;
             FormatExponent(ref sb, info, e, expChar, 3, true);
@@ -2670,6 +2667,7 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
             byte* dig = number.GetDigitsPointer();
+            {
 #else
             fixed (byte* digPtr = &number.Digits[0])
             {
@@ -2701,9 +2699,7 @@ namespace J2N.Numerics
                     while (*dig != 0)
                         sb.Append((char)(*dig++));
                 }
-#if !FEATURE_SPAN
             }
-#endif
 
             if (scientific)
                 FormatExponent(ref sb, info, number.Scale - 1, expChar, 2, true);
@@ -2739,6 +2735,7 @@ namespace J2N.Numerics
         {
 #if FEATURE_SPAN
             byte* dig = number.GetDigitsPointer();
+            {
 #else
             fixed (byte* digPtr = &number.Digits[0])
             {
@@ -2784,9 +2781,7 @@ namespace J2N.Numerics
                 dig[i] = (byte)('\0');
                 number.DigitsCount = i;
                 number.CheckConsistency();
-#if !FEATURE_SPAN
             }
-#endif
 
             static bool ShouldRoundUp(byte* dig, int i, NumberBufferKind numberKind, bool isCorrectlyRounded)
             {

--- a/src/J2N/Numerics/DotNetNumber.Formatting.cs
+++ b/src/J2N/Numerics/DotNetNumber.Formatting.cs
@@ -1263,56 +1263,59 @@ namespace J2N.Numerics
         //    }
         //}
 
-        //public static bool TryFormatInt32(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //{
-        //    // Fast path for default format
-        //    if (format.Length == 0)
-        //    {
-        //        return value >= 0 ?
-        //            TryUInt32ToDecStr((uint)value, digits: -1, destination, out charsWritten) :
-        //            TryNegativeInt32ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
-        //    }
+#if FEATURE_SPAN
+        public static bool TryFormatInt32(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+        {
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return value >= 0 ?
+                    TryUInt32ToDecStr((uint)value, digits: -1, destination, out charsWritten) :
+                    TryNegativeInt32ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
+            }
 
-        //    return TryFormatInt32Slow(value, hexMask, format, provider, destination, out charsWritten);
+            return TryFormatInt32Slow(value, hexMask, format, provider, destination, out charsWritten);
 
-        //    static unsafe bool TryFormatInt32Slow(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //    {
-        //        char fmt = ParseFormatSpecifier(format, out int digits);
-        //        char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
-        //        if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
-        //        {
-        //            return value >= 0 ?
-        //                TryUInt32ToDecStr((uint)value, digits, destination, out charsWritten) :
-        //                TryNegativeInt32ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
-        //        }
-        //        else if (fmtUpper == 'X')
-        //        {
-        //            return TryInt32ToHexStr(value & hexMask, GetHexBase(fmt), digits, destination, out charsWritten);
-        //        }
-        //        else
-        //        {
-        //            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+            static unsafe bool TryFormatInt32Slow(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+            {
+                char fmt = ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return value >= 0 ?
+                        TryUInt32ToDecStr((uint)value, digits, destination, out charsWritten) :
+                        TryNegativeInt32ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt32ToHexStr(value & hexMask, GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-        //            byte* pDigits = stackalloc byte[Int32NumberBufferLength];
-        //            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
+                    byte* pDigits = stackalloc byte[Int32NumberBufferLength];
+                    NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int32NumberBufferLength);
 
-        //            Int32ToNumber(value, ref number);
+                    Int32ToNumber(value, ref number);
 
-        //            char* stackPtr = stackalloc char[CharStackBufferSize];
-        //            ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
 
-        //            if (fmt != 0)
-        //            {
-        //                NumberToString(ref sb, ref number, fmt, digits, info);
-        //            }
-        //            else
-        //            {
-        //                NumberToStringFormat(ref sb, ref number, format, info);
-        //            }
-        //            return sb.TryCopyTo(destination, out charsWritten);
-        //        }
-        //    }
-        //}
+                    if (fmt != 0)
+                    {
+                        NumberToString(ref sb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        NumberToStringFormat(ref sb, ref number, format, info);
+                    }
+                    return sb.TryCopyTo(destination, out charsWritten);
+                }
+            }
+        }
+
+#endif
 
         //public static string FormatUInt32(uint value, string? format, IFormatProvider? provider)
         //{
@@ -1362,52 +1365,56 @@ namespace J2N.Numerics
         //    }
         //}
 
-        //public static bool TryFormatUInt32(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //{
-        //    // Fast path for default format
-        //    if (format.Length == 0)
-        //    {
-        //        return TryUInt32ToDecStr(value, digits: -1, destination, out charsWritten);
-        //    }
 
-        //    return TryFormatUInt32Slow(value, format, provider, destination, out charsWritten);
+#if FEATURE_SPAN
+        public static bool TryFormatUInt32(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+        {
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt32ToDecStr(value, digits: -1, destination, out charsWritten);
+            }
 
-        //    static unsafe bool TryFormatUInt32Slow(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //    {
-        //        char fmt = ParseFormatSpecifier(format, out int digits);
-        //        char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
-        //        if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
-        //        {
-        //            return TryUInt32ToDecStr(value, digits, destination, out charsWritten);
-        //        }
-        //        else if (fmtUpper == 'X')
-        //        {
-        //            return TryInt32ToHexStr((int)value, GetHexBase(fmt), digits, destination, out charsWritten);
-        //        }
-        //        else
-        //        {
-        //            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+            return TryFormatUInt32Slow(value, format, provider, destination, out charsWritten);
 
-        //            byte* pDigits = stackalloc byte[UInt32NumberBufferLength];
-        //            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
+            static unsafe bool TryFormatUInt32Slow(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+            {
+                char fmt = ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return TryUInt32ToDecStr(value, digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt32ToHexStr((int)value, GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-        //            UInt32ToNumber(value, ref number);
+                    byte* pDigits = stackalloc byte[UInt32NumberBufferLength];
+                    NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, UInt32NumberBufferLength);
 
-        //            char* stackPtr = stackalloc char[CharStackBufferSize];
-        //            ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                    UInt32ToNumber(value, ref number);
 
-        //            if (fmt != 0)
-        //            {
-        //                NumberToString(ref sb, ref number, fmt, digits, info);
-        //            }
-        //            else
-        //            {
-        //                NumberToStringFormat(ref sb, ref number, format, info);
-        //            }
-        //            return sb.TryCopyTo(destination, out charsWritten);
-        //        }
-        //    }
-        //}
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        NumberToString(ref sb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        NumberToStringFormat(ref sb, ref number, format, info);
+                    }
+                    return sb.TryCopyTo(destination, out charsWritten);
+                }
+            }
+        }
+
+#endif
 
         //public static string FormatInt64(long value, string? format, IFormatProvider? provider)
         //{
@@ -1461,56 +1468,60 @@ namespace J2N.Numerics
         //    }
         //}
 
-        //public static bool TryFormatInt64(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //{
-        //    // Fast path for default format
-        //    if (format.Length == 0)
-        //    {
-        //        return value >= 0 ?
-        //            TryUInt64ToDecStr((ulong)value, digits: -1, destination, out charsWritten) :
-        //            TryNegativeInt64ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
-        //    }
+#if FEATURE_SPAN
 
-        //    return TryFormatInt64Slow(value, format, provider, destination, out charsWritten);
+        public static bool TryFormatInt64(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+        {
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return value >= 0 ?
+                    TryUInt64ToDecStr((ulong)value, digits: -1, destination, out charsWritten) :
+                    TryNegativeInt64ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
+            }
 
-        //    static unsafe bool TryFormatInt64Slow(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
-        //    {
-        //        char fmt = ParseFormatSpecifier(format, out int digits);
-        //        char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
-        //        if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
-        //        {
-        //            return value >= 0 ?
-        //                TryUInt64ToDecStr((ulong)value, digits, destination, out charsWritten) :
-        //                TryNegativeInt64ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
-        //        }
-        //        else if (fmtUpper == 'X')
-        //        {
-        //            return TryInt64ToHexStr(value, GetHexBase(fmt), digits, destination, out charsWritten);
-        //        }
-        //        else
-        //        {
-        //            NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+            return TryFormatInt64Slow(value, format, provider, destination, out charsWritten);
 
-        //            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
-        //            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
+            static unsafe bool TryFormatInt64Slow(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<char> destination, out int charsWritten)
+            {
+                char fmt = ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return value >= 0 ?
+                        TryUInt64ToDecStr((ulong)value, digits, destination, out charsWritten) :
+                        TryNegativeInt64ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSign, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt64ToHexStr(value, GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
 
-        //            Int64ToNumber(value, ref number);
+                    byte* pDigits = stackalloc byte[Int64NumberBufferLength];
+                    NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
-        //            char* stackPtr = stackalloc char[CharStackBufferSize];
-        //            ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+                    Int64ToNumber(value, ref number);
 
-        //            if (fmt != 0)
-        //            {
-        //                NumberToString(ref sb, ref number, fmt, digits, info);
-        //            }
-        //            else
-        //            {
-        //                NumberToStringFormat(ref sb, ref number, format, info);
-        //            }
-        //            return sb.TryCopyTo(destination, out charsWritten);
-        //        }
-        //    }
-        //}
+                    char* stackPtr = stackalloc char[CharStackBufferSize];
+                    ValueStringBuilder sb = new ValueStringBuilder(new Span<char>(stackPtr, CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        NumberToString(ref sb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        NumberToStringFormat(ref sb, ref number, format, info);
+                    }
+                    return sb.TryCopyTo(destination, out charsWritten);
+                }
+            }
+        }
+
+#endif
 
         //public static string FormatUInt64(ulong value, string? format, IFormatProvider? provider)
         //{
@@ -1607,36 +1618,42 @@ namespace J2N.Numerics
         //    }
         //}
 
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
-        //private static unsafe void Int32ToNumber(int value, ref NumberBuffer number)
-        //{
-        //    number.DigitsCount = Int32Precision;
+#if FEATURE_SPAN // J2N: GetDigitsPointer() would need to be reworked to support net40, but this overload is only called by TryFormat for now
 
-        //    if (value >= 0)
-        //    {
-        //        number.IsNegative = false;
-        //    }
-        //    else
-        //    {
-        //        number.IsNegative = true;
-        //        value = -value;
-        //    }
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
+#endif
+        private static unsafe void Int32ToNumber(int value, ref NumberBuffer number)
+        {
+            number.DigitsCount = Int32Precision;
 
-        //    byte* buffer = number.GetDigitsPointer();
-        //    byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
+            if (value >= 0)
+            {
+                number.IsNegative = false;
+            }
+            else
+            {
+                number.IsNegative = true;
+                value = -value;
+            }
 
-        //    int i = (int)(buffer + Int32Precision - p);
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = UInt32ToDecChars(buffer + Int32Precision, (uint)value, 0);
 
-        //    number.DigitsCount = i;
-        //    number.Scale = i;
+            int i = (int)(buffer + Int32Precision - p);
 
-        //    byte* dst = number.GetDigitsPointer();
-        //    while (--i >= 0)
-        //        *dst++ = *p++;
-        //    *dst = (byte)('\0');
+            number.DigitsCount = i;
+            number.Scale = i;
 
-        //    number.CheckConsistency();
-        //}
+            byte* dst = number.GetDigitsPointer();
+            while (--i >= 0)
+                *dst++ = *p++;
+            *dst = (byte)('\0');
+
+            number.CheckConsistency();
+        }
+
+#endif
 
         //public static string Int32ToDecStr(int value)
         //{
@@ -1668,34 +1685,38 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryNegativeInt32ToDecStr(int value, int digits, string sNegative, Span<char> destination, out int charsWritten)
-        //{
-        //    Debug.Assert(value < 0);
+#if FEATURE_SPAN
 
-        //    if (digits < 1)
-        //        digits = 1;
+        private static unsafe bool TryNegativeInt32ToDecStr(int value, int digits, string sNegative, Span<char> destination, out int charsWritten)
+        {
+            Debug.Assert(value < 0);
 
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((uint)(-value))) + sNegative.Length;
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+            if (digits < 1)
+                digits = 1;
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = UInt32ToDecChars(buffer + bufferLength, (uint)(-value), digits);
-        //        Debug.Assert(p == buffer + sNegative.Length);
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((uint)(-value))) + sNegative.Length;
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //        for (int i = sNegative.Length - 1; i >= 0; i--)
-        //        {
-        //            *(--p) = sNegative[i];
-        //        }
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = UInt32ToDecChars(buffer + bufferLength, (uint)(-value), digits);
+                Debug.Assert(p == buffer + sNegative.Length);
+
+                for (int i = sNegative.Length - 1; i >= 0; i--)
+                {
+                    *(--p) = sNegative[i];
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+#endif
 
         //private static unsafe string Int32ToHexStr(int value, char hexBase, int digits)
         //{
@@ -1712,69 +1733,76 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryInt32ToHexStr(int value, char hexBase, int digits, Span<char> destination, out int charsWritten)
-        //{
-        //    if (digits < 1)
-        //        digits = 1;
+#if FEATURE_SPAN
 
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((uint)value));
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+        private static unsafe bool TryInt32ToHexStr(int value, char hexBase, int digits, Span<char> destination, out int charsWritten)
+        {
+            if (digits < 1)
+                digits = 1;
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = Int32ToHexChars(buffer + bufferLength, (uint)value, hexBase, digits);
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((uint)value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //private static unsafe char* Int32ToHexChars(char* buffer, uint value, int hexBase, int digits)
-        //{
-        //    while (--digits >= 0 || value != 0)
-        //    {
-        //        byte digit = (byte)(value & 0xF);
-        //        *(--buffer) = (char)(digit + (digit < 10 ? (byte)'0' : hexBase));
-        //        value >>= 4;
-        //    }
-        //    return buffer;
-        //}
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = Int32ToHexChars(buffer + bufferLength, (uint)value, hexBase, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+#endif
 
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
-        //private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
-        //{
-        //    number.DigitsCount = UInt32Precision;
-        //    number.IsNegative = false;
+        private static unsafe char* Int32ToHexChars(char* buffer, uint value, int hexBase, int digits)
+        {
+            while (--digits >= 0 || value != 0)
+            {
+                byte digit = (byte)(value & 0xF);
+                *(--buffer) = (char)(digit + (digit < 10 ? (byte)'0' : hexBase));
+                value >>= 4;
+            }
+            return buffer;
+        }
 
-        //    byte* buffer = number.GetDigitsPointer();
-        //    byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
+#if FEATURE_SPAN // J2N: GetDigitsPointer() would need to be reworked for older platforms, but this method is only called by TryFormat for now
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
+#endif
+        private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
+        {
+            number.DigitsCount = UInt32Precision;
+            number.IsNegative = false;
 
-        //    int i = (int)(buffer + UInt32Precision - p);
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = UInt32ToDecChars(buffer + UInt32Precision, value, 0);
 
-        //    number.DigitsCount = i;
-        //    number.Scale = i;
+            int i = (int)(buffer + UInt32Precision - p);
 
-        //    byte* dst = number.GetDigitsPointer();
-        //    while (--i >= 0)
-        //        *dst++ = *p++;
-        //    *dst = (byte)('\0');
+            number.DigitsCount = i;
+            number.Scale = i;
 
-        //    number.CheckConsistency();
-        //}
+            byte* dst = number.GetDigitsPointer();
+            while (--i >= 0)
+                *dst++ = *p++;
+            *dst = (byte)('\0');
 
-        //internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value, int digits)
-        //{
-        //    while (--digits >= 0 || value != 0)
-        //    {
-        //        value = MathExtensions.DivRem(value, 10, out uint remainder);
-        //        *(--bufferEnd) = (byte)(remainder + '0');
-        //    }
-        //    return bufferEnd;
-        //}
+            number.CheckConsistency();
+        }
+#endif
+
+        internal static unsafe byte* UInt32ToDecChars(byte* bufferEnd, uint value, int digits)
+        {
+            while (--digits >= 0 || value != 0)
+            {
+                value = MathExtensions.DivRem(value, 10, out uint remainder);
+                *(--bufferEnd) = (byte)(remainder + '0');
+            }
+            return bufferEnd;
+        }
 
         internal static unsafe char* UInt32ToDecChars(char* bufferEnd, uint value, int digits)
         {
@@ -1828,65 +1856,71 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryUInt32ToDecStr(uint value, int digits, Span<char> destination, out int charsWritten)
-        //{
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+#if FEATURE_SPAN
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = buffer + bufferLength;
-        //        if (digits <= 1)
-        //        {
-        //            do
-        //            {
-        //                value = Math.DivRem(value, 10, out uint remainder);
-        //                *(--p) = (char)(remainder + '0');
-        //            }
-        //            while (value != 0);
-        //        }
-        //        else
-        //        {
-        //            p = UInt32ToDecChars(p, value, digits);
-        //        }
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+        private static unsafe bool TryUInt32ToDecStr(uint value, int digits, Span<char> destination, out int charsWritten)
+        {
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //private static unsafe void Int64ToNumber(long input, ref NumberBuffer number)
-        //{
-        //    ulong value = (ulong)input;
-        //    number.IsNegative = input < 0;
-        //    number.DigitsCount = Int64Precision;
-        //    if (number.IsNegative)
-        //    {
-        //        value = (ulong)(-input);
-        //    }
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = buffer + bufferLength;
+                if (digits <= 1)
+                {
+                    do
+                    {
+                        value = MathExtensions.DivRem(value, 10, out uint remainder);
+                        *(--p) = (char)(remainder + '0');
+                    }
+                    while (value != 0);
+                }
+                else
+                {
+                    p = UInt32ToDecChars(p, value, digits);
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
 
-        //    byte* buffer = number.GetDigitsPointer();
-        //    byte* p = buffer + Int64Precision;
-        //    while (High32(value) != 0)
-        //        p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-        //    p = UInt32ToDecChars(p, Low32(value), 0);
+#endif
 
-        //    int i = (int)(buffer + Int64Precision - p);
+#if FEATURE_SPAN // J2N: GetDigitsPointer() would need to be reworked to support net40, but this overload is only called by TryFormat for now
+        private static unsafe void Int64ToNumber(long input, ref NumberBuffer number)
+        {
+            ulong value = (ulong)input;
+            number.IsNegative = input < 0;
+            number.DigitsCount = Int64Precision;
+            if (number.IsNegative)
+            {
+                value = (ulong)(-input);
+            }
 
-        //    number.DigitsCount = i;
-        //    number.Scale = i;
+            byte* buffer = number.GetDigitsPointer();
+            byte* p = buffer + Int64Precision;
+            while (High32(value) != 0)
+                p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
+            p = UInt32ToDecChars(p, Low32(value), 0);
 
-        //    byte* dst = number.GetDigitsPointer();
-        //    while (--i >= 0)
-        //        *dst++ = *p++;
-        //    *dst = (byte)('\0');
+            int i = (int)(buffer + Int64Precision - p);
 
-        //    number.CheckConsistency();
-        //}
+            number.DigitsCount = i;
+            number.Scale = i;
+
+            byte* dst = number.GetDigitsPointer();
+            while (--i >= 0)
+                *dst++ = *p++;
+            *dst = (byte)('\0');
+
+            number.CheckConsistency();
+        }
+#endif
 
         //public static string Int64ToDecStr(long value)
         //{
@@ -1928,44 +1962,48 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryNegativeInt64ToDecStr(long input, int digits, string sNegative, Span<char> destination, out int charsWritten)
-        //{
-        //    Debug.Assert(input < 0);
+#if FEATURE_SPAN
 
-        //    if (digits < 1)
-        //    {
-        //        digits = 1;
-        //    }
+        private static unsafe bool TryNegativeInt64ToDecStr(long input, int digits, string sNegative, Span<char> destination, out int charsWritten)
+        {
+            Debug.Assert(input < 0);
 
-        //    ulong value = (ulong)(-input);
+            if (digits < 1)
+            {
+                digits = 1;
+            }
 
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-input))) + sNegative.Length;
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+            ulong value = (ulong)(-input);
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = buffer + bufferLength;
-        //        while (High32(value) != 0)
-        //        {
-        //            p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-        //            digits -= 9;
-        //        }
-        //        p = UInt32ToDecChars(p, Low32(value), digits);
-        //        Debug.Assert(p == buffer + sNegative.Length);
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-input))) + sNegative.Length;
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //        for (int i = sNegative.Length - 1; i >= 0; i--)
-        //        {
-        //            *(--p) = sNegative[i];
-        //        }
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = buffer + bufferLength;
+                while (High32(value) != 0)
+                {
+                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
+                    digits -= 9;
+                }
+                p = UInt32ToDecChars(p, Low32(value), digits);
+                Debug.Assert(p == buffer + sNegative.Length);
+
+                for (int i = sNegative.Length - 1; i >= 0; i--)
+                {
+                    *(--p) = sNegative[i];
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+#endif
 
         //private static unsafe string Int64ToHexStr(long value, char hexBase, int digits)
         //{
@@ -1988,32 +2026,35 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryInt64ToHexStr(long value, char hexBase, int digits, Span<char> destination, out int charsWritten)
-        //{
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((ulong)value));
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+#if FEATURE_SPAN
+        private static unsafe bool TryInt64ToHexStr(long value, char hexBase, int digits, Span<char> destination, out int charsWritten)
+        {
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((ulong)value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = buffer + bufferLength;
-        //        if (High32((ulong)value) != 0)
-        //        {
-        //            p = Int32ToHexChars(p, Low32((ulong)value), hexBase, 8);
-        //            p = Int32ToHexChars(p, High32((ulong)value), hexBase, digits - 8);
-        //        }
-        //        else
-        //        {
-        //            p = Int32ToHexChars(p, Low32((ulong)value), hexBase, Math.Max(digits, 1));
-        //        }
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = buffer + bufferLength;
+                if (High32((ulong)value) != 0)
+                {
+                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, 8);
+                    p = Int32ToHexChars(p, High32((ulong)value), hexBase, digits - 8);
+                }
+                else
+                {
+                    p = Int32ToHexChars(p, Low32((ulong)value), hexBase, Math.Max(digits, 1));
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+#endif
 
         //private static unsafe void UInt64ToNumber(ulong value, ref NumberBuffer number)
         //{
@@ -2068,32 +2109,35 @@ namespace J2N.Numerics
         //    return result;
         //}
 
-        //private static unsafe bool TryUInt64ToDecStr(ulong value, int digits, Span<char> destination, out int charsWritten)
-        //{
-        //    if (digits < 1)
-        //        digits = 1;
+#if FEATURE_SPAN
+        private static unsafe bool TryUInt64ToDecStr(ulong value, int digits, Span<char> destination, out int charsWritten)
+        {
+            if (digits < 1)
+                digits = 1;
 
-        //    int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
-        //    if (bufferLength > destination.Length)
-        //    {
-        //        charsWritten = 0;
-        //        return false;
-        //    }
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
 
-        //    charsWritten = bufferLength;
-        //    fixed (char* buffer = &MemoryMarshal.GetReference(destination))
-        //    {
-        //        char* p = buffer + bufferLength;
-        //        while (High32(value) != 0)
-        //        {
-        //            p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
-        //            digits -= 9;
-        //        }
-        //        p = UInt32ToDecChars(p, Low32(value), digits);
-        //        Debug.Assert(p == buffer);
-        //    }
-        //    return true;
-        //}
+            charsWritten = bufferLength;
+            fixed (char* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                char* p = buffer + bufferLength;
+                while (High32(value) != 0)
+                {
+                    p = UInt32ToDecChars(p, Int64DivMod1E9(ref value), 9);
+                    digits -= 9;
+                }
+                p = UInt32ToDecChars(p, Low32(value), digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+#endif
 
 #if FEATURE_SPAN
         internal static unsafe char ParseFormatSpecifier(ReadOnlySpan<char> format, out int digits)
@@ -3236,16 +3280,16 @@ namespace J2N.Numerics
             }
         }
 
-        //private static uint Low32(ulong value) => (uint)value;
+        private static uint Low32(ulong value) => (uint)value;
 
-        //private static uint High32(ulong value) => (uint)((value & 0xFFFFFFFF00000000) >> 32);
+        private static uint High32(ulong value) => (uint)((value & 0xFFFFFFFF00000000) >> 32);
 
-        //private static uint Int64DivMod1E9(ref ulong value)
-        //{
-        //    uint rem = (uint)(value % 1000000000);
-        //    value /= 1000000000;
-        //    return rem;
-        //}
+        private static uint Int64DivMod1E9(ref ulong value)
+        {
+            uint rem = (uint)(value % 1000000000);
+            value /= 1000000000;
+            return rem;
+        }
 
         private static ulong ExtractFractionAndBiasedExponent(double value, out int exponent)
         {

--- a/src/J2N/Numerics/DotNetNumber.Grisu3.cs
+++ b/src/J2N/Numerics/DotNetNumber.Grisu3.cs
@@ -424,7 +424,7 @@ namespace J2N.Numerics
                 return result;
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // The counted version of Grisu3 only generates requestedDigits number of digits.
             // This version does not generate the shortest representation, and with enough requested digits 0.1 will at some point print as 0.9999999...
             // Grisu3 is too imprecise for real halfway cases (1.5 will not work) and therefore the rounding strategy for halfway cases is irrelevant.
@@ -503,7 +503,7 @@ namespace J2N.Numerics
                 return result;
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // Provides a decimal representation of v.
             // Returns true if it succeeds; otherwise, the result cannot be trusted.
             //
@@ -656,7 +656,7 @@ namespace J2N.Numerics
                 return power;
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // Generates (at most) requestedDigits of input number w.
             //
             // w is a floating-point number (DiyFp), consisting of a significand and an exponent.
@@ -950,7 +950,7 @@ namespace J2N.Numerics
             }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
             // Generates the digits of input number w.
             //
@@ -1327,7 +1327,7 @@ namespace J2N.Numerics
                 return new DiyFp(s_CachedPowersSignificand[index], s_CachedPowersBinaryExponent[index]);
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // Rounds the buffer upwards if the result is closer to v by possibly adding 1 to the buffer.
             // If the precision of the calculation is not sufficient to round correctly, return false.
             //
@@ -1467,7 +1467,7 @@ namespace J2N.Numerics
                 return false;
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // Adjusts the last digit of the generated number and screens out generated solutions that may be inaccurate.
             // A solution may be inaccurate if it is outside the safe interval or if we cannot provide that it is closer to the input than a neighboring representation of the same length.
             //

--- a/src/J2N/Numerics/DotNetNumber.NumberBuffer.cs
+++ b/src/J2N/Numerics/DotNetNumber.NumberBuffer.cs
@@ -27,8 +27,11 @@ namespace J2N.Numerics
             public bool IsNegative;
             public bool HasNonZeroTail;
             public NumberBufferKind Kind;
-            //public Span<byte> Digits;
+#if FEATURE_SPAN
+            public Span<byte> Digits;
+#else
             public byte[] Digits;
+#endif
 
             public NumberBuffer(NumberBufferKind kind, byte* digits, int digitsLength)
             {
@@ -40,15 +43,21 @@ namespace J2N.Numerics
                 IsNegative = false;
                 HasNonZeroTail = false;
                 Kind = kind;
-                //Digits = new Span<byte>(digits, digitsLength);
+#if FEATURE_SPAN
+                Digits = new Span<byte>(digits, digitsLength);
+#else
                 Digits = new byte[digitsLength];
                 for (int i = 0; i < digitsLength; i++)
                 {
                     Digits[i] = digits[i];
                 }
+#endif
 #if DEBUG
-                //Digits.Fill(0xCC);
+#if FEATURE_SPAN
+                Digits.Fill(0xCC);
+#else
                 Digits.Fill<byte>(0xCC);
+#endif
 #endif
 
                 Digits[0] = (byte)('\0');
@@ -80,11 +89,13 @@ namespace J2N.Numerics
 #endif // DEBUG
             }
 
-            //public byte* GetDigitsPointer()
-            //{
-            //    // This is safe to do since we are a ref struct
-            //    return (byte*)(Unsafe.AsPointer(ref Digits[0]));
-            //}
+#if FEATURE_SPAN
+            public byte* GetDigitsPointer()
+            {
+                // This is safe to do since we are a ref struct
+                return (byte*)(Unsafe.AsPointer(ref Digits[0]));
+            }
+#endif
 
             //
             // Code coverage note: This only exists so that Number displays nicely in the VS watch window. So yes, I know it works.

--- a/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
+++ b/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
@@ -148,8 +148,11 @@ namespace J2N.Numerics
         {
             BigInteger.SetZero(out result);
 
-            //byte* src = number.GetDigitsPointer() + firstIndex;
+#if FEATURE_SPAN
+            byte* src = number.GetDigitsPointer() + firstIndex;
+#else
             fixed (byte* src = &number.Digits[firstIndex])
+#endif
             {
                 uint remaining = lastIndex - firstIndex;
                 uint offset = 0;

--- a/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
+++ b/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
@@ -438,8 +438,9 @@ namespace J2N.Numerics
             // computed to the infinitely precise result and then rounded, which means that
             // we can rely on it to produce the correct result when both inputs are exact.
 
-            //byte* src = number.GetDigitsPointer();
-            //byte[] src = number.Digits;
+#if FEATURE_SPAN
+            byte* src = number.GetDigitsPointer();
+#endif
 
             if ((info.DenormalMantissaBits <= 23) && (totalDigits <= 7) && (fastExponent <= 10))
             {
@@ -448,8 +449,12 @@ namespace J2N.Numerics
                 // wrong value when upcasting to double.
 
                 float result;
+#if !FEATURE_SPAN
                 fixed (byte* src = &number.Digits[0])
+#endif
+                {
                     result = DigitsToUInt32(src, (int)(totalDigits));
+                }
                 float scale = s_Pow10SingleTable[fastExponent];
 
                 if (fractionalDigitsPresent != 0)
@@ -471,8 +476,12 @@ namespace J2N.Numerics
             if ((totalDigits <= 15) && (fastExponent <= 22))
             {
                 double result;
+#if !FEATURE_SPAN
                 fixed (byte* src = &number.Digits[0])
+#endif
+                {
                     result = DigitsToUInt64(src, (int)(totalDigits));
+                }
                 double scale = s_Pow10DoubleTable[fastExponent];
 
                 if (fractionalDigitsPresent != 0)

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -835,7 +835,7 @@ namespace J2N.Numerics
             return false;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -885,7 +885,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         private static unsafe ParsingStatus TryParseInt32Number(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             result = 0;
@@ -924,7 +924,7 @@ namespace J2N.Numerics
             return ParsingStatus.OK;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>Parses int limited to styles that make up NumberStyle.Integer.</summary>
         internal static ParsingStatus TryParseInt32IntegerStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
@@ -1916,7 +1916,7 @@ namespace J2N.Numerics
         //    goto DoneAtEndButPotentialOverflow;
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>Parses uint limited to styles that make up NumberStyle.HexNumber.</summary>
         private static ParsingStatus TryParseUInt32HexNumberStyle(ReadOnlySpan<char> value, NumberStyle styles, out uint result)
         {
@@ -2769,7 +2769,7 @@ namespace J2N.Numerics
         //    return true;
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static double ParseDouble(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         {
             if (!TryParseDouble(value, styles, info, out double result))
@@ -2791,7 +2791,7 @@ namespace J2N.Numerics
             return result;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static float ParseSingle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         {
             if (!TryParseSingle(value, styles, info, out float result))
@@ -2843,7 +2843,7 @@ namespace J2N.Numerics
         //    return ParsingStatus.OK;
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryParseDouble(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out double result)
         {
             if ((styles & NumberStyle.AllowHexSpecifier) != 0)
@@ -2865,7 +2865,7 @@ namespace J2N.Numerics
             return TryParseDoubleFloatStyle(value, styles & ~NumberStyle.AllowHexSpecifier, info, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryParseDoubleFloatStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out double result)
         {
             byte* pDigits = stackalloc byte[DoubleNumberBufferLength];
@@ -2991,7 +2991,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         internal static unsafe bool TryParseDoubleHexFloatStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out double result)
         {
@@ -3189,7 +3189,7 @@ namespace J2N.Numerics
         //    return true;
         //}
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryParseSingle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out float result)
         {
             if ((styles & NumberStyle.AllowHexSpecifier) != 0)
@@ -3212,7 +3212,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryParseSingleFloatStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out float result)
         {
             byte* pDigits = stackalloc byte[SingleNumberBufferLength];
@@ -3348,7 +3348,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         internal static unsafe bool TryParseSingleHexFloatStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out float result)
         {
@@ -3489,7 +3489,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryStringToNumber(ReadOnlySpan<char> value, NumberStyle styles, ref NumberBuffer number, NumberFormatInfo info)
         {
             Debug.Assert(info != null);
@@ -3526,7 +3526,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         internal static unsafe bool TryStringToFloatingPointHexNumber(ReadOnlySpan<char> value, NumberStyle styles, FloatingPointHexNumberBuffer number, NumberFormatInfo info)
         {
             Debug.Assert(info != null);
@@ -3563,7 +3563,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         private static bool TrailingZeros(ReadOnlySpan<char> value, int index)
         {
             // For compatibility, we need to allow trailing zeros at the end of a number string
@@ -3760,7 +3760,7 @@ namespace J2N.Numerics
 
     internal static class MemoryExtensions
     {
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         // From MemoryExtensions class in .NET Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool EqualsOrdinalIgnoreCase(this ReadOnlySpan<char> span, ReadOnlySpan<char> value)
@@ -3775,7 +3775,7 @@ namespace J2N.Numerics
 
         // J2N: For now, we are just calling this on .NET Standard 2.1+
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         // From Ordinal class in .NET Runtime
         internal static unsafe bool EqualsIgnoreCase(ref char charA, ReadOnlySpan<char> spanA, ref char charB, ReadOnlySpan<char> spanB, int length)
         {

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -3,7 +3,6 @@
 
 using J2N.Globalization;
 using System;
-using System.CodeDom;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -58,14 +57,10 @@ namespace J2N.Numerics
                 return false;
             }
             int n = 0;
-#if FEATURE_SPAN
-            byte* p = number.GetDigitsPointer();
-            {
-#else
+            //byte* p = number.GetDigitsPointer();
             fixed (byte* dp = &number.Digits[0])
             {
                 byte* p = dp;
-#endif
                 Debug.Assert(p != null);
                 while (--i >= 0)
                 {
@@ -99,56 +94,48 @@ namespace J2N.Numerics
             return true;
         }
 
-        private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
-        {
-            number.CheckConsistency();
+        //private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
+        //{
+        //    number.CheckConsistency();
 
-            int i = number.Scale;
-            if (i > Int64Precision || i < number.DigitsCount)
-            {
-                return false;
-            }
-            long n = 0;
-#if FEATURE_SPAN
-            byte* p = number.GetDigitsPointer();
-            {
-#else
-            fixed (byte* dp = &number.Digits[0])
-            {
-                byte* p = dp;
-#endif
-                Debug.Assert(p != null);
-                while (--i >= 0)
-                {
-                    if ((ulong)n > (0x7FFFFFFFFFFFFFFF / 10))
-                    {
-                        return false;
-                    }
-                    n *= 10;
-                    if (*p != '\0')
-                    {
-                        n += (*p++ - '0');
-                    }
-                }
-            }
-            if (number.IsNegative)
-            {
-                n = -n;
-                if (n > 0)
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                if (n < 0)
-                {
-                    return false;
-                }
-            }
-            value = n;
-            return true;
-        }
+        //    int i = number.Scale;
+        //    if (i > Int64Precision || i < number.DigitsCount)
+        //    {
+        //        return false;
+        //    }
+        //    byte* p = number.GetDigitsPointer();
+        //    Debug.Assert(p != null);
+        //    long n = 0;
+        //    while (--i >= 0)
+        //    {
+        //        if ((ulong)n > (0x7FFFFFFFFFFFFFFF / 10))
+        //        {
+        //            return false;
+        //        }
+        //        n *= 10;
+        //        if (*p != '\0')
+        //        {
+        //            n += (*p++ - '0');
+        //        }
+        //    }
+        //    if (number.IsNegative)
+        //    {
+        //        n = -n;
+        //        if (n > 0)
+        //        {
+        //            return false;
+        //        }
+        //    }
+        //    else
+        //    {
+        //        if (n < 0)
+        //        {
+        //            return false;
+        //        }
+        //    }
+        //    value = n;
+        //    return true;
+        //}
 
         //private static unsafe bool TryNumberToUInt32(ref NumberBuffer number, ref uint value)
         //{
@@ -218,70 +205,27 @@ namespace J2N.Numerics
         //    return true;
         //}
 
-#if FEATURE_SPAN
+        //internal static int ParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
+        //{
+        //    ParsingStatus status = TryParseInt32(value, styles, info, out int result);
+        //    if (status != ParsingStatus.OK)
+        //    {
+        //        ThrowOverflowOrFormatException(status, TypeCode.Int32);
+        //    }
 
-        internal static int ParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
-        {
-            ParsingStatus status = TryParseInt32(value, styles, info, out int result);
-            if (status != ParsingStatus.OK)
-            {
-                if (status == ParsingStatus.Overflow)
-                    ThrowOverflowException(TypeCode.Int32);
-                else
-                    ThrowFormatException(value.ToString());
-            }
+        //    return result;
+        //}
 
-            return result;
-        }
+        //internal static long ParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
+        //{
+        //    ParsingStatus status = TryParseInt64(value, styles, info, out long result);
+        //    if (status != ParsingStatus.OK)
+        //    {
+        //        ThrowOverflowOrFormatException(status, TypeCode.Int64);
+        //    }
 
-#endif
-
-        internal static int ParseInt32(string value, NumberStyle styles, NumberFormatInfo info)
-        {
-            ParsingStatus status = TryParseInt32(value, styles, info, out int result);
-            if (status != ParsingStatus.OK)
-            {
-                if (status == ParsingStatus.Overflow)
-                    ThrowOverflowException(TypeCode.Int32);
-                else
-                    ThrowFormatException(value);
-            }
-
-            return result;
-        }
-
-
-#if FEATURE_SPAN
-
-        internal static long ParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
-        {
-            ParsingStatus status = TryParseInt64(value, styles, info, out long result);
-            if (status != ParsingStatus.OK)
-            {
-                if (status == ParsingStatus.Overflow)
-                    ThrowOverflowException(TypeCode.Int64);
-                else
-                    ThrowFormatException(value.ToString());
-            }
-
-            return result;
-        }
-
-#endif
-
-        internal static long ParseInt64(string value, NumberStyle styles, NumberFormatInfo info)
-        {
-            ParsingStatus status = TryParseInt64(value, styles, info, out long result);
-            if (status != ParsingStatus.OK)
-            {
-                if (status == ParsingStatus.Overflow)
-                    ThrowOverflowException(TypeCode.Int64);
-                else
-                    ThrowFormatException(value.ToString());
-            }
-
-            return result;
-        }
+        //    return result;
+        //}
 
         //internal static uint ParseUInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         //{
@@ -839,7 +783,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
+#endif 
         internal static ParsingStatus TryParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)
@@ -850,8 +794,15 @@ namespace J2N.Numerics
 
             if ((styles & NumberStyle.AllowHexSpecifier) != 0)
             {
-                result = 0;
-                return TryParseUInt32HexNumberStyle(value, styles, out Unsafe.As<int, uint>(ref result));
+                //result = 0;
+                //return TryParseUInt32HexNumberStyle(value, styles, out Unsafe.As<int, uint>(ref result));
+                ParsingStatus status = TryParseUInt32HexNumberStyle(value, styles, out uint uResult);
+                if (status == ParsingStatus.OK)
+                    result = (int)uResult;
+                else
+                    result = 0;
+
+                return status;
             }
 
             return TryParseInt32Number(value, styles, info, out result);
@@ -860,7 +811,7 @@ namespace J2N.Numerics
 
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
+#endif 
         internal static ParsingStatus TryParseInt32(string value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)
@@ -977,15 +928,15 @@ namespace J2N.Numerics
                 {
                     value = value.Slice(index);
                     index = 0;
-                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
-                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign.AsSpan()))
+                    ReadOnlySpan<char> positiveSign = info.PositiveSign.AsSpan(), negativeSign = info.NegativeSign.AsSpan();
+                    if (positiveSign.Length > 0 && value.StartsWith(positiveSign))
                     {
                         index += positiveSign.Length;
                         if ((uint)index >= (uint)value.Length)
                             goto FalseExit;
                         num = value[index];
                     }
-                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign.AsSpan()))
+                    else if (negativeSign.Length > 0 && value.StartsWith(negativeSign))
                     {
                         sign = -1;
                         index += negativeSign.Length;
@@ -1101,10 +1052,9 @@ namespace J2N.Numerics
         /// <summary>Parses int limited to styles that make up NumberStyle.Integer.</summary>
         internal static ParsingStatus TryParseInt32IntegerStyle(string value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
-            Debug.Assert(value != null);
             Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
 
-            if (value!.Length == 0)
+            if (value.Length == 0)
                 goto FalseExit;
 
             int index = 0;
@@ -1271,444 +1221,213 @@ namespace J2N.Numerics
             goto DoneAtEndButPotentialOverflow;
         }
 
-#if FEATURE_SPAN
+        ///// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
+        //internal static ParsingStatus TryParseInt64IntegerStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        //{
+        //    Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
 
-        /// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
-        internal static ParsingStatus TryParseInt64IntegerStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
+        //    if (value.IsEmpty)
+        //        goto FalseExit;
 
-            if (value.IsEmpty)
-                goto FalseExit;
+        //    int index = 0;
+        //    int num = value[0];
 
-            int index = 0;
-            int num = value[0];
+        //    // Skip past any whitespace at the beginning.
+        //    if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+        //    {
+        //        do
+        //        {
+        //            index++;
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto FalseExit;
+        //            num = value[index];
+        //        }
+        //        while (IsWhite(num));
+        //    }
 
-            // Skip past any whitespace at the beginning.
-            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-            {
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto FalseExit;
-                    num = value[index];
-                }
-                while (IsWhite(num));
-            }
+        //    // Parse leading sign.
+        //    int sign = 1;
+        //    if ((styles & NumberStyle.AllowLeadingSign) != 0)
+        //    {
+        //        if (info.HasInvariantNumberSigns)
+        //        {
+        //            if (num == '-')
+        //            {
+        //                sign = -1;
+        //                index++;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto FalseExit;
+        //                num = value[index];
+        //            }
+        //            else if (num == '+')
+        //            {
+        //                index++;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto FalseExit;
+        //                num = value[index];
+        //            }
+        //        }
+        //        else
+        //        {
+        //            value = value.Slice(index);
+        //            index = 0;
+        //            string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
+        //            if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign))
+        //            {
+        //                index += positiveSign.Length;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto FalseExit;
+        //                num = value[index];
+        //            }
+        //            else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign))
+        //            {
+        //                sign = -1;
+        //                index += negativeSign.Length;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto FalseExit;
+        //                num = value[index];
+        //            }
+        //        }
+        //    }
 
-            // Parse leading sign.
-            int sign = 1;
-            if ((styles & NumberStyle.AllowLeadingSign) != 0)
-            {
-                //if (info.HasInvariantNumberSigns)
-                if (info.PositiveSign == "+" && info.NegativeSign == "-")
-                {
-                    if (num == '-')
-                    {
-                        sign = -1;
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                    else if (num == '+')
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                }
-                else
-                {
-                    value = value.Slice(index);
-                    index = 0;
-                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
-                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign.AsSpan()))
-                    {
-                        index += positiveSign.Length;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign.AsSpan()))
-                    {
-                        sign = -1;
-                        index += negativeSign.Length;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                }
-            }
+        //    bool overflow = false;
+        //    long answer = 0;
 
-            bool overflow = false;
-            long answer = 0;
+        //    if (IsDigit(num))
+        //    {
+        //        // Skip past leading zeros.
+        //        if (num == '0')
+        //        {
+        //            do
+        //            {
+        //                index++;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto DoneAtEnd;
+        //                num = value[index];
+        //            } while (num == '0');
+        //            if (!IsDigit(num))
+        //                goto HasTrailingChars;
+        //        }
 
-            if (IsDigit(num))
-            {
-                // Skip past leading zeros.
-                if (num == '0')
-                {
-                    do
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto DoneAtEnd;
-                        num = value[index];
-                    } while (num == '0');
-                    if (!IsDigit(num))
-                        goto HasTrailingChars;
-                }
+        //        // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
+        //        answer = num - '0'; // first digit
+        //        index++;
+        //        for (int i = 0; i < 17; i++) // next 17 digits can't overflow
+        //        {
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto DoneAtEnd;
+        //            num = value[index];
+        //            if (!IsDigit(num))
+        //                goto HasTrailingChars;
+        //            index++;
+        //            answer = 10 * answer + num - '0';
+        //        }
 
-                // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
-                answer = num - '0'; // first digit
-                index++;
-                for (int i = 0; i < 17; i++) // next 17 digits can't overflow
-                {
-                    if ((uint)index >= (uint)value.Length)
-                        goto DoneAtEnd;
-                    num = value[index];
-                    if (!IsDigit(num))
-                        goto HasTrailingChars;
-                    index++;
-                    answer = 10 * answer + num - '0';
-                }
+        //        if ((uint)index >= (uint)value.Length)
+        //            goto DoneAtEnd;
+        //        num = value[index];
+        //        if (!IsDigit(num))
+        //            goto HasTrailingChars;
+        //        index++;
+        //        // Potential overflow now processing the 19th digit.
+        //        overflow = answer > long.MaxValue / 10;
+        //        answer = answer * 10 + num - '0';
+        //        overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
+        //        if ((uint)index >= (uint)value.Length)
+        //            goto DoneAtEndButPotentialOverflow;
 
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEnd;
-                num = value[index];
-                if (!IsDigit(num))
-                    goto HasTrailingChars;
-                index++;
-                // Potential overflow now processing the 19th digit.
-                overflow = answer > long.MaxValue / 10;
-                answer = answer * 10 + num - '0';
-                overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
+        //        // At this point, we're either overflowing or hitting a formatting error.
+        //        // Format errors take precedence for compatibility.
+        //        num = value[index];
+        //        while (IsDigit(num))
+        //        {
+        //            overflow = true;
+        //            index++;
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto OverflowExit;
+        //            num = value[index];
+        //        }
+        //        goto HasTrailingChars;
+        //    }
+        //    goto FalseExit;
 
-                // At this point, we're either overflowing or hitting a formatting error.
-                // Format errors take precedence for compatibility.
-                num = value[index];
-                while (IsDigit(num))
-                {
-                    overflow = true;
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto OverflowExit;
-                    num = value[index];
-                }
-                goto HasTrailingChars;
-            }
-            goto FalseExit;
+        //DoneAtEndButPotentialOverflow:
+        //    if (overflow)
+        //    {
+        //        goto OverflowExit;
+        //    }
+        //DoneAtEnd:
+        //    result = answer * sign;
+        //    ParsingStatus status = ParsingStatus.OK;
+        //Exit:
+        //    return status;
 
-        DoneAtEndButPotentialOverflow:
-            if (overflow)
-            {
-                goto OverflowExit;
-            }
-        DoneAtEnd:
-            result = answer * sign;
-            ParsingStatus status = ParsingStatus.OK;
-        Exit:
-            return status;
+        //FalseExit: // parsing failed
+        //    result = 0;
+        //    status = ParsingStatus.Failed;
+        //    goto Exit;
+        //OverflowExit:
+        //    result = 0;
+        //    status = ParsingStatus.Overflow;
+        //    goto Exit;
 
-        FalseExit: // parsing failed
-            result = 0;
-            status = ParsingStatus.Failed;
-            goto Exit;
-        OverflowExit:
-            result = 0;
-            status = ParsingStatus.Overflow;
-            goto Exit;
+        //HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+        //    // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+        //    if (IsWhite(num))
+        //    {
+        //        if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+        //            goto FalseExit;
+        //        for (index++; index < value.Length; index++)
+        //        {
+        //            if (!IsWhite(value[index]))
+        //                break;
+        //        }
+        //        if ((uint)index >= (uint)value.Length)
+        //            goto DoneAtEndButPotentialOverflow;
+        //    }
 
-        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-            if (IsWhite(num))
-            {
-                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-                    goto FalseExit;
-                for (index++; index < value.Length; index++)
-                {
-                    if (!IsWhite(value[index]))
-                        break;
-                }
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
-            }
+        //    if (!TrailingZeros(value, index))
+        //        goto FalseExit;
 
-            if (!TrailingZeros(value, index))
-                goto FalseExit;
+        //    goto DoneAtEndButPotentialOverflow;
+        //}
 
-            goto DoneAtEndButPotentialOverflow;
-        }
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //internal static ParsingStatus TryParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        //{
+        //    if ((styles & ~NumberStyle.Integer) == 0)
+        //    {
+        //        // Optimized path for the common case of anything that's allowed for integer style.
+        //        return TryParseInt64IntegerStyle(value, styles, info, out result);
+        //    }
 
-#endif
+        //    if ((styles & NumberStyle.AllowHexSpecifier) != 0)
+        //    {
+        //        result = 0;
+        //        return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
+        //    }
 
-        /// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
-        internal static ParsingStatus TryParseInt64IntegerStyle(string value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            Debug.Assert(value != null);
-            Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
+        //    return TryParseInt64Number(value, styles, info, out result);
+        //}
 
-            if (value!.Length == 0)
-                goto FalseExit;
+        //private static unsafe ParsingStatus TryParseInt64Number(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        //{
+        //    result = 0;
+        //    byte* pDigits = stackalloc byte[Int64NumberBufferLength];
+        //    NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
 
-            int index = 0;
-            int num = value[0];
+        //    if (!TryStringToNumber(value, styles, ref number, info))
+        //    {
+        //        return ParsingStatus.Failed;
+        //    }
 
-            // Skip past any whitespace at the beginning.
-            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-            {
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto FalseExit;
-                    num = value[index];
-                }
-                while (IsWhite(num));
-            }
+        //    if (!TryNumberToInt64(ref number, ref result))
+        //    {
+        //        return ParsingStatus.Overflow;
+        //    }
 
-            // Parse leading sign.
-            int sign = 1;
-            if ((styles & NumberStyle.AllowLeadingSign) != 0)
-            {
-                //if (info.HasInvariantNumberSigns)
-                if (info.PositiveSign == "+" && info.NegativeSign == "-")
-                {
-                    if (num == '-')
-                    {
-                        sign = -1;
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                    else if (num == '+')
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                }
-                else
-                {
-                    value = value.Substring(index);
-                    index = 0;
-                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
-                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign))
-                    {
-                        index += positiveSign.Length;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign))
-                    {
-                        sign = -1;
-                        index += negativeSign.Length;
-                        if ((uint)index >= (uint)value.Length)
-                            goto FalseExit;
-                        num = value[index];
-                    }
-                }
-            }
-
-            bool overflow = false;
-            long answer = 0;
-
-            if (IsDigit(num))
-            {
-                // Skip past leading zeros.
-                if (num == '0')
-                {
-                    do
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto DoneAtEnd;
-                        num = value[index];
-                    } while (num == '0');
-                    if (!IsDigit(num))
-                        goto HasTrailingChars;
-                }
-
-                // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
-                answer = num - '0'; // first digit
-                index++;
-                for (int i = 0; i < 17; i++) // next 17 digits can't overflow
-                {
-                    if ((uint)index >= (uint)value.Length)
-                        goto DoneAtEnd;
-                    num = value[index];
-                    if (!IsDigit(num))
-                        goto HasTrailingChars;
-                    index++;
-                    answer = 10 * answer + num - '0';
-                }
-
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEnd;
-                num = value[index];
-                if (!IsDigit(num))
-                    goto HasTrailingChars;
-                index++;
-                // Potential overflow now processing the 19th digit.
-                overflow = answer > long.MaxValue / 10;
-                answer = answer * 10 + num - '0';
-                overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
-
-                // At this point, we're either overflowing or hitting a formatting error.
-                // Format errors take precedence for compatibility.
-                num = value[index];
-                while (IsDigit(num))
-                {
-                    overflow = true;
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto OverflowExit;
-                    num = value[index];
-                }
-                goto HasTrailingChars;
-            }
-            goto FalseExit;
-
-        DoneAtEndButPotentialOverflow:
-            if (overflow)
-            {
-                goto OverflowExit;
-            }
-        DoneAtEnd:
-            result = answer * sign;
-            ParsingStatus status = ParsingStatus.OK;
-        Exit:
-            return status;
-
-        FalseExit: // parsing failed
-            result = 0;
-            status = ParsingStatus.Failed;
-            goto Exit;
-        OverflowExit:
-            result = 0;
-            status = ParsingStatus.Overflow;
-            goto Exit;
-
-        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-            if (IsWhite(num))
-            {
-                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-                    goto FalseExit;
-                for (index++; index < value.Length; index++)
-                {
-                    if (!IsWhite(value[index]))
-                        break;
-                }
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
-            }
-
-            if (!TrailingZeros(value, index))
-                goto FalseExit;
-
-            goto DoneAtEndButPotentialOverflow;
-        }
-
-
-#if FEATURE_SPAN
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        internal static ParsingStatus TryParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            if ((styles & ~NumberStyle.Integer) == 0)
-            {
-                // Optimized path for the common case of anything that's allowed for integer style.
-                return TryParseInt64IntegerStyle(value, styles, info, out result);
-            }
-
-            if ((styles & NumberStyle.AllowHexSpecifier) != 0)
-            {
-                result = 0;
-                return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
-            }
-
-            return TryParseInt64Number(value, styles, info, out result);
-        }
-#endif
-
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        internal static ParsingStatus TryParseInt64(string value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            if ((styles & ~NumberStyle.Integer) == 0)
-            {
-                // Optimized path for the common case of anything that's allowed for integer style.
-                return TryParseInt64IntegerStyle(value, styles, info, out result);
-            }
-
-            if ((styles & NumberStyle.AllowHexSpecifier) != 0)
-            {
-                //result = 0;
-                //return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
-                ParsingStatus status = TryParseUInt64HexNumberStyle(value, styles, out ulong uResult);
-                if (status == ParsingStatus.OK)
-                    result = (long)uResult;
-                else
-                    result = 0;
-
-                return status;
-            }
-
-            return TryParseInt64Number(value, styles, info, out result);
-        }
-
-#if FEATURE_SPAN
-        private static unsafe ParsingStatus TryParseInt64Number(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            result = 0;
-            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
-            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
-
-            if (!TryStringToNumber(value, styles, ref number, info))
-            {
-                return ParsingStatus.Failed;
-            }
-
-            if (!TryNumberToInt64(ref number, ref result))
-            {
-                return ParsingStatus.Overflow;
-            }
-
-            return ParsingStatus.OK;
-        }
-#endif
-
-        private static unsafe ParsingStatus TryParseInt64Number(string value, NumberStyle styles, NumberFormatInfo info, out long result)
-        {
-            result = 0;
-            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
-            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
-
-            if (!TryStringToNumber(value, styles, ref number, info))
-            {
-                return ParsingStatus.Failed;
-            }
-
-            if (!TryNumberToInt64(ref number, ref result))
-            {
-                return ParsingStatus.Overflow;
-            }
-
-            return ParsingStatus.OK;
-        }
+        //    return ParsingStatus.OK;
+        //}
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
         //internal static ParsingStatus TryParseUInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out uint result)
@@ -1965,7 +1684,7 @@ namespace J2N.Numerics
 
                 // Parse up through 8 digits, as no overflow is possible
                 //answer = (uint)HexConverter.FromChar(num); // first digit
-                answer = (uint)Character.Digit(num, 16); // first digit
+                answer = (uint)Character.Digit(num, 16);
                 index++;
                 for (int i = 0; i < 7; i++) // next 7 digits can't overflow
                 {
@@ -2048,10 +1767,9 @@ namespace J2N.Numerics
         /// <summary>Parses uint limited to styles that make up NumberStyle.HexNumber.</summary>
         private static ParsingStatus TryParseUInt32HexNumberStyle(string value, NumberStyle styles, out uint result)
         {
-            Debug.Assert(value != null);
             Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
 
-            if (value!.Length == 0)
+            if (value.Length == 0)
                 goto FalseExit;
 
             int index = 0;
@@ -2380,264 +2098,126 @@ namespace J2N.Numerics
         //    goto DoneAtEndButPotentialOverflow;
         //}
 
-#if FEATURE_SPAN
+        ///// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
+        //private static ParsingStatus TryParseUInt64HexNumberStyle(ReadOnlySpan<char> value, NumberStyle styles, out ulong result)
+        //{
+        //    Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
 
-        /// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
-        private static ParsingStatus TryParseUInt64HexNumberStyle(ReadOnlySpan<char> value, NumberStyle styles, out ulong result)
-        {
-            Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
+        //    if (value.IsEmpty)
+        //        goto FalseExit;
 
-            if (value.IsEmpty)
-                goto FalseExit;
+        //    int index = 0;
+        //    int num = value[0];
 
-            int index = 0;
-            int num = value[0];
+        //    // Skip past any whitespace at the beginning.
+        //    if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+        //    {
+        //        do
+        //        {
+        //            index++;
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto FalseExit;
+        //            num = value[index];
+        //        }
+        //        while (IsWhite(num));
+        //    }
 
-            // Skip past any whitespace at the beginning.
-            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-            {
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto FalseExit;
-                    num = value[index];
-                }
-                while (IsWhite(num));
-            }
+        //    bool overflow = false;
+        //    ulong answer = 0;
 
-            bool overflow = false;
-            ulong answer = 0;
+        //    if (HexConverter.IsHexChar(num))
+        //    {
+        //        // Skip past leading zeros.
+        //        if (num == '0')
+        //        {
+        //            do
+        //            {
+        //                index++;
+        //                if ((uint)index >= (uint)value.Length)
+        //                    goto DoneAtEnd;
+        //                num = value[index];
+        //            } while (num == '0');
+        //            if (!HexConverter.IsHexChar(num))
+        //                goto HasTrailingChars;
+        //        }
 
-            //if (HexConverter.IsHexChar(num))
-            if (!Character.IsAsciiHexDigit(num))
-            {
-                // Skip past leading zeros.
-                if (num == '0')
-                {
-                    do
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto DoneAtEnd;
-                        num = value[index];
-                    } while (num == '0');
-                    //if (!HexConverter.IsHexChar(num))
-                    if (!Character.IsAsciiHexDigit(num))
-                        goto HasTrailingChars;
-                }
+        //        // Parse up through 16 digits, as no overflow is possible
+        //        answer = (uint)HexConverter.FromChar(num); // first digit
+        //        index++;
+        //        for (int i = 0; i < 15; i++) // next 15 digits can't overflow
+        //        {
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto DoneAtEnd;
+        //            num = value[index];
 
-                // Parse up through 16 digits, as no overflow is possible
-                //answer = (uint)HexConverter.FromChar(num); // first digit
-                answer = (uint)Character.Digit(num, 16); // first digit
-                index++;
-                for (int i = 0; i < 15; i++) // next 15 digits can't overflow
-                {
-                    if ((uint)index >= (uint)value.Length)
-                        goto DoneAtEnd;
-                    num = value[index];
+        //            uint numValue = (uint)HexConverter.FromChar(num);
+        //            if (numValue == 0xFF)
+        //                goto HasTrailingChars;
+        //            index++;
+        //            answer = 16 * answer + numValue;
+        //        }
 
-                    //uint numValue = (uint)HexConverter.FromChar(num);
-                    uint numValue = (uint)Character.Digit(num, 16);
-                    if (numValue == 0xFF)
-                        goto HasTrailingChars;
-                    index++;
-                    answer = 16 * answer + numValue;
-                }
+        //        // If there's another digit, it's an overflow.
+        //        if ((uint)index >= (uint)value.Length)
+        //            goto DoneAtEnd;
+        //        num = value[index];
+        //        if (!HexConverter.IsHexChar(num))
+        //            goto HasTrailingChars;
 
-                // If there's another digit, it's an overflow.
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEnd;
-                num = value[index];
-                //if (!HexConverter.IsHexChar(num))
-                if (!Character.IsAsciiHexDigit(num))
-                    goto HasTrailingChars;
+        //        // At this point, we're either overflowing or hitting a formatting error.
+        //        // Format errors take precedence for compatibility. Read through any remaining digits.
+        //        do
+        //        {
+        //            index++;
+        //            if ((uint)index >= (uint)value.Length)
+        //                goto OverflowExit;
+        //            num = value[index];
+        //        } while (HexConverter.IsHexChar(num));
+        //        overflow = true;
+        //        goto HasTrailingChars;
+        //    }
+        //    goto FalseExit;
 
-                // At this point, we're either overflowing or hitting a formatting error.
-                // Format errors take precedence for compatibility. Read through any remaining digits.
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto OverflowExit;
-                    num = value[index];
-                } while (Character.IsAsciiHexDigit(num));
-                //} while (HexConverter.IsHexChar(num));
-                overflow = true;
-                goto HasTrailingChars;
-            }
-            goto FalseExit;
+        //DoneAtEndButPotentialOverflow:
+        //    if (overflow)
+        //    {
+        //        goto OverflowExit;
+        //    }
+        //DoneAtEnd:
+        //    result = answer;
+        //    ParsingStatus status = ParsingStatus.OK;
+        //Exit:
+        //    return status;
 
-        DoneAtEndButPotentialOverflow:
-            if (overflow)
-            {
-                goto OverflowExit;
-            }
-        DoneAtEnd:
-            result = answer;
-            ParsingStatus status = ParsingStatus.OK;
-        Exit:
-            return status;
+        //FalseExit: // parsing failed
+        //    result = 0;
+        //    status = ParsingStatus.Failed;
+        //    goto Exit;
+        //OverflowExit:
+        //    result = 0;
+        //    status = ParsingStatus.Overflow;
+        //    goto Exit;
 
-        FalseExit: // parsing failed
-            result = 0;
-            status = ParsingStatus.Failed;
-            goto Exit;
-        OverflowExit:
-            result = 0;
-            status = ParsingStatus.Overflow;
-            goto Exit;
+        //HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+        //    // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+        //    if (IsWhite(num))
+        //    {
+        //        if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+        //            goto FalseExit;
+        //        for (index++; index < value.Length; index++)
+        //        {
+        //            if (!IsWhite(value[index]))
+        //                break;
+        //        }
+        //        if ((uint)index >= (uint)value.Length)
+        //            goto DoneAtEndButPotentialOverflow;
+        //    }
 
-        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-            if (IsWhite(num))
-            {
-                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-                    goto FalseExit;
-                for (index++; index < value.Length; index++)
-                {
-                    if (!IsWhite(value[index]))
-                        break;
-                }
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
-            }
+        //    if (!TrailingZeros(value, index))
+        //        goto FalseExit;
 
-            if (!TrailingZeros(value, index))
-                goto FalseExit;
-
-            goto DoneAtEndButPotentialOverflow;
-        }
-
-#endif
-
-        /// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
-        private static ParsingStatus TryParseUInt64HexNumberStyle(string value, NumberStyle styles, out ulong result)
-        {
-            Debug.Assert(value != null);
-            Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
-
-            if (value!.Length == 0)
-                goto FalseExit;
-
-            int index = 0;
-            int num = value[0];
-
-            // Skip past any whitespace at the beginning.
-            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-            {
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto FalseExit;
-                    num = value[index];
-                }
-                while (IsWhite(num));
-            }
-
-            bool overflow = false;
-            ulong answer = 0;
-
-            //if (HexConverter.IsHexChar(num))
-            if (!Character.IsAsciiHexDigit(num))
-            {
-                // Skip past leading zeros.
-                if (num == '0')
-                {
-                    do
-                    {
-                        index++;
-                        if ((uint)index >= (uint)value.Length)
-                            goto DoneAtEnd;
-                        num = value[index];
-                    } while (num == '0');
-                    //if (!HexConverter.IsHexChar(num))
-                    if (!Character.IsAsciiHexDigit(num))
-                        goto HasTrailingChars;
-                }
-
-                // Parse up through 16 digits, as no overflow is possible
-                //answer = (uint)HexConverter.FromChar(num); // first digit
-                answer = (uint)Character.Digit(num, 16); // first digit
-                index++;
-                for (int i = 0; i < 15; i++) // next 15 digits can't overflow
-                {
-                    if ((uint)index >= (uint)value.Length)
-                        goto DoneAtEnd;
-                    num = value[index];
-
-                    //uint numValue = (uint)HexConverter.FromChar(num);
-                    uint numValue = (uint)Character.Digit(num, 16);
-                    if (numValue == 0xFF)
-                        goto HasTrailingChars;
-                    index++;
-                    answer = 16 * answer + numValue;
-                }
-
-                // If there's another digit, it's an overflow.
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEnd;
-                num = value[index];
-                //if (!HexConverter.IsHexChar(num))
-                if (!Character.IsAsciiHexDigit(num))
-                    goto HasTrailingChars;
-
-                // At this point, we're either overflowing or hitting a formatting error.
-                // Format errors take precedence for compatibility. Read through any remaining digits.
-                do
-                {
-                    index++;
-                    if ((uint)index >= (uint)value.Length)
-                        goto OverflowExit;
-                    num = value[index];
-                } while (Character.IsAsciiHexDigit(num));
-                //} while (HexConverter.IsHexChar(num));
-                overflow = true;
-                goto HasTrailingChars;
-            }
-            goto FalseExit;
-
-        DoneAtEndButPotentialOverflow:
-            if (overflow)
-            {
-                goto OverflowExit;
-            }
-        DoneAtEnd:
-            result = answer;
-            ParsingStatus status = ParsingStatus.OK;
-        Exit:
-            return status;
-
-        FalseExit: // parsing failed
-            result = 0;
-            status = ParsingStatus.Failed;
-            goto Exit;
-        OverflowExit:
-            result = 0;
-            status = ParsingStatus.Overflow;
-            goto Exit;
-
-        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-            if (IsWhite(num))
-            {
-                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-                    goto FalseExit;
-                for (index++; index < value.Length; index++)
-                {
-                    if (!IsWhite(value[index]))
-                        break;
-                }
-                if ((uint)index >= (uint)value.Length)
-                    goto DoneAtEndButPotentialOverflow;
-            }
-
-            if (!TrailingZeros(value, index))
-                goto FalseExit;
-
-            goto DoneAtEndButPotentialOverflow;
-        }
+        //    goto DoneAtEndButPotentialOverflow;
+        //}
 
         //internal static decimal ParseDecimal(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         //{
@@ -3001,7 +2581,7 @@ namespace J2N.Numerics
 
             var number = new DoubleNumberBuffer(value.Length);
 
-            if (!TryStringToFloatingPointHexNumber(value, styles, number, info!))
+            if (!TryStringToFloatingPointHexNumber(value, styles, number, info))
             {
                 ReadOnlySpan<char> valueTrim = value.Trim();
 
@@ -3009,7 +2589,7 @@ namespace J2N.Numerics
                 // we don't so we'll check the existing cases first and then handle `PositiveSign` +
                 // `PositiveInfinitySymbol` and `PositiveSign/NegativeSign` + `NaNSymbol` last.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info!.PositiveInfinitySymbol.AsSpan()))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = double.PositiveInfinity;
                 }
@@ -3358,7 +2938,7 @@ namespace J2N.Numerics
 
             var number = new SingleHexNumberBuffer(value.Length);
 
-            if (!TryStringToFloatingPointHexNumber(value, styles, number, info!))
+            if (!TryStringToFloatingPointHexNumber(value, styles, number, info))
             {
                 ReadOnlySpan<char> valueTrim = value.Trim();
 
@@ -3370,7 +2950,7 @@ namespace J2N.Numerics
                 // to include `PositiveSign`, we need to check whether `PositiveInfinitySymbol` fits
                 // that case so that we don't start parsing things like `++infini`.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info!.PositiveInfinitySymbol.AsSpan()))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = float.PositiveInfinity;
                 }
@@ -3497,7 +3077,7 @@ namespace J2N.Numerics
             fixed (char* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 char* p = stringPointer;
-                if (!TryParseNumber(ref p, p + value.Length, styles, ref number, info!)
+                if (!TryParseNumber(ref p, p + value.Length, styles, ref number, info)
                     || ((int)(p - stringPointer) < value.Length && !TrailingZeros(value, (int)(p - stringPointer))))
                 {
                     number.CheckConsistency();
@@ -3534,7 +3114,7 @@ namespace J2N.Numerics
             fixed (char* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 char* p = stringPointer;
-                if (!TryParseFloatingPointHexNumber(ref p, p + value.Length, styles, number, info!)
+                if (!TryParseFloatingPointHexNumber(ref p, p + value.Length, styles, number, info)
                     || ((int)(p - stringPointer) < value.Length && !TrailingZeros(value, (int)(p - stringPointer))))
                 {
                     //number.CheckConsistency();

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -3,6 +3,7 @@
 
 using J2N.Globalization;
 using System;
+using System.CodeDom;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -57,10 +58,14 @@ namespace J2N.Numerics
                 return false;
             }
             int n = 0;
-            //byte* p = number.GetDigitsPointer();
+#if FEATURE_SPAN
+            byte* p = number.GetDigitsPointer();
+            {
+#else
             fixed (byte* dp = &number.Digits[0])
             {
                 byte* p = dp;
+#endif
                 Debug.Assert(p != null);
                 while (--i >= 0)
                 {
@@ -94,48 +99,56 @@ namespace J2N.Numerics
             return true;
         }
 
-        //private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
-        //{
-        //    number.CheckConsistency();
+        private static unsafe bool TryNumberToInt64(ref NumberBuffer number, ref long value)
+        {
+            number.CheckConsistency();
 
-        //    int i = number.Scale;
-        //    if (i > Int64Precision || i < number.DigitsCount)
-        //    {
-        //        return false;
-        //    }
-        //    byte* p = number.GetDigitsPointer();
-        //    Debug.Assert(p != null);
-        //    long n = 0;
-        //    while (--i >= 0)
-        //    {
-        //        if ((ulong)n > (0x7FFFFFFFFFFFFFFF / 10))
-        //        {
-        //            return false;
-        //        }
-        //        n *= 10;
-        //        if (*p != '\0')
-        //        {
-        //            n += (*p++ - '0');
-        //        }
-        //    }
-        //    if (number.IsNegative)
-        //    {
-        //        n = -n;
-        //        if (n > 0)
-        //        {
-        //            return false;
-        //        }
-        //    }
-        //    else
-        //    {
-        //        if (n < 0)
-        //        {
-        //            return false;
-        //        }
-        //    }
-        //    value = n;
-        //    return true;
-        //}
+            int i = number.Scale;
+            if (i > Int64Precision || i < number.DigitsCount)
+            {
+                return false;
+            }
+            long n = 0;
+#if FEATURE_SPAN
+            byte* p = number.GetDigitsPointer();
+            {
+#else
+            fixed (byte* dp = &number.Digits[0])
+            {
+                byte* p = dp;
+#endif
+                Debug.Assert(p != null);
+                while (--i >= 0)
+                {
+                    if ((ulong)n > (0x7FFFFFFFFFFFFFFF / 10))
+                    {
+                        return false;
+                    }
+                    n *= 10;
+                    if (*p != '\0')
+                    {
+                        n += (*p++ - '0');
+                    }
+                }
+            }
+            if (number.IsNegative)
+            {
+                n = -n;
+                if (n > 0)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (n < 0)
+                {
+                    return false;
+                }
+            }
+            value = n;
+            return true;
+        }
 
         //private static unsafe bool TryNumberToUInt32(ref NumberBuffer number, ref uint value)
         //{
@@ -205,27 +218,70 @@ namespace J2N.Numerics
         //    return true;
         //}
 
-        //internal static int ParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
-        //{
-        //    ParsingStatus status = TryParseInt32(value, styles, info, out int result);
-        //    if (status != ParsingStatus.OK)
-        //    {
-        //        ThrowOverflowOrFormatException(status, TypeCode.Int32);
-        //    }
+#if FEATURE_SPAN
 
-        //    return result;
-        //}
+        internal static int ParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
+        {
+            ParsingStatus status = TryParseInt32(value, styles, info, out int result);
+            if (status != ParsingStatus.OK)
+            {
+                if (status == ParsingStatus.Overflow)
+                    ThrowOverflowException(TypeCode.Int32);
+                else
+                    ThrowFormatException(value.ToString());
+            }
 
-        //internal static long ParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
-        //{
-        //    ParsingStatus status = TryParseInt64(value, styles, info, out long result);
-        //    if (status != ParsingStatus.OK)
-        //    {
-        //        ThrowOverflowOrFormatException(status, TypeCode.Int64);
-        //    }
+            return result;
+        }
 
-        //    return result;
-        //}
+#endif
+
+        internal static int ParseInt32(string value, NumberStyle styles, NumberFormatInfo info)
+        {
+            ParsingStatus status = TryParseInt32(value, styles, info, out int result);
+            if (status != ParsingStatus.OK)
+            {
+                if (status == ParsingStatus.Overflow)
+                    ThrowOverflowException(TypeCode.Int32);
+                else
+                    ThrowFormatException(value);
+            }
+
+            return result;
+        }
+
+
+#if FEATURE_SPAN
+
+        internal static long ParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
+        {
+            ParsingStatus status = TryParseInt64(value, styles, info, out long result);
+            if (status != ParsingStatus.OK)
+            {
+                if (status == ParsingStatus.Overflow)
+                    ThrowOverflowException(TypeCode.Int64);
+                else
+                    ThrowFormatException(value.ToString());
+            }
+
+            return result;
+        }
+
+#endif
+
+        internal static long ParseInt64(string value, NumberStyle styles, NumberFormatInfo info)
+        {
+            ParsingStatus status = TryParseInt64(value, styles, info, out long result);
+            if (status != ParsingStatus.OK)
+            {
+                if (status == ParsingStatus.Overflow)
+                    ThrowOverflowException(TypeCode.Int64);
+                else
+                    ThrowFormatException(value.ToString());
+            }
+
+            return result;
+        }
 
         //internal static uint ParseUInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         //{
@@ -783,7 +839,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         internal static ParsingStatus TryParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)
@@ -794,15 +850,8 @@ namespace J2N.Numerics
 
             if ((styles & NumberStyle.AllowHexSpecifier) != 0)
             {
-                //result = 0;
-                //return TryParseUInt32HexNumberStyle(value, styles, out Unsafe.As<int, uint>(ref result));
-                ParsingStatus status = TryParseUInt32HexNumberStyle(value, styles, out uint uResult);
-                if (status == ParsingStatus.OK)
-                    result = (int)uResult;
-                else
-                    result = 0;
-
-                return status;
+                result = 0;
+                return TryParseUInt32HexNumberStyle(value, styles, out Unsafe.As<int, uint>(ref result));
             }
 
             return TryParseInt32Number(value, styles, info, out result);
@@ -811,7 +860,7 @@ namespace J2N.Numerics
 
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         internal static ParsingStatus TryParseInt32(string value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)
@@ -928,15 +977,15 @@ namespace J2N.Numerics
                 {
                     value = value.Slice(index);
                     index = 0;
-                    ReadOnlySpan<char> positiveSign = info.PositiveSign.AsSpan(), negativeSign = info.NegativeSign.AsSpan();
-                    if (positiveSign.Length > 0 && value.StartsWith(positiveSign))
+                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
+                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign.AsSpan()))
                     {
                         index += positiveSign.Length;
                         if ((uint)index >= (uint)value.Length)
                             goto FalseExit;
                         num = value[index];
                     }
-                    else if (negativeSign.Length > 0 && value.StartsWith(negativeSign))
+                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign.AsSpan()))
                     {
                         sign = -1;
                         index += negativeSign.Length;
@@ -1052,9 +1101,10 @@ namespace J2N.Numerics
         /// <summary>Parses int limited to styles that make up NumberStyle.Integer.</summary>
         internal static ParsingStatus TryParseInt32IntegerStyle(string value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
+            Debug.Assert(value != null);
             Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
 
-            if (value.Length == 0)
+            if (value!.Length == 0)
                 goto FalseExit;
 
             int index = 0;
@@ -1221,213 +1271,444 @@ namespace J2N.Numerics
             goto DoneAtEndButPotentialOverflow;
         }
 
-        ///// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
-        //internal static ParsingStatus TryParseInt64IntegerStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        //{
-        //    Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
+#if FEATURE_SPAN
 
-        //    if (value.IsEmpty)
-        //        goto FalseExit;
+        /// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
+        internal static ParsingStatus TryParseInt64IntegerStyle(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
 
-        //    int index = 0;
-        //    int num = value[0];
+            if (value.IsEmpty)
+                goto FalseExit;
 
-        //    // Skip past any whitespace at the beginning.
-        //    if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-        //    {
-        //        do
-        //        {
-        //            index++;
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto FalseExit;
-        //            num = value[index];
-        //        }
-        //        while (IsWhite(num));
-        //    }
+            int index = 0;
+            int num = value[0];
 
-        //    // Parse leading sign.
-        //    int sign = 1;
-        //    if ((styles & NumberStyle.AllowLeadingSign) != 0)
-        //    {
-        //        if (info.HasInvariantNumberSigns)
-        //        {
-        //            if (num == '-')
-        //            {
-        //                sign = -1;
-        //                index++;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto FalseExit;
-        //                num = value[index];
-        //            }
-        //            else if (num == '+')
-        //            {
-        //                index++;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto FalseExit;
-        //                num = value[index];
-        //            }
-        //        }
-        //        else
-        //        {
-        //            value = value.Slice(index);
-        //            index = 0;
-        //            string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
-        //            if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign))
-        //            {
-        //                index += positiveSign.Length;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto FalseExit;
-        //                num = value[index];
-        //            }
-        //            else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign))
-        //            {
-        //                sign = -1;
-        //                index += negativeSign.Length;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto FalseExit;
-        //                num = value[index];
-        //            }
-        //        }
-        //    }
+            // Skip past any whitespace at the beginning.
+            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+            {
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
+                }
+                while (IsWhite(num));
+            }
 
-        //    bool overflow = false;
-        //    long answer = 0;
+            // Parse leading sign.
+            int sign = 1;
+            if ((styles & NumberStyle.AllowLeadingSign) != 0)
+            {
+                //if (info.HasInvariantNumberSigns)
+                if (info.PositiveSign == "+" && info.NegativeSign == "-")
+                {
+                    if (num == '-')
+                    {
+                        sign = -1;
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                    else if (num == '+')
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                }
+                else
+                {
+                    value = value.Slice(index);
+                    index = 0;
+                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
+                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign.AsSpan()))
+                    {
+                        index += positiveSign.Length;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign.AsSpan()))
+                    {
+                        sign = -1;
+                        index += negativeSign.Length;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                }
+            }
 
-        //    if (IsDigit(num))
-        //    {
-        //        // Skip past leading zeros.
-        //        if (num == '0')
-        //        {
-        //            do
-        //            {
-        //                index++;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto DoneAtEnd;
-        //                num = value[index];
-        //            } while (num == '0');
-        //            if (!IsDigit(num))
-        //                goto HasTrailingChars;
-        //        }
+            bool overflow = false;
+            long answer = 0;
 
-        //        // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
-        //        answer = num - '0'; // first digit
-        //        index++;
-        //        for (int i = 0; i < 17; i++) // next 17 digits can't overflow
-        //        {
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto DoneAtEnd;
-        //            num = value[index];
-        //            if (!IsDigit(num))
-        //                goto HasTrailingChars;
-        //            index++;
-        //            answer = 10 * answer + num - '0';
-        //        }
+            if (IsDigit(num))
+            {
+                // Skip past leading zeros.
+                if (num == '0')
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto DoneAtEnd;
+                        num = value[index];
+                    } while (num == '0');
+                    if (!IsDigit(num))
+                        goto HasTrailingChars;
+                }
 
-        //        if ((uint)index >= (uint)value.Length)
-        //            goto DoneAtEnd;
-        //        num = value[index];
-        //        if (!IsDigit(num))
-        //            goto HasTrailingChars;
-        //        index++;
-        //        // Potential overflow now processing the 19th digit.
-        //        overflow = answer > long.MaxValue / 10;
-        //        answer = answer * 10 + num - '0';
-        //        overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
-        //        if ((uint)index >= (uint)value.Length)
-        //            goto DoneAtEndButPotentialOverflow;
+                // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
+                answer = num - '0'; // first digit
+                index++;
+                for (int i = 0; i < 17; i++) // next 17 digits can't overflow
+                {
+                    if ((uint)index >= (uint)value.Length)
+                        goto DoneAtEnd;
+                    num = value[index];
+                    if (!IsDigit(num))
+                        goto HasTrailingChars;
+                    index++;
+                    answer = 10 * answer + num - '0';
+                }
 
-        //        // At this point, we're either overflowing or hitting a formatting error.
-        //        // Format errors take precedence for compatibility.
-        //        num = value[index];
-        //        while (IsDigit(num))
-        //        {
-        //            overflow = true;
-        //            index++;
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto OverflowExit;
-        //            num = value[index];
-        //        }
-        //        goto HasTrailingChars;
-        //    }
-        //    goto FalseExit;
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEnd;
+                num = value[index];
+                if (!IsDigit(num))
+                    goto HasTrailingChars;
+                index++;
+                // Potential overflow now processing the 19th digit.
+                overflow = answer > long.MaxValue / 10;
+                answer = answer * 10 + num - '0';
+                overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
 
-        //DoneAtEndButPotentialOverflow:
-        //    if (overflow)
-        //    {
-        //        goto OverflowExit;
-        //    }
-        //DoneAtEnd:
-        //    result = answer * sign;
-        //    ParsingStatus status = ParsingStatus.OK;
-        //Exit:
-        //    return status;
+                // At this point, we're either overflowing or hitting a formatting error.
+                // Format errors take precedence for compatibility.
+                num = value[index];
+                while (IsDigit(num))
+                {
+                    overflow = true;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto OverflowExit;
+                    num = value[index];
+                }
+                goto HasTrailingChars;
+            }
+            goto FalseExit;
 
-        //FalseExit: // parsing failed
-        //    result = 0;
-        //    status = ParsingStatus.Failed;
-        //    goto Exit;
-        //OverflowExit:
-        //    result = 0;
-        //    status = ParsingStatus.Overflow;
-        //    goto Exit;
+        DoneAtEndButPotentialOverflow:
+            if (overflow)
+            {
+                goto OverflowExit;
+            }
+        DoneAtEnd:
+            result = answer * sign;
+            ParsingStatus status = ParsingStatus.OK;
+        Exit:
+            return status;
 
-        //HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-        //    // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-        //    if (IsWhite(num))
-        //    {
-        //        if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-        //            goto FalseExit;
-        //        for (index++; index < value.Length; index++)
-        //        {
-        //            if (!IsWhite(value[index]))
-        //                break;
-        //        }
-        //        if ((uint)index >= (uint)value.Length)
-        //            goto DoneAtEndButPotentialOverflow;
-        //    }
+        FalseExit: // parsing failed
+            result = 0;
+            status = ParsingStatus.Failed;
+            goto Exit;
+        OverflowExit:
+            result = 0;
+            status = ParsingStatus.Overflow;
+            goto Exit;
 
-        //    if (!TrailingZeros(value, index))
-        //        goto FalseExit;
+        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+            if (IsWhite(num))
+            {
+                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+                    goto FalseExit;
+                for (index++; index < value.Length; index++)
+                {
+                    if (!IsWhite(value[index]))
+                        break;
+                }
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
+            }
 
-        //    goto DoneAtEndButPotentialOverflow;
-        //}
+            if (!TrailingZeros(value, index))
+                goto FalseExit;
 
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //internal static ParsingStatus TryParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        //{
-        //    if ((styles & ~NumberStyle.Integer) == 0)
-        //    {
-        //        // Optimized path for the common case of anything that's allowed for integer style.
-        //        return TryParseInt64IntegerStyle(value, styles, info, out result);
-        //    }
+            goto DoneAtEndButPotentialOverflow;
+        }
 
-        //    if ((styles & NumberStyle.AllowHexSpecifier) != 0)
-        //    {
-        //        result = 0;
-        //        return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
-        //    }
+#endif
 
-        //    return TryParseInt64Number(value, styles, info, out result);
-        //}
+        /// <summary>Parses long inputs limited to styles that make up NumberStyle.Integer.</summary>
+        internal static ParsingStatus TryParseInt64IntegerStyle(string value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert((styles & ~NumberStyle.Integer) == 0, "Only handles subsets of Integer format");
 
-        //private static unsafe ParsingStatus TryParseInt64Number(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
-        //{
-        //    result = 0;
-        //    byte* pDigits = stackalloc byte[Int64NumberBufferLength];
-        //    NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
+            if (value!.Length == 0)
+                goto FalseExit;
 
-        //    if (!TryStringToNumber(value, styles, ref number, info))
-        //    {
-        //        return ParsingStatus.Failed;
-        //    }
+            int index = 0;
+            int num = value[0];
 
-        //    if (!TryNumberToInt64(ref number, ref result))
-        //    {
-        //        return ParsingStatus.Overflow;
-        //    }
+            // Skip past any whitespace at the beginning.
+            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+            {
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
+                }
+                while (IsWhite(num));
+            }
 
-        //    return ParsingStatus.OK;
-        //}
+            // Parse leading sign.
+            int sign = 1;
+            if ((styles & NumberStyle.AllowLeadingSign) != 0)
+            {
+                //if (info.HasInvariantNumberSigns)
+                if (info.PositiveSign == "+" && info.NegativeSign == "-")
+                {
+                    if (num == '-')
+                    {
+                        sign = -1;
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                    else if (num == '+')
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                }
+                else
+                {
+                    value = value.Substring(index);
+                    index = 0;
+                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
+                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign))
+                    {
+                        index += positiveSign.Length;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign))
+                    {
+                        sign = -1;
+                        index += negativeSign.Length;
+                        if ((uint)index >= (uint)value.Length)
+                            goto FalseExit;
+                        num = value[index];
+                    }
+                }
+            }
+
+            bool overflow = false;
+            long answer = 0;
+
+            if (IsDigit(num))
+            {
+                // Skip past leading zeros.
+                if (num == '0')
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto DoneAtEnd;
+                        num = value[index];
+                    } while (num == '0');
+                    if (!IsDigit(num))
+                        goto HasTrailingChars;
+                }
+
+                // Parse most digits, up to the potential for overflow, which can't happen until after 18 digits.
+                answer = num - '0'; // first digit
+                index++;
+                for (int i = 0; i < 17; i++) // next 17 digits can't overflow
+                {
+                    if ((uint)index >= (uint)value.Length)
+                        goto DoneAtEnd;
+                    num = value[index];
+                    if (!IsDigit(num))
+                        goto HasTrailingChars;
+                    index++;
+                    answer = 10 * answer + num - '0';
+                }
+
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEnd;
+                num = value[index];
+                if (!IsDigit(num))
+                    goto HasTrailingChars;
+                index++;
+                // Potential overflow now processing the 19th digit.
+                overflow = answer > long.MaxValue / 10;
+                answer = answer * 10 + num - '0';
+                overflow |= (ulong)answer > (ulong)long.MaxValue + (((uint)sign) >> 31);
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
+
+                // At this point, we're either overflowing or hitting a formatting error.
+                // Format errors take precedence for compatibility.
+                num = value[index];
+                while (IsDigit(num))
+                {
+                    overflow = true;
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto OverflowExit;
+                    num = value[index];
+                }
+                goto HasTrailingChars;
+            }
+            goto FalseExit;
+
+        DoneAtEndButPotentialOverflow:
+            if (overflow)
+            {
+                goto OverflowExit;
+            }
+        DoneAtEnd:
+            result = answer * sign;
+            ParsingStatus status = ParsingStatus.OK;
+        Exit:
+            return status;
+
+        FalseExit: // parsing failed
+            result = 0;
+            status = ParsingStatus.Failed;
+            goto Exit;
+        OverflowExit:
+            result = 0;
+            status = ParsingStatus.Overflow;
+            goto Exit;
+
+        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+            if (IsWhite(num))
+            {
+                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+                    goto FalseExit;
+                for (index++; index < value.Length; index++)
+                {
+                    if (!IsWhite(value[index]))
+                        break;
+                }
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
+            }
+
+            if (!TrailingZeros(value, index))
+                goto FalseExit;
+
+            goto DoneAtEndButPotentialOverflow;
+        }
+
+
+#if FEATURE_SPAN
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static ParsingStatus TryParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            if ((styles & ~NumberStyle.Integer) == 0)
+            {
+                // Optimized path for the common case of anything that's allowed for integer style.
+                return TryParseInt64IntegerStyle(value, styles, info, out result);
+            }
+
+            if ((styles & NumberStyle.AllowHexSpecifier) != 0)
+            {
+                result = 0;
+                return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
+            }
+
+            return TryParseInt64Number(value, styles, info, out result);
+        }
+#endif
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal static ParsingStatus TryParseInt64(string value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            if ((styles & ~NumberStyle.Integer) == 0)
+            {
+                // Optimized path for the common case of anything that's allowed for integer style.
+                return TryParseInt64IntegerStyle(value, styles, info, out result);
+            }
+
+            if ((styles & NumberStyle.AllowHexSpecifier) != 0)
+            {
+                //result = 0;
+                //return TryParseUInt64HexNumberStyle(value, styles, out Unsafe.As<long, ulong>(ref result));
+                ParsingStatus status = TryParseUInt64HexNumberStyle(value, styles, out ulong uResult);
+                if (status == ParsingStatus.OK)
+                    result = (long)uResult;
+                else
+                    result = 0;
+
+                return status;
+            }
+
+            return TryParseInt64Number(value, styles, info, out result);
+        }
+
+#if FEATURE_SPAN
+        private static unsafe ParsingStatus TryParseInt64Number(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            result = 0;
+            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
+
+            if (!TryStringToNumber(value, styles, ref number, info))
+            {
+                return ParsingStatus.Failed;
+            }
+
+            if (!TryNumberToInt64(ref number, ref result))
+            {
+                return ParsingStatus.Overflow;
+            }
+
+            return ParsingStatus.OK;
+        }
+#endif
+
+        private static unsafe ParsingStatus TryParseInt64Number(string value, NumberStyle styles, NumberFormatInfo info, out long result)
+        {
+            result = 0;
+            byte* pDigits = stackalloc byte[Int64NumberBufferLength];
+            NumberBuffer number = new NumberBuffer(NumberBufferKind.Integer, pDigits, Int64NumberBufferLength);
+
+            if (!TryStringToNumber(value, styles, ref number, info))
+            {
+                return ParsingStatus.Failed;
+            }
+
+            if (!TryNumberToInt64(ref number, ref result))
+            {
+                return ParsingStatus.Overflow;
+            }
+
+            return ParsingStatus.OK;
+        }
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
         //internal static ParsingStatus TryParseUInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out uint result)
@@ -1684,7 +1965,7 @@ namespace J2N.Numerics
 
                 // Parse up through 8 digits, as no overflow is possible
                 //answer = (uint)HexConverter.FromChar(num); // first digit
-                answer = (uint)Character.Digit(num, 16);
+                answer = (uint)Character.Digit(num, 16); // first digit
                 index++;
                 for (int i = 0; i < 7; i++) // next 7 digits can't overflow
                 {
@@ -1767,9 +2048,10 @@ namespace J2N.Numerics
         /// <summary>Parses uint limited to styles that make up NumberStyle.HexNumber.</summary>
         private static ParsingStatus TryParseUInt32HexNumberStyle(string value, NumberStyle styles, out uint result)
         {
+            Debug.Assert(value != null);
             Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
 
-            if (value.Length == 0)
+            if (value!.Length == 0)
                 goto FalseExit;
 
             int index = 0;
@@ -2098,126 +2380,264 @@ namespace J2N.Numerics
         //    goto DoneAtEndButPotentialOverflow;
         //}
 
-        ///// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
-        //private static ParsingStatus TryParseUInt64HexNumberStyle(ReadOnlySpan<char> value, NumberStyle styles, out ulong result)
-        //{
-        //    Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
+#if FEATURE_SPAN
 
-        //    if (value.IsEmpty)
-        //        goto FalseExit;
+        /// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
+        private static ParsingStatus TryParseUInt64HexNumberStyle(ReadOnlySpan<char> value, NumberStyle styles, out ulong result)
+        {
+            Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
 
-        //    int index = 0;
-        //    int num = value[0];
+            if (value.IsEmpty)
+                goto FalseExit;
 
-        //    // Skip past any whitespace at the beginning.
-        //    if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
-        //    {
-        //        do
-        //        {
-        //            index++;
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto FalseExit;
-        //            num = value[index];
-        //        }
-        //        while (IsWhite(num));
-        //    }
+            int index = 0;
+            int num = value[0];
 
-        //    bool overflow = false;
-        //    ulong answer = 0;
+            // Skip past any whitespace at the beginning.
+            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+            {
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
+                }
+                while (IsWhite(num));
+            }
 
-        //    if (HexConverter.IsHexChar(num))
-        //    {
-        //        // Skip past leading zeros.
-        //        if (num == '0')
-        //        {
-        //            do
-        //            {
-        //                index++;
-        //                if ((uint)index >= (uint)value.Length)
-        //                    goto DoneAtEnd;
-        //                num = value[index];
-        //            } while (num == '0');
-        //            if (!HexConverter.IsHexChar(num))
-        //                goto HasTrailingChars;
-        //        }
+            bool overflow = false;
+            ulong answer = 0;
 
-        //        // Parse up through 16 digits, as no overflow is possible
-        //        answer = (uint)HexConverter.FromChar(num); // first digit
-        //        index++;
-        //        for (int i = 0; i < 15; i++) // next 15 digits can't overflow
-        //        {
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto DoneAtEnd;
-        //            num = value[index];
+            //if (HexConverter.IsHexChar(num))
+            if (!Character.IsAsciiHexDigit(num))
+            {
+                // Skip past leading zeros.
+                if (num == '0')
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto DoneAtEnd;
+                        num = value[index];
+                    } while (num == '0');
+                    //if (!HexConverter.IsHexChar(num))
+                    if (!Character.IsAsciiHexDigit(num))
+                        goto HasTrailingChars;
+                }
 
-        //            uint numValue = (uint)HexConverter.FromChar(num);
-        //            if (numValue == 0xFF)
-        //                goto HasTrailingChars;
-        //            index++;
-        //            answer = 16 * answer + numValue;
-        //        }
+                // Parse up through 16 digits, as no overflow is possible
+                //answer = (uint)HexConverter.FromChar(num); // first digit
+                answer = (uint)Character.Digit(num, 16); // first digit
+                index++;
+                for (int i = 0; i < 15; i++) // next 15 digits can't overflow
+                {
+                    if ((uint)index >= (uint)value.Length)
+                        goto DoneAtEnd;
+                    num = value[index];
 
-        //        // If there's another digit, it's an overflow.
-        //        if ((uint)index >= (uint)value.Length)
-        //            goto DoneAtEnd;
-        //        num = value[index];
-        //        if (!HexConverter.IsHexChar(num))
-        //            goto HasTrailingChars;
+                    //uint numValue = (uint)HexConverter.FromChar(num);
+                    uint numValue = (uint)Character.Digit(num, 16);
+                    if (numValue == 0xFF)
+                        goto HasTrailingChars;
+                    index++;
+                    answer = 16 * answer + numValue;
+                }
 
-        //        // At this point, we're either overflowing or hitting a formatting error.
-        //        // Format errors take precedence for compatibility. Read through any remaining digits.
-        //        do
-        //        {
-        //            index++;
-        //            if ((uint)index >= (uint)value.Length)
-        //                goto OverflowExit;
-        //            num = value[index];
-        //        } while (HexConverter.IsHexChar(num));
-        //        overflow = true;
-        //        goto HasTrailingChars;
-        //    }
-        //    goto FalseExit;
+                // If there's another digit, it's an overflow.
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEnd;
+                num = value[index];
+                //if (!HexConverter.IsHexChar(num))
+                if (!Character.IsAsciiHexDigit(num))
+                    goto HasTrailingChars;
 
-        //DoneAtEndButPotentialOverflow:
-        //    if (overflow)
-        //    {
-        //        goto OverflowExit;
-        //    }
-        //DoneAtEnd:
-        //    result = answer;
-        //    ParsingStatus status = ParsingStatus.OK;
-        //Exit:
-        //    return status;
+                // At this point, we're either overflowing or hitting a formatting error.
+                // Format errors take precedence for compatibility. Read through any remaining digits.
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto OverflowExit;
+                    num = value[index];
+                } while (Character.IsAsciiHexDigit(num));
+                //} while (HexConverter.IsHexChar(num));
+                overflow = true;
+                goto HasTrailingChars;
+            }
+            goto FalseExit;
 
-        //FalseExit: // parsing failed
-        //    result = 0;
-        //    status = ParsingStatus.Failed;
-        //    goto Exit;
-        //OverflowExit:
-        //    result = 0;
-        //    status = ParsingStatus.Overflow;
-        //    goto Exit;
+        DoneAtEndButPotentialOverflow:
+            if (overflow)
+            {
+                goto OverflowExit;
+            }
+        DoneAtEnd:
+            result = answer;
+            ParsingStatus status = ParsingStatus.OK;
+        Exit:
+            return status;
 
-        //HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
-        //    // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
-        //    if (IsWhite(num))
-        //    {
-        //        if ((styles & NumberStyle.AllowTrailingWhite) == 0)
-        //            goto FalseExit;
-        //        for (index++; index < value.Length; index++)
-        //        {
-        //            if (!IsWhite(value[index]))
-        //                break;
-        //        }
-        //        if ((uint)index >= (uint)value.Length)
-        //            goto DoneAtEndButPotentialOverflow;
-        //    }
+        FalseExit: // parsing failed
+            result = 0;
+            status = ParsingStatus.Failed;
+            goto Exit;
+        OverflowExit:
+            result = 0;
+            status = ParsingStatus.Overflow;
+            goto Exit;
 
-        //    if (!TrailingZeros(value, index))
-        //        goto FalseExit;
+        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+            if (IsWhite(num))
+            {
+                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+                    goto FalseExit;
+                for (index++; index < value.Length; index++)
+                {
+                    if (!IsWhite(value[index]))
+                        break;
+                }
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
+            }
 
-        //    goto DoneAtEndButPotentialOverflow;
-        //}
+            if (!TrailingZeros(value, index))
+                goto FalseExit;
+
+            goto DoneAtEndButPotentialOverflow;
+        }
+
+#endif
+
+        /// <summary>Parses ulong limited to styles that make up NumberStyle.HexNumber.</summary>
+        private static ParsingStatus TryParseUInt64HexNumberStyle(string value, NumberStyle styles, out ulong result)
+        {
+            Debug.Assert(value != null);
+            Debug.Assert((styles & ~NumberStyle.HexNumber) == 0, "Only handles subsets of HexNumber format");
+
+            if (value!.Length == 0)
+                goto FalseExit;
+
+            int index = 0;
+            int num = value[0];
+
+            // Skip past any whitespace at the beginning.
+            if ((styles & NumberStyle.AllowLeadingWhite) != 0 && IsWhite(num))
+            {
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto FalseExit;
+                    num = value[index];
+                }
+                while (IsWhite(num));
+            }
+
+            bool overflow = false;
+            ulong answer = 0;
+
+            //if (HexConverter.IsHexChar(num))
+            if (!Character.IsAsciiHexDigit(num))
+            {
+                // Skip past leading zeros.
+                if (num == '0')
+                {
+                    do
+                    {
+                        index++;
+                        if ((uint)index >= (uint)value.Length)
+                            goto DoneAtEnd;
+                        num = value[index];
+                    } while (num == '0');
+                    //if (!HexConverter.IsHexChar(num))
+                    if (!Character.IsAsciiHexDigit(num))
+                        goto HasTrailingChars;
+                }
+
+                // Parse up through 16 digits, as no overflow is possible
+                //answer = (uint)HexConverter.FromChar(num); // first digit
+                answer = (uint)Character.Digit(num, 16); // first digit
+                index++;
+                for (int i = 0; i < 15; i++) // next 15 digits can't overflow
+                {
+                    if ((uint)index >= (uint)value.Length)
+                        goto DoneAtEnd;
+                    num = value[index];
+
+                    //uint numValue = (uint)HexConverter.FromChar(num);
+                    uint numValue = (uint)Character.Digit(num, 16);
+                    if (numValue == 0xFF)
+                        goto HasTrailingChars;
+                    index++;
+                    answer = 16 * answer + numValue;
+                }
+
+                // If there's another digit, it's an overflow.
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEnd;
+                num = value[index];
+                //if (!HexConverter.IsHexChar(num))
+                if (!Character.IsAsciiHexDigit(num))
+                    goto HasTrailingChars;
+
+                // At this point, we're either overflowing or hitting a formatting error.
+                // Format errors take precedence for compatibility. Read through any remaining digits.
+                do
+                {
+                    index++;
+                    if ((uint)index >= (uint)value.Length)
+                        goto OverflowExit;
+                    num = value[index];
+                } while (Character.IsAsciiHexDigit(num));
+                //} while (HexConverter.IsHexChar(num));
+                overflow = true;
+                goto HasTrailingChars;
+            }
+            goto FalseExit;
+
+        DoneAtEndButPotentialOverflow:
+            if (overflow)
+            {
+                goto OverflowExit;
+            }
+        DoneAtEnd:
+            result = answer;
+            ParsingStatus status = ParsingStatus.OK;
+        Exit:
+            return status;
+
+        FalseExit: // parsing failed
+            result = 0;
+            status = ParsingStatus.Failed;
+            goto Exit;
+        OverflowExit:
+            result = 0;
+            status = ParsingStatus.Overflow;
+            goto Exit;
+
+        HasTrailingChars: // we've successfully parsed, but there are still remaining characters in the span
+            // Skip past trailing whitespace, then past trailing zeros, and if anything else remains, fail.
+            if (IsWhite(num))
+            {
+                if ((styles & NumberStyle.AllowTrailingWhite) == 0)
+                    goto FalseExit;
+                for (index++; index < value.Length; index++)
+                {
+                    if (!IsWhite(value[index]))
+                        break;
+                }
+                if ((uint)index >= (uint)value.Length)
+                    goto DoneAtEndButPotentialOverflow;
+            }
+
+            if (!TrailingZeros(value, index))
+                goto FalseExit;
+
+            goto DoneAtEndButPotentialOverflow;
+        }
 
         //internal static decimal ParseDecimal(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info)
         //{
@@ -2581,7 +3001,7 @@ namespace J2N.Numerics
 
             var number = new DoubleNumberBuffer(value.Length);
 
-            if (!TryStringToFloatingPointHexNumber(value, styles, number, info))
+            if (!TryStringToFloatingPointHexNumber(value, styles, number, info!))
             {
                 ReadOnlySpan<char> valueTrim = value.Trim();
 
@@ -2589,7 +3009,7 @@ namespace J2N.Numerics
                 // we don't so we'll check the existing cases first and then handle `PositiveSign` +
                 // `PositiveInfinitySymbol` and `PositiveSign/NegativeSign` + `NaNSymbol` last.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info!.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = double.PositiveInfinity;
                 }
@@ -2938,7 +3358,7 @@ namespace J2N.Numerics
 
             var number = new SingleHexNumberBuffer(value.Length);
 
-            if (!TryStringToFloatingPointHexNumber(value, styles, number, info))
+            if (!TryStringToFloatingPointHexNumber(value, styles, number, info!))
             {
                 ReadOnlySpan<char> valueTrim = value.Trim();
 
@@ -2950,7 +3370,7 @@ namespace J2N.Numerics
                 // to include `PositiveSign`, we need to check whether `PositiveInfinitySymbol` fits
                 // that case so that we don't start parsing things like `++infini`.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info!.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = float.PositiveInfinity;
                 }
@@ -3077,7 +3497,7 @@ namespace J2N.Numerics
             fixed (char* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 char* p = stringPointer;
-                if (!TryParseNumber(ref p, p + value.Length, styles, ref number, info)
+                if (!TryParseNumber(ref p, p + value.Length, styles, ref number, info!)
                     || ((int)(p - stringPointer) < value.Length && !TrailingZeros(value, (int)(p - stringPointer))))
                 {
                     number.CheckConsistency();
@@ -3114,7 +3534,7 @@ namespace J2N.Numerics
             fixed (char* stringPointer = &MemoryMarshal.GetReference(value))
             {
                 char* p = stringPointer;
-                if (!TryParseFloatingPointHexNumber(ref p, p + value.Length, styles, number, info)
+                if (!TryParseFloatingPointHexNumber(ref p, p + value.Length, styles, number, info!)
                     || ((int)(p - stringPointer) < value.Length && !TrailingZeros(value, (int)(p - stringPointer))))
                 {
                     //number.CheckConsistency();

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -928,15 +928,15 @@ namespace J2N.Numerics
                 {
                     value = value.Slice(index);
                     index = 0;
-                    string positiveSign = info.PositiveSign, negativeSign = info.NegativeSign;
-                    if (!string.IsNullOrEmpty(positiveSign) && value.StartsWith(positiveSign))
+                    ReadOnlySpan<char> positiveSign = info.PositiveSign.AsSpan(), negativeSign = info.NegativeSign.AsSpan();
+                    if (positiveSign.Length > 0 && value.StartsWith(positiveSign))
                     {
                         index += positiveSign.Length;
                         if ((uint)index >= (uint)value.Length)
                             goto FalseExit;
                         num = value[index];
                     }
-                    else if (!string.IsNullOrEmpty(negativeSign) && value.StartsWith(negativeSign))
+                    else if (negativeSign.Length > 0 && value.StartsWith(negativeSign))
                     {
                         sign = -1;
                         index += negativeSign.Length;
@@ -2355,7 +2355,7 @@ namespace J2N.Numerics
         {
             if (!TryParseDouble(value, styles, info, out double result))
             {
-                ThrowFormatException(new string(value));
+                ThrowFormatException(value.ToString());
             }
 
             return result;
@@ -2377,7 +2377,7 @@ namespace J2N.Numerics
         {
             if (!TryParseSingle(value, styles, info, out float result))
             {
-                ThrowFormatException(new string(value));
+                ThrowFormatException(value.ToString());
             }
 
             return result;
@@ -2460,27 +2460,27 @@ namespace J2N.Numerics
                 // we don't so we'll check the existing cases first and then handle `PositiveSign` +
                 // `PositiveInfinitySymbol` and `PositiveSign/NegativeSign` + `NaNSymbol` last.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = double.PositiveInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol.AsSpan()))
                 {
                     result = double.NegativeInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = double.NaN;
                 }
-                else if (valueTrim.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase))
+                else if (valueTrim.StartsWith(info.PositiveSign.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     valueTrim = valueTrim.Slice(info.PositiveSign.Length);
 
-                    if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                    if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                     {
                         result = double.PositiveInfinity;
                     }
-                    else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                    else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                     {
                         result = double.NaN;
                     }
@@ -2490,8 +2490,8 @@ namespace J2N.Numerics
                         return false;
                     }
                 }
-                else if (valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
-                        valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.StartsWith(info.NegativeSign.AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                        valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = double.NaN;
                 }
@@ -2589,27 +2589,27 @@ namespace J2N.Numerics
                 // we don't so we'll check the existing cases first and then handle `PositiveSign` +
                 // `PositiveInfinitySymbol` and `PositiveSign/NegativeSign` + `NaNSymbol` last.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = double.PositiveInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol.AsSpan()))
                 {
                     result = double.NegativeInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = double.NaN;
                 }
-                else if (valueTrim.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase))
+                else if (valueTrim.StartsWith(info.PositiveSign.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     valueTrim = valueTrim.Slice(info.PositiveSign.Length);
 
-                    if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                    if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                     {
                         result = double.PositiveInfinity;
                     }
-                    else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                    else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                     {
                         result = double.NaN;
                     }
@@ -2619,8 +2619,8 @@ namespace J2N.Numerics
                         return false;
                     }
                 }
-                else if (valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
-                        valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.StartsWith(info.NegativeSign.AsSpan(), StringComparison.OrdinalIgnoreCase) &&
+                        valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = double.NaN;
                 }
@@ -2811,27 +2811,27 @@ namespace J2N.Numerics
                 // to include `PositiveSign`, we need to check whether `PositiveInfinitySymbol` fits
                 // that case so that we don't start parsing things like `++infini`.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = float.PositiveInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol.AsSpan()))
                 {
                     result = float.NegativeInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = float.NaN;
                 }
-                else if (valueTrim.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase))
+                else if (valueTrim.StartsWith(info.PositiveSign.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     valueTrim = valueTrim.Slice(info.PositiveSign.Length);
 
-                    if (!info.PositiveInfinitySymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                    if (!info.PositiveInfinitySymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                     {
                         result = float.PositiveInfinity;
                     }
-                    else if (!info.NaNSymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                    else if (!info.NaNSymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                     {
                         result = float.NaN;
                     }
@@ -2841,9 +2841,9 @@ namespace J2N.Numerics
                         return false;
                     }
                 }
-                else if (valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
+                else if (valueTrim.StartsWith(info.NegativeSign.AsSpan(), StringComparison.OrdinalIgnoreCase) &&
                          !info.NaNSymbol.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
-                         valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                         valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = float.NaN;
                 }
@@ -2950,27 +2950,27 @@ namespace J2N.Numerics
                 // to include `PositiveSign`, we need to check whether `PositiveInfinitySymbol` fits
                 // that case so that we don't start parsing things like `++infini`.
 
-                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                if (valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                 {
                     result = float.PositiveInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NegativeInfinitySymbol.AsSpan()))
                 {
                     result = float.NegativeInfinity;
                 }
-                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                else if (valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = float.NaN;
                 }
-                else if (valueTrim.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase))
+                else if (valueTrim.StartsWith(info.PositiveSign.AsSpan(), StringComparison.OrdinalIgnoreCase))
                 {
                     valueTrim = valueTrim.Slice(info.PositiveSign.Length);
 
-                    if (!info.PositiveInfinitySymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol))
+                    if (!info.PositiveInfinitySymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.PositiveInfinitySymbol.AsSpan()))
                     {
                         result = float.PositiveInfinity;
                     }
-                    else if (!info.NaNSymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                    else if (!info.NaNSymbol.StartsWith(info.PositiveSign, StringComparison.OrdinalIgnoreCase) && valueTrim.EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                     {
                         result = float.NaN;
                     }
@@ -2980,9 +2980,9 @@ namespace J2N.Numerics
                         return false;
                     }
                 }
-                else if (valueTrim.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
+                else if (valueTrim.StartsWith(info.NegativeSign.AsSpan(), StringComparison.OrdinalIgnoreCase) &&
                          !info.NaNSymbol.StartsWith(info.NegativeSign, StringComparison.OrdinalIgnoreCase) &&
-                         valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol))
+                         valueTrim.Slice(info.NegativeSign.Length).EqualsOrdinalIgnoreCase(info.NaNSymbol.AsSpan()))
                 {
                     result = float.NaN;
                 }

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -935,7 +935,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its double-precision floating-point number equivalent.
@@ -1331,7 +1331,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseDouble(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent.
@@ -1904,7 +1904,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -3023,14 +3023,35 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the current double instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatDouble(value, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(double value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The double number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(double value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatDouble(value, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -1105,7 +1105,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1138,6 +1138,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1185,8 +1189,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1251,7 +1257,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -1385,7 +1392,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1418,6 +1425,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1465,8 +1476,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1531,7 +1544,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -1676,7 +1690,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1709,6 +1723,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1756,8 +1774,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1822,7 +1842,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -1968,7 +1989,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -2001,6 +2022,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -2048,8 +2073,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -2114,7 +2141,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -3271,7 +3299,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -3304,6 +3332,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -3351,8 +3383,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -935,7 +935,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its double-precision floating-point number equivalent.
@@ -1331,7 +1331,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseDouble(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent.
@@ -1904,7 +1904,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -3029,6 +3029,12 @@ namespace J2N.Numerics
             return DotNetNumber.TryFormatDouble(value, format, provider, destination, out charsWritten);
         }
 
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(double value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatDouble(value, format, provider, destination, out charsWritten);
+        }
+
 #endif
 
         #endregion TryFormat

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -935,7 +935,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its double-precision floating-point number equivalent.
@@ -1331,7 +1331,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseDouble(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent.
@@ -1904,7 +1904,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseDouble(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its double-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -3019,6 +3019,20 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatDouble(value, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region Compare
 
         /// <summary>

--- a/src/J2N/Numerics/FormattingHelpers.cs
+++ b/src/J2N/Numerics/FormattingHelpers.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace J2N.Numerics //J2N.Buffers.Text
+{
+    internal static partial class FormattingHelpers
+    {
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int CountDigits(ulong value)
+        {
+            int digits = 1;
+            uint part;
+            if (value >= 10000000)
+            {
+                if (value >= 100000000000000)
+                {
+                    part = (uint)(value / 100000000000000);
+                    digits += 14;
+                }
+                else
+                {
+                    part = (uint)(value / 10000000);
+                    digits += 7;
+                }
+            }
+            else
+            {
+                part = (uint)value;
+            }
+
+            if (part < 10)
+            {
+                // no-op
+            }
+            else if (part < 100)
+            {
+                digits++;
+            }
+            else if (part < 1000)
+            {
+                digits += 2;
+            }
+            else if (part < 10000)
+            {
+                digits += 3;
+            }
+            else if (part < 100000)
+            {
+                digits += 4;
+            }
+            else if (part < 1000000)
+            {
+                digits += 5;
+            }
+            else
+            {
+                Debug.Assert(part < 10000000);
+                digits += 6;
+            }
+
+            return digits;
+        }
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int CountDigits(uint value)
+        {
+            int digits = 1;
+            if (value >= 100000)
+            {
+                value /= 100000;
+                digits += 5;
+            }
+
+            if (value < 10)
+            {
+                // no-op
+            }
+            else if (value < 100)
+            {
+                digits++;
+            }
+            else if (value < 1000)
+            {
+                digits += 2;
+            }
+            else if (value < 10000)
+            {
+                digits += 3;
+            }
+            else
+            {
+                Debug.Assert(value < 100000);
+                digits += 4;
+            }
+
+            return digits;
+        }
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int CountHexDigits(ulong value)
+        {
+            // The number of hex digits is log16(value) + 1, or log2(value) / 4 + 1
+            return (BitOperation.Log2(value) >> 2) + 1;
+        }
+
+        // Counts the number of trailing '0' digits in a decimal number.
+        // e.g., value =      0 => retVal = 0, valueWithoutTrailingZeros = 0
+        //       value =   1234 => retVal = 0, valueWithoutTrailingZeros = 1234
+        //       value = 320900 => retVal = 2, valueWithoutTrailingZeros = 3209
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int CountDecimalTrailingZeros(uint value, out uint valueWithoutTrailingZeros)
+        {
+            int zeroCount = 0;
+
+            if (value != 0)
+            {
+                while (true)
+                {
+                    uint temp = value / 10;
+                    if (value != (temp * 10))
+                    {
+                        break;
+                    }
+
+                    value = temp;
+                    zeroCount++;
+                }
+            }
+
+            valueWithoutTrailingZeros = value;
+            return zeroCount;
+        }
+    }
+}

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -1692,7 +1692,11 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse(ReadOnlySpan<char> s, out short result)
         {
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return short.TryParse(s, out result);
+#else
+            return short.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 
@@ -2075,7 +2079,11 @@ namespace J2N.Numerics
         public static short Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseShort()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return short.Parse(s, style.ToNumberStyles(), provider);
+#else
+            return short.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2496,7 +2504,11 @@ namespace J2N.Numerics
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out short result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return short.TryParse(s, style.ToNumberStyles(), provider, out result);
+#else
+            return short.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -1745,11 +1745,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1803,9 +1803,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -1864,6 +1884,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -1871,10 +1896,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -1939,11 +1966,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1997,9 +2024,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2058,6 +2105,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -2065,10 +2117,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2193,11 +2247,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2249,8 +2303,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2311,7 +2385,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2339,10 +2414,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in <paramref name="style"/>
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2413,11 +2490,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2471,6 +2548,26 @@ namespace J2N.Numerics
         ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2531,7 +2628,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The type suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2559,10 +2657,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, s must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -455,7 +455,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -897,7 +897,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int16
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1621,7 +1621,7 @@ namespace J2N.Numerics
             return short.TryParse(s, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1889,7 +1889,7 @@ namespace J2N.Numerics
             return short.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 16-bit signed integer equivalent.
@@ -2290,7 +2290,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -455,7 +455,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -897,7 +897,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int16
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1621,7 +1621,7 @@ namespace J2N.Numerics
             return short.TryParse(s, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1889,7 +1889,7 @@ namespace J2N.Numerics
             return short.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 16-bit signed integer equivalent.
@@ -2290,7 +2290,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -1332,6 +1332,63 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32
 
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>. 
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt16(string?, int)"/> method. It differs in that
+        /// it allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/>.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="short"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <returns>A 16-bit signed integer that is equivalent to the number in <paramref name="s"/>, or 0 (zero) if
+        /// <paramref name="s"/> is <c>null</c>.</returns>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of a long integer (bit 15) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="short"/>
+        /// data type is converted to a <see cref="short"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// <paramref name="s"/> contains a character that is not a valid digit in the base specified by <paramref name="radix"/>.
+        /// The exception message indicates that there are no digits to convert if the first character in <paramref name="s"/> is invalid;
+        /// otherwise, the message indicates that <paramref name="s"/> contains invalid trailing characters.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="s"/> contains only a the ASCII character \u002d ('-') or \u002B ('+') sign and/or hexadecimal
+        /// prefix 0X or 0x with no digits.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="s"/> represents a number that is less than <see cref="short.MinValue"/> or greater than <see cref="short.MaxValue"/>.
+        /// </exception>
+        /// <seealso cref="TryParse(ReadOnlySpan{char}, int, out short)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static short Parse(ReadOnlySpan<char> s, int radix) // J2N: Renamed from ParseShort()
+        {
+            int r = ParseNumbers.StringToInt(s, radix, ParseNumbers.IsTight | ParseNumbers.TreatAsI2);
+            if (radix != 10 && r <= ushort.MaxValue)
+                return (short)r;
+
+            if (r < short.MinValue || r > short.MaxValue)
+                throw new OverflowException(SR.Overflow_Int16);
+            return (short)r;
+        }
+
+#endif
+
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>. 
         /// <para/>
@@ -1393,6 +1450,71 @@ namespace J2N.Numerics
         #endregion Parse_CharSequence_Int32
 
         #region TryParse_CharSequence_Int32_Int16
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>.
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt16(string?, int)"/> method. It differs in that it
+        /// allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/> and allows any 
+        /// <paramref name="radix"/> value from <see cref="Character.MinRadix"/> to <see cref="Character.MaxRadix"/> inclusive.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// <para/>
+        /// Since <see cref="Parse(ReadOnlySpan{char}, int)"/> throws many different exception types and in Java they are all normalized to
+        /// <c>NumberFormatException</c>, this method can be used to mimic the same behavior by throwing <see cref="FormatException"/>
+        /// when this method returns <c>false</c>.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="short"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <param name="result">The signed <see cref="short"/> represented by the subsequence in the specified <paramref name="radix"/>.</param>
+        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of an integer (bit 15) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="short"/>
+        /// data type is converted to a <see cref="short"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int, int, int)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static bool TryParse(ReadOnlySpan<char> s, int radix, out short result) // J2N: Renamed from ParseShort()
+        {
+            if (radix < Character.MinRadix || radix > Character.MaxRadix)
+                throw new ArgumentOutOfRangeException(nameof(radix), SR.ArgumentOutOfRange_Radix);
+
+            if (!ParseNumbers.TryStringToInt(s, radix, ParseNumbers.IsTight | ParseNumbers.TreatAsI2, out int r))
+            {
+                result = default;
+                return false;
+            }
+
+            if (radix != 10 && r <= ushort.MaxValue)
+            {
+                result = (short)r;
+                return true;
+            }
+
+            if (r < short.MinValue || r > short.MaxValue)
+            {
+                result = default;
+                return false;
+            }
+
+            result = (short)r;
+            return true;
+        }
+
+#endif
 
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>.

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -455,7 +455,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -897,7 +897,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int16
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="short"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1636,7 +1636,7 @@ namespace J2N.Numerics
                 , NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1909,7 +1909,7 @@ namespace J2N.Numerics
                 , style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 16-bit signed integer equivalent.
@@ -2374,7 +2374,7 @@ namespace J2N.Numerics
                 , style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 16-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -3096,14 +3096,36 @@ namespace J2N.Numerics
         #region TryFormat
 
 #if FEATURE_SPAN
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+
+        /// <summary>
+        /// Tries to format the value of the current short number instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, 0x0000FFFF, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(short value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The short number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(short value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, 0x0000FFFF, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -1542,7 +1542,12 @@ namespace J2N.Numerics
         /// <seealso cref="GetInstance(string, IFormatProvider?)"/>
         public static short Parse(string s, IFormatProvider? provider) // J2N: Renamed from ParseShort()
         {
-            return short.Parse(s, provider);
+            if (s is null) throw new ArgumentNullException(nameof(s));
+            return Parse(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , NumberStyle.Integer, NumberFormatInfo.GetInstance(provider));
         }
 
         #endregion Parse_CharSequence_IFormatProvider
@@ -1618,7 +1623,17 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse([NotNullWhen(true)] string? s, out short result)
         {
-            return short.TryParse(s, out result);
+            if (s == null)
+            {
+                result = 0;
+                return false;
+            }
+
+            return TryParse(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
 #if FEATURE_READONLYSPAN
@@ -1692,11 +1707,7 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse(ReadOnlySpan<char> s, out short result)
         {
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return short.TryParse(s, out result);
-#else
-            return short.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 #endif
 
@@ -1890,7 +1901,12 @@ namespace J2N.Numerics
         public static short Parse(string s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseShort()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return short.Parse(s, style.ToNumberStyles(), provider);
+            if (s is null) throw new ArgumentNullException(nameof(s));
+            return Parse(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider));
         }
 
 #if FEATURE_READONLYSPAN
@@ -2079,14 +2095,64 @@ namespace J2N.Numerics
         public static short Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseShort()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return short.Parse(s, style.ToNumberStyles(), provider);
-#else
-            return short.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return Parse(s, style, NumberFormatInfo.GetInstance(provider));
         }
+
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
+
+        #region Parse_CharSequence_NumberStyle_NumberFormatInfo
+
+#if FEATURE_SPAN
+        private static short Parse(ReadOnlySpan<char> s, NumberStyle style, NumberFormatInfo info)
+#else
+        private static short Parse(string s, NumberStyle style, NumberFormatInfo info)
+#endif
+        {
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, info, out int i);
+            if (status != DotNetNumber.ParsingStatus.OK)
+            {
+                if (status == DotNetNumber.ParsingStatus.Overflow)
+                    DotNetNumber.ThrowOverflowException(TypeCode.Int16);
+                else
+                    DotNetNumber.ThrowFormatException(s.ToString());
+            }
+
+            // For hex number styles AllowHexSpecifier << 6 == 0x8000 and cancels out MinValue so the check is effectively: (uint)i > ushort.MaxValue
+            // For integer styles it's zero and the effective check is (uint)(i - MinValue) > ushort.MaxValue
+            if ((uint)(i - short.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) << 6)) > ushort.MaxValue)
+            {
+                DotNetNumber.ThrowOverflowException(TypeCode.Int16);
+            }
+            return (short)i;
+        }
+
+        #endregion Parse_CharSequence_NumberStyle_NumberFormatInfo
+
+        #region TryParse_CharSequence_NumberStyle_NumberFormatInfo_Int16
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+#if FEATURE_SPAN
+        private static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, NumberFormatInfo info, out short result)
+#else
+        private static bool TryParse(string s, NumberStyle style, NumberFormatInfo info, out short result)
+#endif
+        {
+            // For hex number styles AllowHexSpecifier << 6 == 0x8000 and cancels out MinValue so the check is effectively: (uint)i > ushort.MaxValue
+            // For integer styles it's zero and the effective check is (uint)(i - MinValue) > ushort.MaxValue
+            if (DotNetNumber.TryParseInt32(s, style, info, out int i) != DotNetNumber.ParsingStatus.OK
+                || (uint)(i - short.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) << 6)) > ushort.MaxValue)
+            {
+                result = 0;
+                return false;
+            }
+            result = (short)i;
+            return true;
+        }
+
+        #endregion TryParse_CharSequence_NumberStyle_NumberFormatInfo_Int16
 
         #region TryParse_CharSequence_NumberStyle_IFormatProvider_Int16
 
@@ -2294,9 +2360,19 @@ namespace J2N.Numerics
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out short result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return short.TryParse(s, style.ToNumberStyles(), provider, out result);
-        }
 
+            if (s == null)
+            {
+                result = 0;
+                return false;
+            }
+
+            return TryParse(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider), out result);
+        }
 
 #if FEATURE_READONLYSPAN
         /// <summary>
@@ -2504,11 +2580,7 @@ namespace J2N.Numerics
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out short result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return short.TryParse(s, style.ToNumberStyles(), provider, out result);
-#else
-            return short.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return TryParse(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 #endif
 

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -3093,6 +3093,25 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, 0x0000FFFF, format, provider, destination, out charsWritten);
+        }
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(short value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, 0x0000FFFF, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region ReverseBytes
 
         /// <summary>

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1576,7 +1576,11 @@ namespace J2N.Numerics
 #endif 
         public static bool TryParse(ReadOnlySpan<char> s, out int result)
         {
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return int.TryParse(s, out result);
+#else
+            return int.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 
@@ -1959,7 +1963,11 @@ namespace J2N.Numerics
         public static int Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return int.Parse(s, style.ToNumberStyles(), provider);
+#else
+            return int.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2380,7 +2388,11 @@ namespace J2N.Numerics
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return int.TryParse(s, style.ToNumberStyles(), provider, out result);
+#else
+            return int.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1425,7 +1425,12 @@ namespace J2N.Numerics
         /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
         public static int Parse(string s, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
-            return Parse(s, NumberStyle.Integer, provider);
+            if (s == null) throw new ArgumentNullException(nameof(s));
+            return DotNetNumber.ParseInt32(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , NumberStyle.Integer, NumberFormatInfo.GetInstance(provider));
         }
 
         #endregion
@@ -1502,7 +1507,13 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse([NotNullWhen(true)] string? s, out int result)
         {
-            return int.TryParse(s, out result);
+            if (s == null)
+            {
+                result = 0;
+                return false;
+            }
+
+            return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
         }
 
 #if FEATURE_READONLYSPAN
@@ -1576,11 +1587,7 @@ namespace J2N.Numerics
 #endif 
         public static bool TryParse(ReadOnlySpan<char> s, out int result)
         {
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return int.TryParse(s, out result);
-#else
-            return int.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
         }
 #endif
 
@@ -1774,7 +1781,12 @@ namespace J2N.Numerics
         public static int Parse(string s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return int.Parse(s, style.ToNumberStyles(), provider);
+            if (s == null) throw new ArgumentNullException(nameof(s));
+            return DotNetNumber.ParseInt32(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider));
         }
 
 #if FEATURE_READONLYSPAN
@@ -1963,11 +1975,7 @@ namespace J2N.Numerics
         public static int Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return int.Parse(s, style.ToNumberStyles(), provider);
-#else
-            return int.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return DotNetNumber.ParseInt32(s, style, NumberFormatInfo.GetInstance(provider));
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2178,7 +2186,18 @@ namespace J2N.Numerics
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return int.TryParse(s, style.ToNumberStyles(), provider, out result);
+
+            if (s == null)
+            {
+                result = 0;
+                return false;
+            }
+
+            return DotNetNumber.TryParseInt32(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
         }
 
 
@@ -2388,11 +2407,7 @@ namespace J2N.Numerics
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return int.TryParse(s, style.ToNumberStyles(), provider, out result);
-#else
-            return int.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
         }
 #endif
 

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -486,7 +486,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -896,7 +896,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1505,7 +1505,7 @@ namespace J2N.Numerics
             return int.TryParse(s, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1773,7 +1773,7 @@ namespace J2N.Numerics
             return int.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 32-bit signed integer equivalent.
@@ -2174,7 +2174,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.
@@ -2376,7 +2376,7 @@ namespace J2N.Numerics
         /// <seealso cref="NumberStyle"/>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
+#endif
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1425,12 +1425,7 @@ namespace J2N.Numerics
         /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
         public static int Parse(string s, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
-            if (s == null) throw new ArgumentNullException(nameof(s));
-            return DotNetNumber.ParseInt32(s
-#if FEATURE_SPAN
-                .AsSpan()
-#endif
-                , NumberStyle.Integer, NumberFormatInfo.GetInstance(provider));
+            return Parse(s, NumberStyle.Integer, provider);
         }
 
         #endregion
@@ -1507,13 +1502,7 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse([NotNullWhen(true)] string? s, out int result)
         {
-            if (s == null)
-            {
-                result = 0;
-                return false;
-            }
-
-            return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
+            return int.TryParse(s, out result);
         }
 
 #if FEATURE_READONLYSPAN
@@ -1587,7 +1576,11 @@ namespace J2N.Numerics
 #endif 
         public static bool TryParse(ReadOnlySpan<char> s, out int result)
         {
-            return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+            return int.TryParse(s, out result);
+#else
+            return int.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 
@@ -1781,12 +1774,7 @@ namespace J2N.Numerics
         public static int Parse(string s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            if (s == null) throw new ArgumentNullException(nameof(s));
-            return DotNetNumber.ParseInt32(s
-#if FEATURE_SPAN
-                .AsSpan()
-#endif
-                , style, NumberFormatInfo.GetInstance(provider));
+            return int.Parse(s, style.ToNumberStyles(), provider);
         }
 
 #if FEATURE_READONLYSPAN
@@ -1975,7 +1963,11 @@ namespace J2N.Numerics
         public static int Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseInt()
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return DotNetNumber.ParseInt32(s, style, NumberFormatInfo.GetInstance(provider));
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+            return int.Parse(s, style.ToNumberStyles(), provider);
+#else
+            return int.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2186,18 +2178,7 @@ namespace J2N.Numerics
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-
-            if (s == null)
-            {
-                result = 0;
-                return false;
-            }
-
-            return DotNetNumber.TryParseInt32(s
-#if FEATURE_SPAN
-                .AsSpan()
-#endif
-                , style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
+            return int.TryParse(s, style.ToNumberStyles(), provider, out result);
         }
 
 
@@ -2407,7 +2388,11 @@ namespace J2N.Numerics
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
+            return int.TryParse(s, style.ToNumberStyles(), provider, out result);
+#else
+            return int.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -486,7 +486,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -896,7 +896,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1516,7 +1516,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1789,7 +1789,7 @@ namespace J2N.Numerics
                 , style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 32-bit signed integer equivalent.
@@ -2201,7 +2201,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1247,6 +1247,55 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32
 
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>. 
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt64(string?, int)"/> method. It differs in that
+        /// it allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/>.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="int"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <returns>A 32-bit signed integer that is equivalent to the number in <paramref name="s"/>, or 0 (zero) if
+        /// <paramref name="s"/> is <c>null</c>.</returns>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of a long integer (bit 31) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="int"/>
+        /// data type is converted to an <see cref="int"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// <paramref name="s"/> contains a character that is not a valid digit in the base specified by <paramref name="radix"/>.
+        /// The exception message indicates that there are no digits to convert if the first character in <paramref name="s"/> is invalid;
+        /// otherwise, the message indicates that <paramref name="s"/> contains invalid trailing characters.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="s"/> contains only a the ASCII character \u002d ('-') or \u002B ('+') sign and/or hexadecimal
+        /// prefix 0X or 0x with no digits.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="s"/> represents a number that is less than <see cref="int.MinValue"/> or greater than <see cref="int.MaxValue"/>.
+        /// </exception>
+        /// <seealso cref="TryParse(ReadOnlySpan{char}, int, out int)"/>
+        /// <seealso cref="GetInstance(string?, int)"/>
+        public static int Parse(ReadOnlySpan<char> s, int radix) // J2N: Renamed from ParseInt()
+        {
+            return ParseNumbers.StringToInt(s, radix, ParseNumbers.IsTight);
+        }
+
+#endif
+
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>. 
         /// <para/>
@@ -1297,6 +1346,50 @@ namespace J2N.Numerics
         #endregion Parse_CharSequence_Int32
 
         #region TryParse_CharSequence_Int32_Int32
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>.
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt64(string?, int)"/> method. It differs in that it
+        /// allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/> and allows any 
+        /// <paramref name="radix"/> value from <see cref="Character.MinRadix"/> to <see cref="Character.MaxRadix"/> inclusive.
+        /// <para/>
+        /// Since <see cref="Parse(ReadOnlySpan{char}, int)"/> throws many different exception types and in Java they are all normalized to
+        /// <c>NumberFormatException</c>, this method can be used to mimic the same behavior by throwing <see cref="FormatException"/>
+        /// when this method returns <c>false</c>.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="int"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <param name="result">The signed <see cref="int"/> represented by the subsequence in the specified <paramref name="radix"/>.</param>
+        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of an integer (bit 31) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="int"/>
+        /// data type is converted to an <see cref="int"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int, int, int)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static bool TryParse(ReadOnlySpan<char> s, int radix, out int result) // J2N: Renamed from ParseInt()
+        {
+            if (radix < Character.MinRadix || radix > Character.MaxRadix)
+                throw new ArgumentOutOfRangeException(nameof(radix), SR.ArgumentOutOfRange_Radix);
+
+            return ParseNumbers.TryStringToInt(s, radix, ParseNumbers.IsTight, out result);
+        }
+
+#endif
 
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>.

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -486,7 +486,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -896,7 +896,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="int"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1505,7 +1505,7 @@ namespace J2N.Numerics
             return int.TryParse(s, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1773,7 +1773,7 @@ namespace J2N.Numerics
             return int.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 32-bit signed integer equivalent.
@@ -2174,7 +2174,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 32-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.
@@ -2376,7 +2376,7 @@ namespace J2N.Numerics
         /// <seealso cref="NumberStyle"/>
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
+#endif 
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -2975,14 +2975,36 @@ namespace J2N.Numerics
         #region TryFormat
 
 #if FEATURE_SPAN
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+
+        /// <summary>
+        /// Tries to format the value of the current integer number instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, ~0, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(int value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The integer number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(int value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, ~0, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1513,7 +1513,11 @@ namespace J2N.Numerics
                 return false;
             }
 
-            return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
+            return DotNetNumber.TryParseInt32IntegerStyle(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
         }
 
 #if FEATURE_SPAN
@@ -1625,11 +1629,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1683,9 +1687,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -1744,6 +1768,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -1751,10 +1780,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -1819,11 +1850,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1877,9 +1908,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -1938,6 +1989,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -1945,10 +2001,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2019,11 +2077,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2075,8 +2133,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2137,7 +2215,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The type suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2165,10 +2244,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, s must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2240,11 +2321,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2296,8 +2377,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2358,7 +2459,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2386,10 +2488,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in <paramref name="style"/>
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -2972,6 +2972,25 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, ~0, format, provider, destination, out charsWritten);
+        }
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(int value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, ~0, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region HighestOneBit
 
         /// <summary>

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -488,7 +488,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -893,7 +893,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int64
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1506,7 +1506,7 @@ namespace J2N.Numerics
             return long.TryParse(s, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1775,7 +1775,7 @@ namespace J2N.Numerics
             return long.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 64-bit signed integer equivalent.
@@ -2179,7 +2179,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -1426,7 +1426,12 @@ namespace J2N.Numerics
         /// <seealso cref="GetInstance(string, IFormatProvider?)"/>
         public static long Parse(string s, IFormatProvider? provider) // J2N: Renamed from ParseLong()
         {
-            return Parse(s, NumberStyle.Integer, provider);
+            if (s == null) throw new ArgumentNullException(nameof(s));
+            return DotNetNumber.ParseInt64(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , NumberStyle.Integer, NumberFormatInfo.GetInstance(provider));
         }
 
         #endregion Parse_CharSequence_IFormatProvider
@@ -1577,11 +1582,7 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse(ReadOnlySpan<char> s, out long result)
         {
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return long.TryParse(s, out result);
-#else
-            return long.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return DotNetNumber.TryParseInt64IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
         }
 #endif
 
@@ -1776,7 +1777,13 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return long.Parse(s, style.ToNumberStyles(), provider);
+            if (s == null) throw new ArgumentNullException(nameof(s));
+            return DotNetNumber.ParseInt64(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider));
+
         }
 
 #if FEATURE_READONLYSPAN
@@ -1967,11 +1974,7 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return long.Parse(s, style.ToNumberStyles(), provider);
-#else
-            return long.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
-#endif
+            return DotNetNumber.ParseInt64(s, style, NumberFormatInfo.GetInstance(provider));
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2183,7 +2186,18 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return long.TryParse(s, style.ToNumberStyles(), provider, out result);
+
+            if (s == null)
+            {
+                result = 0;
+                return false;
+            }
+
+            return DotNetNumber.TryParseInt64(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
         }
 
 
@@ -2394,11 +2408,7 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
-            return long.TryParse(s, style.ToNumberStyles(), provider, out result);
-#else
-            return long.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result);
-#endif
+            return DotNetNumber.TryParseInt64(s, style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
         }
 #endif
         #endregion TryParse_CharSequence_NumberStyle_IFormatProvider_Int64

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -488,7 +488,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -893,7 +893,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int64
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1506,7 +1506,7 @@ namespace J2N.Numerics
             return long.TryParse(s, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1775,7 +1775,7 @@ namespace J2N.Numerics
             return long.Parse(s, style.ToNumberStyles(), provider);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 64-bit signed integer equivalent.
@@ -2179,7 +2179,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -1620,11 +1620,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1678,404 +1678,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
-        ///         <term><i>hexdigits</i></term>
-        ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
-        ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
-        ///     </item>
-        /// </list>
-        /// <para/>
-        /// NOTE: Any terminating NUL (U+0000) characters in <paramref name="s"/> are ignored by the parsing operation, regardless of
-        /// the value of the <paramref name="style"/> argument.
-        /// <para/>
-        /// A string with decimal digits only (which corresponds to the <see cref="NumberStyle.None"/> flag) always parses successfully.
-        /// Most of the remaining <see cref="NumberStyle"/> members control elements that may be but are not required to be present in
-        /// this input string. The following table indicates how individual <see cref="NumberStyle"/> members affect the elements that may
-        /// be present in <paramref name="s"/>.
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Non-composite NumberStyle values</term>
-        ///         <term>Elements permitted in <paramref name="s"/> in addition to digits</term>
-        ///     </listheader>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.None"/></term>
-        ///         <term>Decimal digits only.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowDecimalPoint"/></term>
-        ///         <term>The decimal point (.) and <i>fractional-digits</i> elements. However, <i>fractional-digits</i> must consist
-        ///         of only one or more 0 digits or the method returns <c>false</c>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowExponent"/></term>
-        ///         <term>The <paramref name="s"/> parameter can also use exponential notation. If <paramref name="s"/> represents a
-        ///         number in exponential notation, it must represent an integer within the range of the <see cref="long"/> data type
-        ///         without a non-zero, fractional component.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowLeadingWhite"/></term>
-        ///         <term>The <i>ws</i> element at the beginning of <paramref name="s"/>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowTrailingWhite"/></term>
-        ///         <term>The <i>ws</i> element at the end of <paramref name="s"/>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowLeadingSign"/></term>
-        ///         <term>A sign can appear before <i>digits</i>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowTrailingSign"/></term>
-        ///         <term>A sign can appear after <i>digits</i>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowParentheses"/></term>
-        ///         <term>The <i>sign</i> element in the form of parentheses enclosing the numeric value.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowThousands"/></term>
-        ///         <term>The thousands separator (,) element.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
-        ///         <term>The <i>$</i> element.</term>
-        ///     </item>
-        /// </list>
-        /// <para/>
-        /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
-        /// <see cref="NumberStyleExtensions.ToNumberStyles(NumberStyle)"/> extension method.
-        /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
-        /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
-        /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
-        /// <para/>
-        /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
-        /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
-        /// method returns a <see cref="NumberFormatInfo"/> object. The <see cref="NumberFormatInfo"/> object provides culture-specific information about
-        /// the format of <paramref name="s"/>. When the <see cref="Parse(string, IFormatProvider)"/> method is invoked, it calls the provider parameter's
-        /// <see cref="IFormatProvider.GetFormat(Type?)"/> method and passes it a <see cref="Type"/> object that represents the <see cref="NumberFormatInfo"/> type.
-        /// The <see cref="IFormatProvider.GetFormat(Type?)"/> method then returns the <see cref="NumberFormatInfo"/> object that provides information about the
-        /// format of the <paramref name="s"/> parameter. There are three ways to use the <paramref name="provider"/> parameter to supply custom formatting
-        /// information to the parse operation:
-        /// <list type="bullet">
-        ///     <item><description>You can pass a <see cref="CultureInfo"/> object that represents the culture that supplies formatting information. Its
-        ///     <see cref="IFormatProvider.GetFormat(Type?)"/> method returns the <see cref="NumberFormatInfo"/> object that provides numeric formatting
-        ///     information for that culture.</description></item>
-        ///     <item><description>You can pass the actual <see cref="NumberFormatInfo"/> object that provides numeric formatting information. (Its
-        ///     implementation of <see cref="IFormatProvider.GetFormat(Type?)"/> just returns itself.)</description></item>
-        ///     <item><description>You can pass a custom object that implements <see cref="IFormatProvider"/>. Its <see cref="IFormatProvider.GetFormat(Type?)"/>
-        ///     method instantiates and returns the <see cref="NumberFormatInfo"/> object that provides formatting information.</description></item>
-        /// </list>
-        /// If <paramref name="provider"/> is <c>null</c> or a <see cref="NumberFormatInfo"/> object cannot be obtained, the <see cref="NumberFormatInfo"/>
-        /// object for the current culture is used.
-        /// </remarks>
-        /// <seealso cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/>
-        /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
-        public static long Parse(string s, NumberStyle style , IFormatProvider? provider) // J2N: Renamed from ParseLong()
-        {
-            // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
-            NumberStyleExtensions.ValidateParseStyleInteger(style);
-            if (s == null) throw new ArgumentNullException(nameof(s));
-            return DotNetNumber.ParseInt64(s
-#if FEATURE_SPAN
-                .AsSpan()
-#endif
-                , style, NumberFormatInfo.GetInstance(provider));
-
-        }
-
-#if FEATURE_SPAN
-        /// <summary>
-        /// Converts the string representation of a number in a specified style and culture-specific format to its
-        /// 64-bit signed integer equivalent.
-        /// </summary>
-        /// <param name="s">A string containing a number to convert.</param>
-        /// <param name="style">A bitwise combination of enumeration values that indicates the style elements that can be
-        /// present in <paramref name="s"/>. A typical value to specify is <see cref="NumberStyle.Integer"/>.</param>
-        /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information about <paramref name="s"/>.</param>
-        /// <returns>A 64-bit signed integer equivalent to the number specified in <paramref name="s"/>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="s"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="style"/> is not a <see cref="NumberStyle"/> value.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="style"/> is not a combination of <see cref="NumberStyle.AllowHexSpecifier"/> and <see cref="NumberStyle.HexNumber"/> values.
-        /// </exception>
-        /// <exception cref="FormatException"><paramref name="s"/> is not in a format compliant with <paramref name="style"/>.</exception>
-        /// <exception cref="OverflowException">
-        /// <paramref name="s"/> represents a number less than <see cref="long.MinValue"/> or greater than <see cref="long.MaxValue"/>.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="s"/> includes non-zero fractional digits.
-        /// </exception>
-        /// <remarks>
-        /// The <paramref name="style"/> parameter defines the style elements (such as white space or the positive sign) that are allowed in the
-        /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
-        /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
-        /// <para/>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
-        /// <para/>
-        /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
-        /// <para/>
-        /// [ws]hexdigits[ws]
-        /// <para/>
-        /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
-        /// <para/>
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Element</term>
-        ///         <term>Description</term>
-        ///     </listheader>
-        ///     <item>
-        ///         <term><i>ws</i></term>
-        ///         <term>A series of white-space characters. White space can appear at the beginning of <paramref name="s"/> if style includes the
-        ///             <see cref="NumberStyle.AllowLeadingWhite"/> flag, and it can appear at the end of <paramref name="s"/> if style includes the
-        ///             <see cref="NumberStyle.AllowTrailingWhite"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>$</i></term>
-        ///         <term>A culture-specific currency symbol. Its position in the string is defined by the <see cref="NumberFormatInfo.CurrencyNegativePattern"/>
-        ///             and <see cref="NumberFormatInfo.CurrencyPositivePattern"/> properties of the <see cref="NumberFormatInfo"/> object returned by the
-        ///             <see cref="IFormatProvider.GetFormat(Type?)"/> method of the <paramref name="provider"/> parameter. The current culture's currency symbol can
-        ///             appear in <paramref name="s"/> if style includes the <see cref="NumberStyle.AllowCurrencySymbol"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>sign</i></term>
-        ///         <term>A negative sign symbol (-) or a positive sign symbol (+). The sign can appear at the beginning of <paramref name="s"/> if
-        ///             <paramref name="style"/> includes the <see cref="NumberStyle.AllowLeadingSign"/> flag, and it can appear at the end of <paramref name="s"/>
-        ///             if <paramref name="style"/> includes the <see cref="NumberStyle.AllowTrailingSign"/> flag. Parentheses can be used in <paramref name="s"/>
-        ///             to indicate a negative value if <paramref name="style"/> includes the <see cref="NumberStyle.AllowParentheses"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>digits</i></term>
-        ///         <term>A series of digits ranging from 0 to 9.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>.</i></term>
-        ///         <term>A culture-specific decimal point symbol. The decimal point symbol of the culture specified by <paramref name="provider"/>
-        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>fractional-digits</i>
-        ///         </term>
-        ///         <term>A series of digits ranging from 0 to 9 that specify the fractional part of the number. Fractional digits can appear in
-        ///         <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>e</i></term>
-        ///         <term>The 'e' or 'E' character, which indicates that the value is represented in exponential notation. The <paramref name="s"/>
-        ///         parameter can represent a number in exponential notation if <paramref name="style"/> includes the <see cref="NumberStyle.AllowExponent"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>exponential-digits</i></term>
-        ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
         ///     </item>
-        /// </list>
-        /// <para/>
-        /// NOTE: Any terminating NUL (U+0000) characters in <paramref name="s"/> are ignored by the parsing operation, regardless of
-        /// the value of the <paramref name="style"/> argument.
-        /// <para/>
-        /// A string with decimal digits only (which corresponds to the <see cref="NumberStyle.None"/> flag) always parses successfully.
-        /// Most of the remaining <see cref="NumberStyle"/> members control elements that may be but are not required to be present in
-        /// this input string. The following table indicates how individual <see cref="NumberStyle"/> members affect the elements that may
-        /// be present in <paramref name="s"/>.
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Non-composite NumberStyle values</term>
-        ///         <term>Elements permitted in <paramref name="s"/> in addition to digits</term>
-        ///     </listheader>
         ///     <item>
-        ///         <term><see cref="NumberStyle.None"/></term>
-        ///         <term>Decimal digits only.</term>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
         ///     </item>
         ///     <item>
-        ///         <term><see cref="NumberStyle.AllowDecimalPoint"/></term>
-        ///         <term>The decimal point (.) and <i>fractional-digits</i> elements. However, <i>fractional-digits</i> must consist
-        ///         of only one or more 0 digits or the method returns <c>false</c>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowExponent"/></term>
-        ///         <term>The <paramref name="s"/> parameter can also use exponential notation. If <paramref name="s"/> represents a
-        ///         number in exponential notation, it must represent an integer within the range of the <see cref="long"/> data type
-        ///         without a non-zero, fractional component.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowLeadingWhite"/></term>
-        ///         <term>The <i>ws</i> element at the beginning of <paramref name="s"/>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowTrailingWhite"/></term>
-        ///         <term>The <i>ws</i> element at the end of <paramref name="s"/>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowLeadingSign"/></term>
-        ///         <term>A sign can appear before <i>digits</i>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowTrailingSign"/></term>
-        ///         <term>A sign can appear after <i>digits</i>.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowParentheses"/></term>
-        ///         <term>The <i>sign</i> element in the form of parentheses enclosing the numeric value.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowThousands"/></term>
-        ///         <term>The thousands separator (,) element.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
-        ///         <term>The <i>$</i> element.</term>
-        ///     </item>
-        /// </list>
-        /// <para/>
-        /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
-        /// <see cref="NumberStyleExtensions.ToNumberStyles(NumberStyle)"/> extension method.
-        /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
-        /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
-        /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
-        /// <para/>
-        /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
-        /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
-        /// method returns a <see cref="NumberFormatInfo"/> object. The <see cref="NumberFormatInfo"/> object provides culture-specific information about
-        /// the format of <paramref name="s"/>. When the <see cref="Parse(string, IFormatProvider)"/> method is invoked, it calls the provider parameter's
-        /// <see cref="IFormatProvider.GetFormat(Type?)"/> method and passes it a <see cref="Type"/> object that represents the <see cref="NumberFormatInfo"/> type.
-        /// The <see cref="IFormatProvider.GetFormat(Type?)"/> method then returns the <see cref="NumberFormatInfo"/> object that provides information about the
-        /// format of the <paramref name="s"/> parameter. There are three ways to use the <paramref name="provider"/> parameter to supply custom formatting
-        /// information to the parse operation:
-        /// <list type="bullet">
-        ///     <item><description>You can pass a <see cref="CultureInfo"/> object that represents the culture that supplies formatting information. Its
-        ///     <see cref="IFormatProvider.GetFormat(Type?)"/> method returns the <see cref="NumberFormatInfo"/> object that provides numeric formatting
-        ///     information for that culture.</description></item>
-        ///     <item><description>You can pass the actual <see cref="NumberFormatInfo"/> object that provides numeric formatting information. (Its
-        ///     implementation of <see cref="IFormatProvider.GetFormat(Type?)"/> just returns itself.)</description></item>
-        ///     <item><description>You can pass a custom object that implements <see cref="IFormatProvider"/>. Its <see cref="IFormatProvider.GetFormat(Type?)"/>
-        ///     method instantiates and returns the <see cref="NumberFormatInfo"/> object that provides formatting information.</description></item>
-        /// </list>
-        /// If <paramref name="provider"/> is <c>null</c> or a <see cref="NumberFormatInfo"/> object cannot be obtained, the <see cref="NumberFormatInfo"/>
-        /// object for the current culture is used.
-        /// </remarks>
-        /// <seealso cref="TryParse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?, out long)"/>
-        /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
-        public static long Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseLong()
-        {
-            // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
-            NumberStyleExtensions.ValidateParseStyleInteger(style);
-            return DotNetNumber.ParseInt64(s, style, NumberFormatInfo.GetInstance(provider));
-        }
-#endif
-        #endregion Parse_CharSequence_NumberStyle_IFormatProvider
-
-        #region TryParse_CharSequence_NumberStyle_IFormatProvider_Int64
-
-        /// <summary>
-        /// Converts the string representation of a number in a specified style and culture-specific format to its
-        /// 64-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
-        /// <para/>
-        /// Usage Note: To exactly match Java, use <see cref="NumberStyle.AllowLeadingSign"/> for <paramref name="style"/> and
-        /// <see cref="NumberFormatInfo.InvariantInfo"/> for <paramref name="provider"/>. We recommend factoring out
-        /// exceptions when parsing, but if the Java code depends on exceptions, throw <see cref="FormatException"/>
-        /// when this method returns <c>false</c>.
-        /// </summary>
-        /// <param name="s">A string containing a number to convert. The string is interpreted using the style specified by <paramref name="style"/>.</param>
-        /// <param name="style">A bitwise combination of enumeration values that indicates the style elements that can be present in <paramref name="s"/>.
-        /// A typical value to specify is <see cref="NumberStyle.Integer"/>.</param>
-        /// <param name="provider">An object that supplies culture-specific formatting information about <paramref name="s"/>.</param>
-        /// <param name="result">When this method returns, contains the 64-bit signed integer value equivalent of
-        /// the number contained in <paramref name="s"/>, if the conversion succeeded, or zero if the conversion failed.
-        /// The conversion fails if the s parameter is <c>null</c> or <see cref="string.Empty"/>, is not of the correct format,
-        /// or represents a number less than <see cref="long.MinValue"/> or greater than <see cref="long.MaxValue"/>. This parameter
-        /// is passed uninitialized; any value originally supplied in <paramref name="result"/> will be overwritten.</param>
-        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="style"/> is not a <see cref="NumberStyle"/> value.
-        /// <para/>
-        /// -or-
-        /// <para/>
-        /// <paramref name="style"/> is not a combination of <see cref="NumberStyle.AllowHexSpecifier"/> and <see cref="NumberStyle.HexNumber"/> values.
-        /// </exception>
-        /// <remarks>
-        /// The <see cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/> method is like the <see cref="Parse(string, NumberStyle, IFormatProvider?)"/> method,
-        /// except the <see cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/> method does not throw an exception if the
-        /// conversion fails. It eliminates the need to use exception handling to test for a <see cref="FormatException"/>
-        /// in the event that <paramref name="s"/> is invalid and cannot be successfully parsed.
-        /// <para/>
-        /// The <paramref name="style"/> parameter defines the style elements (such as white space or a positive or negative sign)
-        /// that are allowed in the <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of
-        /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
-        /// parameter may include the following elements:
-        /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
-        /// </code>
-        /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
-        /// <code>
-        /// [ws]hexdigits[ws]
-        /// </code>
-        /// Items in square brackets ([ and ]) are optional. The following table describes each element.
-        /// <list type="table">
-        ///     <listheader>
-        ///         <term>Element</term>
-        ///         <term>Description</term>
-        ///     </listheader>
-        ///     <item>
-        ///         <term><i>ws</i></term>
-        ///         <term>Optional white space.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>$</i></term>
-        ///         <term>A culture-specific currency symbol. Its position in the string is defined by the <see cref="NumberFormatInfo.CurrencyPositivePattern"/>
-        ///         property of the <see cref="NumberFormatInfo"/> object returned by the <see cref="IFormatProvider.GetFormat(Type?)"/> method of the
-        ///         <paramref name="provider"/> parameter. The currency symbol can appear in <paramref name="s"/> if style includes the
-        ///         <see cref="NumberStyle.AllowCurrencySymbol"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>sign</i></term>
-        ///         <term>An optional sign.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>digits</i></term>
-        ///         <term>A sequence of digits ranging from 0 to 9.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>,</i></term>
-        ///         <term>A culture-specific thousands separator. The thousands separator of the culture specified by <paramref name="provider"/>
-        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowThousands"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>.</i></term>
-        ///         <term>A culture-specific decimal point symbol. The decimal point symbol of the culture specified by <paramref name="provider"/>
-        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>fractional-digits</i></term>
-        ///         <term>One or more occurrences of the digit 0. Fractional digits can appear in <paramref name="s"/> only if style includes
-        ///         the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>e</i></term>
-        ///         <term>The 'e' or 'E' character, which indicates that the value is represented in exponential notation. The <paramref name="s"/>
-        ///         parameter can represent a number in exponential notation if style includes the <see cref="NumberStyle.AllowExponent"/> flag.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>exponential-digits</i></term>
-        ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
-        ///     </item>
-        ///     <item>
-        ///         <term><i>hexdigits</i></term>
-        ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2136,7 +1761,455 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The type suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
+        /// </list>
+        /// <para/>
+        /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
+        /// <see cref="NumberStyleExtensions.ToNumberStyles(NumberStyle)"/> extension method.
+        /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
+        /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
+        /// <para/>
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
+        /// <para/>
+        /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
+        /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
+        /// method returns a <see cref="NumberFormatInfo"/> object. The <see cref="NumberFormatInfo"/> object provides culture-specific information about
+        /// the format of <paramref name="s"/>. When the <see cref="Parse(string, IFormatProvider)"/> method is invoked, it calls the provider parameter's
+        /// <see cref="IFormatProvider.GetFormat(Type?)"/> method and passes it a <see cref="Type"/> object that represents the <see cref="NumberFormatInfo"/> type.
+        /// The <see cref="IFormatProvider.GetFormat(Type?)"/> method then returns the <see cref="NumberFormatInfo"/> object that provides information about the
+        /// format of the <paramref name="s"/> parameter. There are three ways to use the <paramref name="provider"/> parameter to supply custom formatting
+        /// information to the parse operation:
+        /// <list type="bullet">
+        ///     <item><description>You can pass a <see cref="CultureInfo"/> object that represents the culture that supplies formatting information. Its
+        ///     <see cref="IFormatProvider.GetFormat(Type?)"/> method returns the <see cref="NumberFormatInfo"/> object that provides numeric formatting
+        ///     information for that culture.</description></item>
+        ///     <item><description>You can pass the actual <see cref="NumberFormatInfo"/> object that provides numeric formatting information. (Its
+        ///     implementation of <see cref="IFormatProvider.GetFormat(Type?)"/> just returns itself.)</description></item>
+        ///     <item><description>You can pass a custom object that implements <see cref="IFormatProvider"/>. Its <see cref="IFormatProvider.GetFormat(Type?)"/>
+        ///     method instantiates and returns the <see cref="NumberFormatInfo"/> object that provides formatting information.</description></item>
+        /// </list>
+        /// If <paramref name="provider"/> is <c>null</c> or a <see cref="NumberFormatInfo"/> object cannot be obtained, the <see cref="NumberFormatInfo"/>
+        /// object for the current culture is used.
+        /// </remarks>
+        /// <seealso cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/>
+        /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
+        public static long Parse(string s, NumberStyle style , IFormatProvider? provider) // J2N: Renamed from ParseLong()
+        {
+            NumberStyleExtensions.ValidateParseStyleInteger(style);
+            if (s == null) throw new ArgumentNullException(nameof(s));
+            return DotNetNumber.ParseInt64(s
+#if FEATURE_SPAN
+                .AsSpan()
+#endif
+                , style, NumberFormatInfo.GetInstance(provider));
+
+        }
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Converts the string representation of a number in a specified style and culture-specific format to its
+        /// 64-bit signed integer equivalent.
+        /// </summary>
+        /// <param name="s">A string containing a number to convert.</param>
+        /// <param name="style">A bitwise combination of enumeration values that indicates the style elements that can be
+        /// present in <paramref name="s"/>. A typical value to specify is <see cref="NumberStyle.Integer"/>.</param>
+        /// <param name="provider">An <see cref="IFormatProvider"/> that supplies culture-specific formatting information about <paramref name="s"/>.</param>
+        /// <returns>A 64-bit signed integer equivalent to the number specified in <paramref name="s"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="s"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="style"/> is not a <see cref="NumberStyle"/> value.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="style"/> is not a combination of <see cref="NumberStyle.AllowHexSpecifier"/> and <see cref="NumberStyle.HexNumber"/> values.
+        /// </exception>
+        /// <exception cref="FormatException"><paramref name="s"/> is not in a format compliant with <paramref name="style"/>.</exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="s"/> represents a number less than <see cref="long.MinValue"/> or greater than <see cref="long.MaxValue"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="s"/> includes non-zero fractional digits.
+        /// </exception>
+        /// <remarks>
+        /// The <paramref name="style"/> parameter defines the style elements (such as white space or the positive sign) that are allowed in the
+        /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
+        /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
+        /// <para/>
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
+        /// <para/>
+        /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
+        /// <para/>
+        /// [ws][0x]hexdigits[hextype][ws]
+        /// <para/>
+        /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
+        /// <para/>
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Element</term>
+        ///         <term>Description</term>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><i>ws</i></term>
+        ///         <term>A series of white-space characters. White space can appear at the beginning of <paramref name="s"/> if style includes the
+        ///             <see cref="NumberStyle.AllowLeadingWhite"/> flag, and it can appear at the end of <paramref name="s"/> if style includes the
+        ///             <see cref="NumberStyle.AllowTrailingWhite"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>$</i></term>
+        ///         <term>A culture-specific currency symbol. Its position in the string is defined by the <see cref="NumberFormatInfo.CurrencyNegativePattern"/>
+        ///             and <see cref="NumberFormatInfo.CurrencyPositivePattern"/> properties of the <see cref="NumberFormatInfo"/> object returned by the
+        ///             <see cref="IFormatProvider.GetFormat(Type?)"/> method of the <paramref name="provider"/> parameter. The current culture's currency symbol can
+        ///             appear in <paramref name="s"/> if style includes the <see cref="NumberStyle.AllowCurrencySymbol"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>sign</i></term>
+        ///         <term>A negative sign symbol (-) or a positive sign symbol (+). The sign can appear at the beginning of <paramref name="s"/> if
+        ///             <paramref name="style"/> includes the <see cref="NumberStyle.AllowLeadingSign"/> flag, and it can appear at the end of <paramref name="s"/>
+        ///             if <paramref name="style"/> includes the <see cref="NumberStyle.AllowTrailingSign"/> flag. Parentheses can be used in <paramref name="s"/>
+        ///             to indicate a negative value if <paramref name="style"/> includes the <see cref="NumberStyle.AllowParentheses"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>digits</i></term>
+        ///         <term>A series of digits ranging from 0 to 9.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>.</i></term>
+        ///         <term>A culture-specific decimal point symbol. The decimal point symbol of the culture specified by <paramref name="provider"/>
+        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>fractional-digits</i>
+        ///         </term>
+        ///         <term>A series of digits ranging from 0 to 9 that specify the fractional part of the number. Fractional digits can appear in
+        ///         <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>e</i></term>
+        ///         <term>The 'e' or 'E' character, which indicates that the value is represented in exponential notation. The <paramref name="s"/>
+        ///         parameter can represent a number in exponential notation if <paramref name="style"/> includes the <see cref="NumberStyle.AllowExponent"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>exponential-digits</i></term>
+        ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hexdigits</i></term>
+        ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
+        ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
+        ///     </item>
+        /// </list>
+        /// <para/>
+        /// NOTE: Any terminating NUL (U+0000) characters in <paramref name="s"/> are ignored by the parsing operation, regardless of
+        /// the value of the <paramref name="style"/> argument.
+        /// <para/>
+        /// A string with decimal digits only (which corresponds to the <see cref="NumberStyle.None"/> flag) always parses successfully.
+        /// Most of the remaining <see cref="NumberStyle"/> members control elements that may be but are not required to be present in
+        /// this input string. The following table indicates how individual <see cref="NumberStyle"/> members affect the elements that may
+        /// be present in <paramref name="s"/>.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Non-composite NumberStyle values</term>
+        ///         <term>Elements permitted in <paramref name="s"/> in addition to digits</term>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.None"/></term>
+        ///         <term>Decimal digits only.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowDecimalPoint"/></term>
+        ///         <term>The decimal point (.) and <i>fractional-digits</i> elements. However, <i>fractional-digits</i> must consist
+        ///         of only one or more 0 digits or the method returns <c>false</c>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowExponent"/></term>
+        ///         <term>The <paramref name="s"/> parameter can also use exponential notation. If <paramref name="s"/> represents a
+        ///         number in exponential notation, it must represent an integer within the range of the <see cref="long"/> data type
+        ///         without a non-zero, fractional component.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowLeadingWhite"/></term>
+        ///         <term>The <i>ws</i> element at the beginning of <paramref name="s"/>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTrailingWhite"/></term>
+        ///         <term>The <i>ws</i> element at the end of <paramref name="s"/>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowLeadingSign"/></term>
+        ///         <term>A sign can appear before <i>digits</i>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTrailingSign"/></term>
+        ///         <term>A sign can appear after <i>digits</i>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowParentheses"/></term>
+        ///         <term>The <i>sign</i> element in the form of parentheses enclosing the numeric value.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowThousands"/></term>
+        ///         <term>The thousands separator (,) element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
+        ///         <term>The <i>$</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
+        /// </list>
+        /// <para/>
+        /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
+        /// <see cref="NumberStyleExtensions.ToNumberStyles(NumberStyle)"/> extension method.
+        /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
+        /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
+        /// <para/>
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
+        /// <para/>
+        /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
+        /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
+        /// method returns a <see cref="NumberFormatInfo"/> object. The <see cref="NumberFormatInfo"/> object provides culture-specific information about
+        /// the format of <paramref name="s"/>. When the <see cref="Parse(string, IFormatProvider)"/> method is invoked, it calls the provider parameter's
+        /// <see cref="IFormatProvider.GetFormat(Type?)"/> method and passes it a <see cref="Type"/> object that represents the <see cref="NumberFormatInfo"/> type.
+        /// The <see cref="IFormatProvider.GetFormat(Type?)"/> method then returns the <see cref="NumberFormatInfo"/> object that provides information about the
+        /// format of the <paramref name="s"/> parameter. There are three ways to use the <paramref name="provider"/> parameter to supply custom formatting
+        /// information to the parse operation:
+        /// <list type="bullet">
+        ///     <item><description>You can pass a <see cref="CultureInfo"/> object that represents the culture that supplies formatting information. Its
+        ///     <see cref="IFormatProvider.GetFormat(Type?)"/> method returns the <see cref="NumberFormatInfo"/> object that provides numeric formatting
+        ///     information for that culture.</description></item>
+        ///     <item><description>You can pass the actual <see cref="NumberFormatInfo"/> object that provides numeric formatting information. (Its
+        ///     implementation of <see cref="IFormatProvider.GetFormat(Type?)"/> just returns itself.)</description></item>
+        ///     <item><description>You can pass a custom object that implements <see cref="IFormatProvider"/>. Its <see cref="IFormatProvider.GetFormat(Type?)"/>
+        ///     method instantiates and returns the <see cref="NumberFormatInfo"/> object that provides formatting information.</description></item>
+        /// </list>
+        /// If <paramref name="provider"/> is <c>null</c> or a <see cref="NumberFormatInfo"/> object cannot be obtained, the <see cref="NumberFormatInfo"/>
+        /// object for the current culture is used.
+        /// </remarks>
+        /// <seealso cref="TryParse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?, out long)"/>
+        /// <seealso cref="GetInstance(string, NumberStyle, IFormatProvider?)"/>
+        public static long Parse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider) // J2N: Renamed from ParseLong()
+        {
+            NumberStyleExtensions.ValidateParseStyleInteger(style);
+            return DotNetNumber.ParseInt64(s, style, NumberFormatInfo.GetInstance(provider));
+        }
+#endif
+        #endregion Parse_CharSequence_NumberStyle_IFormatProvider
+
+        #region TryParse_CharSequence_NumberStyle_IFormatProvider_Int64
+
+        /// <summary>
+        /// Converts the string representation of a number in a specified style and culture-specific format to its
+        /// 64-bit signed integer equivalent. A return value indicates whether the conversion succeeded.
+        /// <para/>
+        /// Usage Note: To exactly match Java, use <see cref="NumberStyle.AllowLeadingSign"/> for <paramref name="style"/> and
+        /// <see cref="NumberFormatInfo.InvariantInfo"/> for <paramref name="provider"/>. We recommend factoring out
+        /// exceptions when parsing, but if the Java code depends on exceptions, throw <see cref="FormatException"/>
+        /// when this method returns <c>false</c>.
+        /// </summary>
+        /// <param name="s">A string containing a number to convert. The string is interpreted using the style specified by <paramref name="style"/>.</param>
+        /// <param name="style">A bitwise combination of enumeration values that indicates the style elements that can be present in <paramref name="s"/>.
+        /// A typical value to specify is <see cref="NumberStyle.Integer"/>.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information about <paramref name="s"/>.</param>
+        /// <param name="result">When this method returns, contains the 64-bit signed integer value equivalent of
+        /// the number contained in <paramref name="s"/>, if the conversion succeeded, or zero if the conversion failed.
+        /// The conversion fails if the s parameter is <c>null</c> or <see cref="string.Empty"/>, is not of the correct format,
+        /// or represents a number less than <see cref="long.MinValue"/> or greater than <see cref="long.MaxValue"/>. This parameter
+        /// is passed uninitialized; any value originally supplied in <paramref name="result"/> will be overwritten.</param>
+        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="style"/> is not a <see cref="NumberStyle"/> value.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="style"/> is not a combination of <see cref="NumberStyle.AllowHexSpecifier"/> and <see cref="NumberStyle.HexNumber"/> values.
+        /// </exception>
+        /// <remarks>
+        /// The <see cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/> method is like the <see cref="Parse(string, NumberStyle, IFormatProvider?)"/> method,
+        /// except the <see cref="TryParse(string?, NumberStyle, IFormatProvider?, out long)"/> method does not throw an exception if the
+        /// conversion fails. It eliminates the need to use exception handling to test for a <see cref="FormatException"/>
+        /// in the event that <paramref name="s"/> is invalid and cannot be successfully parsed.
+        /// <para/>
+        /// The <paramref name="style"/> parameter defines the style elements (such as white space or a positive or negative sign)
+        /// that are allowed in the <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of
+        /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
+        /// parameter may include the following elements:
+        /// <code>
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
+        /// </code>
+        /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
+        /// <code>
+        /// [ws][0x]hexdigits[hextype][ws]
+        /// </code>
+        /// Items in square brackets ([ and ]) are optional. The following table describes each element.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Element</term>
+        ///         <term>Description</term>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><i>ws</i></term>
+        ///         <term>Optional white space.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>$</i></term>
+        ///         <term>A culture-specific currency symbol. Its position in the string is defined by the <see cref="NumberFormatInfo.CurrencyPositivePattern"/>
+        ///         property of the <see cref="NumberFormatInfo"/> object returned by the <see cref="IFormatProvider.GetFormat(Type?)"/> method of the
+        ///         <paramref name="provider"/> parameter. The currency symbol can appear in <paramref name="s"/> if style includes the
+        ///         <see cref="NumberStyle.AllowCurrencySymbol"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>sign</i></term>
+        ///         <term>An optional sign.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>digits</i></term>
+        ///         <term>A sequence of digits ranging from 0 to 9.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>,</i></term>
+        ///         <term>A culture-specific thousands separator. The thousands separator of the culture specified by <paramref name="provider"/>
+        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowThousands"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>.</i></term>
+        ///         <term>A culture-specific decimal point symbol. The decimal point symbol of the culture specified by <paramref name="provider"/>
+        ///         can appear in <paramref name="s"/> if <paramref name="style"/> includes the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>fractional-digits</i></term>
+        ///         <term>One or more occurrences of the digit 0. Fractional digits can appear in <paramref name="s"/> only if style includes
+        ///         the <see cref="NumberStyle.AllowDecimalPoint"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>e</i></term>
+        ///         <term>The 'e' or 'E' character, which indicates that the value is represented in exponential notation. The <paramref name="s"/>
+        ///         parameter can represent a number in exponential notation if style includes the <see cref="NumberStyle.AllowExponent"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>exponential-digits</i></term>
+        ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hexdigits</i></term>
+        ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
+        ///     </item>
+        /// </list>
+        /// <para/>
+        /// NOTE: Any terminating NUL (U+0000) characters in <paramref name="s"/> are ignored by the parsing operation, regardless of
+        /// the value of the <paramref name="style"/> argument.
+        /// <para/>
+        /// A string with decimal digits only (which corresponds to the <see cref="NumberStyle.None"/> flag) always parses successfully.
+        /// Most of the remaining <see cref="NumberStyle"/> members control elements that may be but are not required to be present in
+        /// this input string. The following table indicates how individual <see cref="NumberStyle"/> members affect the elements that may
+        /// be present in <paramref name="s"/>.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Non-composite NumberStyle values</term>
+        ///         <term>Elements permitted in <paramref name="s"/> in addition to digits</term>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.None"/></term>
+        ///         <term>Decimal digits only.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowDecimalPoint"/></term>
+        ///         <term>The decimal point (.) and <i>fractional-digits</i> elements. However, <i>fractional-digits</i> must consist
+        ///         of only one or more 0 digits or the method returns <c>false</c>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowExponent"/></term>
+        ///         <term>The <paramref name="s"/> parameter can also use exponential notation. If <paramref name="s"/> represents a
+        ///         number in exponential notation, it must represent an integer within the range of the <see cref="long"/> data type
+        ///         without a non-zero, fractional component.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowLeadingWhite"/></term>
+        ///         <term>The <i>ws</i> element at the beginning of <paramref name="s"/>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTrailingWhite"/></term>
+        ///         <term>The <i>ws</i> element at the end of <paramref name="s"/>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowLeadingSign"/></term>
+        ///         <term>A sign can appear before <i>digits</i>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTrailingSign"/></term>
+        ///         <term>A sign can appear after <i>digits</i>.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowParentheses"/></term>
+        ///         <term>The <i>sign</i> element in the form of parentheses enclosing the numeric value.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowThousands"/></term>
+        ///         <term>The thousands separator (,) element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
+        ///         <term>The <i>$</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2164,10 +2237,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, s must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2184,7 +2259,6 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out long result)
         {
-            // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
 
             if (s == null)
@@ -2240,11 +2314,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2296,8 +2370,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2358,7 +2452,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2386,10 +2481,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2406,7 +2503,6 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out long result)
         {
-            // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
             return DotNetNumber.TryParseInt64(s, style, NumberFormatInfo.GetInstance(provider), out result) == DotNetNumber.ParsingStatus.OK;
         }

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -1577,7 +1577,11 @@ namespace J2N.Numerics
 #endif
         public static bool TryParse(ReadOnlySpan<char> s, out long result)
         {
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return long.TryParse(s, out result);
+#else
+            return long.TryParse(s.ToString(), out result); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
 
@@ -1963,7 +1967,11 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return long.Parse(s, style.ToNumberStyles(), provider);
+#else
+            return long.Parse(s.ToString(), style.ToNumberStyles(), provider); // ICU4N TODO: ReadOnlySpan<char> implementation
+#endif
         }
 #endif
         #endregion Parse_CharSequence_NumberStyle_IFormatProvider
@@ -2386,7 +2394,11 @@ namespace J2N.Numerics
         {
             // J2N TODO: Support NumberStyle.AllowTypeSuffix ("l" or "L")
             NumberStyleExtensions.ValidateParseStyleInteger(style);
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             return long.TryParse(s, style.ToNumberStyles(), provider, out result);
+#else
+            return long.TryParse(s.ToString(), style.ToNumberStyles(), provider, out result);
+#endif
         }
 #endif
         #endregion TryParse_CharSequence_NumberStyle_IFormatProvider_Int64

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -2972,6 +2972,25 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt64(value, format, provider, destination, out charsWritten);
+        }
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(long value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt64(value, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region HighestOneBit
 
         /// <summary>

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -488,7 +488,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -893,7 +893,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_Int64
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1511,7 +1511,7 @@ namespace J2N.Numerics
             return long.TryParse(s, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1786,7 +1786,7 @@ namespace J2N.Numerics
 
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the string representation of a number in a specified style and culture-specific format to its
         /// 64-bit signed integer equivalent.
@@ -2201,7 +2201,7 @@ namespace J2N.Numerics
         }
 
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 64-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -1244,6 +1244,57 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32
 
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>. 
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt64(string?, int)"/> method. It differs in that
+        /// it allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/>.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="long"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <returns>A 64-bit signed integer that is equivalent to the number in <paramref name="s"/>, or 0 (zero) if
+        /// <paramref name="s"/> is <c>null</c>.</returns>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of a long integer (bit 63) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="long"/>
+        /// data type is converted to an <see cref="long"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// <paramref name="s"/> contains a character that is not a valid digit in the base specified by <paramref name="radix"/>.
+        /// The exception message indicates that there are no digits to convert if the first character in <paramref name="s"/> is invalid;
+        /// otherwise, the message indicates that <paramref name="s"/> contains invalid trailing characters.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="s"/> contains only a the ASCII character \u002d ('-') or \u002B ('+') sign and/or hexadecimal
+        /// prefix 0X or 0x with no digits.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="s"/> represents a number that is less than <see cref="long.MinValue"/> or greater than <see cref="long.MaxValue"/>.
+        /// </exception>
+        /// <seealso cref="TryParse(ReadOnlySpan{char}, int, out long)"/>
+        /// <seealso cref="GetInstance(string?, int)"/>
+        public static long Parse(ReadOnlySpan<char> s, int radix) // J2N: Renamed from ParseLong()
+        {
+            return ParseNumbers.StringToLong(s, radix, ParseNumbers.IsTight);
+        }
+
+#endif
+
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>. 
         /// <para/>
@@ -1296,6 +1347,52 @@ namespace J2N.Numerics
         #endregion Parse_CharSequence_Int32
 
         #region TryParse_CharSequence_Int32_Int64
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>.
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToInt64(string?, int)"/> method. It differs in that it
+        /// allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/> and allows any 
+        /// <paramref name="radix"/> value from <see cref="Character.MinRadix"/> to <see cref="Character.MaxRadix"/> inclusive.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// <para/>
+        /// Since <see cref="Parse(ReadOnlySpan{char}, int)"/> throws many different exception types and in Java they are all normalized to
+        /// <c>NumberFormatException</c>, this method can be used to mimic the same behavior by throwing <see cref="FormatException"/>
+        /// when this method returns <c>false</c>.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="long"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <param name="result">The signed <see cref="long"/> represented by the subsequence in the specified <paramref name="radix"/>.</param>
+        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of an integer (bit 63) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="long"/>
+        /// data type is converted to an <see cref="long"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int, int, int)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static bool TryParse(ReadOnlySpan<char> s, int radix, out long result)
+        {
+            if (radix < Character.MinRadix || radix > Character.MaxRadix)
+                throw new ArgumentOutOfRangeException(nameof(radix), SR.ArgumentOutOfRange_Radix);
+
+            return ParseNumbers.TryStringToLong(s, radix, ParseNumbers.IsTight, out result);
+        }
+
+#endif
 
         /// <summary>
         /// Parses the <see cref="string"/> argument as a signed <see cref="long"/> in the specified <paramref name="radix"/>.

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -2975,14 +2975,36 @@ namespace J2N.Numerics
         #region TryFormat
 
 #if FEATURE_SPAN
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+
+        /// <summary>
+        /// Tries to format the value of the current long number instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt64(value, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(long value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The long number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(long value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt64(value, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/ParseNumbers.cs
+++ b/src/J2N/Numerics/ParseNumbers.cs
@@ -30,7 +30,7 @@ namespace J2N.Numerics
 
         #region StringToLong
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         public static unsafe long StringToLong(ReadOnlySpan<char> s, int radix, int flags) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC, KEEP Try... versions IN SYNC
         {
@@ -378,7 +378,7 @@ namespace J2N.Numerics
 
         #region TryStringToLong
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         public static unsafe bool TryStringToLong(ReadOnlySpan<char> s, int radix, int flags, out long result) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC, KEEP Try... versions IN SYNC
         {
@@ -770,7 +770,7 @@ namespace J2N.Numerics
 
         #region StringToInt
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         public static int StringToInt(ReadOnlySpan<char> s, int radix, int flags) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC, KEEP Try... versions IN SYNC
         {
@@ -1122,7 +1122,7 @@ namespace J2N.Numerics
 
         #region TryStringToInt
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         public static bool TryStringToInt(ReadOnlySpan<char> s, int radix, int flags, out int result) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC, KEEP Try... versions IN SYNC
         {
@@ -1818,7 +1818,7 @@ namespace J2N.Numerics
 
         #region EatWhiteSpace
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         private static void EatWhiteSpace(ReadOnlySpan<char> s, ref int i) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC
         {
             int localIndex = i;
@@ -1852,7 +1852,7 @@ namespace J2N.Numerics
 
         #region TryGrabLongs
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         private static bool TryGrabLongs(int radix, ReadOnlySpan<char> s, ref int i, int end, bool isUnsigned, out long result) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC
         {
@@ -2108,7 +2108,7 @@ namespace J2N.Numerics
 
         #region TryGrabInts
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         private static bool TryGrabInts(int radix, ReadOnlySpan<char> s, ref int i, int end, bool isUnsigned, out int result) // KEEP OVERLOADS FOR ICharSequence, char[], ReadOnlySpan<char>, and string IN SYNC
         {
@@ -2460,7 +2460,7 @@ namespace J2N.Numerics
 
         #region EatDigit
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -464,7 +464,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -906,7 +906,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_SByte
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1626,7 +1626,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1892,7 +1892,7 @@ namespace J2N.Numerics
             NumberStyleExtensions.ValidateParseStyleInteger(style);
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
@@ -1914,7 +1914,7 @@ namespace J2N.Numerics
             return (sbyte)i;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="sbyte"/> equivalent.
         /// </summary>
@@ -2327,7 +2327,7 @@ namespace J2N.Numerics
                 result = 0;
                 return false;
             }
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
             if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
@@ -2346,7 +2346,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -1735,11 +1735,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1793,9 +1793,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -1854,6 +1874,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -1861,10 +1886,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in <paramref name="style"/> are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -1944,11 +1971,11 @@ namespace J2N.Numerics
         /// <paramref name="s"/> parameter for the parse operation to succeed. It must be a combination of bit flags from the <see cref="NumberStyle"/>
         /// enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/> parameter may include the following elements:
         /// <para/>
-        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// <para/>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -2002,9 +2029,29 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F. Hexadecimal digits can appear in <paramref name="s"/>
         ///         if <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2063,6 +2110,11 @@ namespace J2N.Numerics
         ///         <term><see cref="NumberStyle.AllowCurrencySymbol"/></term>
         ///         <term>The <i>$</i> element.</term>
         ///     </item>
+        ///     <item>
+        ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
+        ///     </item>
         /// </list>
         /// <para/>
         /// The <see cref="NumberStyle"/> enum can be converted to the .NET <see cref="NumberStyles"/> enum by using the
@@ -2070,10 +2122,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "F3" parses successfully, but "0xF3" does not. The only other flags that can be present in style are
-        /// <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/> enumeration
-        /// has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2160,11 +2214,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2216,8 +2270,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2278,7 +2352,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The type suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2304,10 +2379,12 @@ namespace J2N.Numerics
         /// The <see cref="NumberStyle"/> enum is a match in both symbol and value for the .NET <see cref="NumberStyles"/> enum.
         /// Therefore, simply casting the value will convert it properly between the two in both directions.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, s must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in style
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>
@@ -2385,11 +2462,11 @@ namespace J2N.Numerics
         /// bit flags from the <see cref="NumberStyle"/> enumeration. Depending on the value of <paramref name="style"/>, the <paramref name="s"/>
         /// parameter may include the following elements:
         /// <code>
-        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][ws]
+        /// [ws][$][sign][digits,]digits[.fractional-digits][e[sign]exponential-digits][type][ws]
         /// </code>
         /// Or, if the <paramref name="style"/> parameter includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <code>
-        /// [ws]hexdigits[ws]
+        /// [ws][0x]hexdigits[hextype][ws]
         /// </code>
         /// Items in square brackets ([ and ]) are optional. The following table describes each element.
         /// <list type="table">
@@ -2441,8 +2518,28 @@ namespace J2N.Numerics
         ///         <term>A sequence of decimal digits from 0 through 9 that specify an exponent.</term>
         ///     </item>
         ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
+        ///     </item>
+        ///     <item>
         ///         <term><i>hexdigits</i></term>
         ///         <term>A sequence of hexadecimal digits from 0 through f, or 0 through F.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>hextype</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. Real type suffixes are not supported.</term>
         ///     </item>
         /// </list>
         /// <para/>
@@ -2503,7 +2600,8 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.AllowTypeSpecifier"/></term>
-        ///         <term>The <i>type</i> suffix used in the literal identifier syntax of C# or Java.</term>
+        ///         <term>The literal <i>type</i> suffix used in the literal identifier syntax of C# (suffixed with one of
+        ///         'D', 'd', 'F', 'f', 'M', 'm', 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu').</term>
         ///     </item>
         ///     <item>
         ///         <term><see cref="NumberStyle.Currency"/></term>
@@ -2531,10 +2629,12 @@ namespace J2N.Numerics
         /// Similarly, <see cref="NumberStyles"/> enum can be converted to the J2N <see cref="NumberStyle"/> enum by using
         /// the <see cref="NumberStyleExtensions.ToNumberStyle(NumberStyles)"/> extension method.
         /// <para/>
-        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value without a prefix.
-        /// For example, "C9AF3" parses successfully, but "0xC9AF3" does not. The only other flags that can be present in <paramref name="style"/>
-        /// are <see cref="NumberStyle.AllowLeadingWhite"/> and <see cref="NumberStyle.AllowTrailingWhite"/>. (The <see cref="NumberStyle"/>
-        /// enumeration has a composite style, <see cref="NumberStyle.HexNumber"/>, that includes both white space flags.)
+        /// If the <see cref="NumberStyle.AllowHexSpecifier"/> flag is used, <paramref name="s"/> must be a hexadecimal value with or without a <c>0x</c> prefix.
+        /// For example, "F3" and "0xF3" both parse successfully. The only other flags that can be present in <paramref name="style"/> are
+        /// <see cref="NumberStyle.AllowLeadingWhite"/>, <see cref="NumberStyle.AllowTrailingWhite"/> and <see cref="NumberStyle.AllowTypeSpecifier"/>.
+        /// (The <see cref="NumberStyle"/> enumeration has a composite number style, <see cref="NumberStyle.HexNumber"/>, that includes both white space
+        /// flags.)
+        /// The <see cref="NumberStyle.AllowTypeSpecifier"/> only allows 'L', 'l', 'U', 'u', 'UL', 'ul', 'LU', or 'lu' for hexadecimal numbers.
         /// <para/>
         /// The <paramref name="provider"/> parameter is an <see cref="IFormatProvider"/> implementation, such as a <see cref="CultureInfo"/> object,
         /// a <see cref="NumberFormatInfo"/> object or a <see cref="J2N.Text.StringFormatter"/> object, whose <see cref="IFormatProvider.GetFormat(Type?)"/>

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -464,7 +464,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -906,7 +906,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_SByte
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1626,7 +1626,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1893,7 +1893,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -1914,7 +1914,7 @@ namespace J2N.Numerics
             return (sbyte)i;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="sbyte"/> equivalent.
         /// </summary>
@@ -2330,7 +2330,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
@@ -2346,7 +2346,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -3072,6 +3072,25 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, 0x000000FF, format, provider, destination, out charsWritten);
+        }
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(sbyte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatInt32(value, 0x000000FF, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region GetInstance (ValueOf)
 
         /// <summary>

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -3075,14 +3075,36 @@ namespace J2N.Numerics
         #region TryFormat
 
 #if FEATURE_SPAN
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+
+        /// <summary>
+        /// Tries to format the value of the current 8-bit signed integer number instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, 0x000000FF, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(sbyte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The 8-bit signed integer number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(sbyte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatInt32(value, 0x000000FF, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -1341,6 +1341,64 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32
 
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>. 
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToSByte(string?, int)"/> method. It differs in that
+        /// it allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/>.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// </summary>
+        /// <param name="s">The <see cref="ReadOnlySpan{T}"/> containing the <see cref="sbyte"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <returns>An 8-bit signed integer that is equivalent to the number in <paramref name="s"/>, or 0 (zero) if
+        /// <paramref name="s"/> is <c>null</c>.</returns>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of a long integer (bit 7) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="sbyte"/>
+        /// data type is converted to a <see cref="sbyte"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        /// <paramref name="s"/> contains a character that is not a valid digit in the base specified by <paramref name="radix"/>.
+        /// The exception message indicates that there are no digits to convert if the first character in <paramref name="s"/> is invalid;
+        /// otherwise, the message indicates that <paramref name="s"/> contains invalid trailing characters.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="s"/> contains only a the ASCII character \u002d ('-') or \u002B ('+') sign and/or hexadecimal
+        /// prefix 0X or 0x with no digits.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        /// <paramref name="s"/> represents a number that is less than <see cref="sbyte.MinValue"/> or greater than <see cref="sbyte.MaxValue"/>.
+        /// </exception>
+        /// <seealso cref="TryParse(ReadOnlySpan{char}, int, out sbyte)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static sbyte Parse(ReadOnlySpan<char> s, int radix) // J2N: Renamed from ParseByte()
+        {
+            int r = ParseNumbers.StringToInt(s, radix, ParseNumbers.IsTight | ParseNumbers.TreatAsI1);
+
+            if (radix != 10 && r <= byte.MaxValue)
+                return (sbyte)r;
+
+            if (r < sbyte.MinValue || r > sbyte.MaxValue) // J2N: Allow negative sbyte values for compatibility, even though we return sbyte rather than sbyte
+                throw new OverflowException(SR.Overflow_SByte);
+            return (sbyte)r;
+        }
+
+#endif
+
         /// <summary>
         /// Parses the <see cref="string"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>. 
         /// <para/>
@@ -1403,6 +1461,71 @@ namespace J2N.Numerics
         #endregion Parse_CharSequence_Int32
 
         #region TryParse_CharSequence_Int32_SByte
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>.
+        /// <para/>
+        /// Usage Note: This method is similar to the <see cref="Convert.ToSByte(string?, int)"/> method. It differs in that it
+        /// allows the use of the ASCII character \u002d ('-') or \u002B ('+') in any <paramref name="radix"/> and allows any 
+        /// <paramref name="radix"/> value from <see cref="Character.MinRadix"/> to <see cref="Character.MaxRadix"/> inclusive.
+        /// <para/>
+        /// Supports any BMP (Basic Multilingual Plane) or SMP (Supplementary Mulitlingual Plane) digit as defined by Unicode 10.0.
+        /// <para/>
+        /// Since <see cref="Parse(ReadOnlySpan{char}, int)"/> throws many different exception types and in Java they are all normalized to
+        /// <c>NumberFormatException</c>, this method can be used to mimic the same behavior by throwing <see cref="FormatException"/>
+        /// when this method returns <c>false</c>.
+        /// </summary>
+        /// <param name="s">The <see cref="string"/> containing the <see cref="sbyte"/> representation to be parsed.</param>
+        /// <param name="radix">The radix (or base) to use when parsing <paramref name="s"/>. The value must be in the range
+        /// <see cref="Character.MinRadix"/> - <see cref="Character.MaxRadix"/> inclusive.</param>
+        /// <param name="result">The <see cref="sbyte"/> represented by the subsequence in the specified <paramref name="radix"/>.</param>
+        /// <returns><c>true</c> if <paramref name="s"/> was converted successfully; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="radix"/> is less than <see cref="Character.MinRadix"/> or greater than <see cref="Character.MaxRadix"/>.
+        /// </exception>
+        /// <remarks>
+        /// If <paramref name="radix"/> is 16, you can prefix the number specified by the <paramref name="s"/> parameter with "0x" or "0X".
+        /// <para/>
+        /// To specify a negative value for base (radix) 10 numeric representations, use the ASCII character \u002d ('-').
+        /// <para/>
+        /// For any other <paramref name="radix"/>,  negative values may either be specified with ASCII character \u002d ('-')
+        /// (as in Java) or by specifying the two's complement representation (as in .NET), but not both.
+        /// In the latter case, the highest-order binary bit of an integer (bit 7) is interpreted as the sign bit.
+        /// As a result, it is possible to write code in which a non-base 10 number that is out of the range of the <see cref="sbyte"/>
+        /// data type is converted to a <see cref="sbyte"/> value without the method throwing an exception.
+        /// </remarks>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int, int, int)"/>
+        /// <seealso cref="Parse(ReadOnlySpan{char}, int)"/>
+        public static bool TryParse(ReadOnlySpan<char> s, int radix, out sbyte result) // J2N: Renamed from ParseByte()
+        {
+            if (radix < Character.MinRadix || radix > Character.MaxRadix)
+                throw new ArgumentOutOfRangeException(nameof(radix), SR.ArgumentOutOfRange_Radix);
+
+            if (!ParseNumbers.TryStringToInt(s, radix, ParseNumbers.IsTight | ParseNumbers.TreatAsI1, out int r))
+            {
+                result = default;
+                return false;
+            }
+
+            if (radix != 10 && r <= byte.MaxValue)
+            {
+                result = (sbyte)r;
+                return true;
+            }
+
+            if (r < sbyte.MinValue || r > sbyte.MaxValue)
+            {
+                result = default;
+                return false;
+            }
+
+            result = (sbyte)r;
+            return true;
+        }
+
+#endif
 
         /// <summary>
         /// Parses the <see cref="string"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>.

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -1893,7 +1893,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -2330,7 +2330,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -464,7 +464,7 @@ namespace J2N.Numerics
 
         #region Parse_CharSequence_Int32_Int32_Int32
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{T}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -906,7 +906,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_Int32_Int32_Int32_SByte
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Parses the <see cref="ReadOnlySpan{Char}"/> argument as a <see cref="sbyte"/> in the specified <paramref name="radix"/>, beginning at the
@@ -1626,7 +1626,7 @@ namespace J2N.Numerics
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed
         /// integer equivalent. A return value indicates whether the conversion succeeded.
@@ -1893,7 +1893,7 @@ namespace J2N.Numerics
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
 #if FEATURE_READONLYSPAN
-            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i);
+            DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #else
             DotNetNumber.ParsingStatus status = DotNetNumber.TryParseInt32(s, style, NumberFormatInfo.GetInstance(provider), out int i);
 #endif
@@ -1914,7 +1914,7 @@ namespace J2N.Numerics
             return (sbyte)i;
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its <see cref="sbyte"/> equivalent.
         /// </summary>
@@ -2330,7 +2330,7 @@ namespace J2N.Numerics
 #if FEATURE_READONLYSPAN
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
             // For integer styles it's zero and the effective check is (uint)(i - MinValue) > byte.MaxValue
-            if (DotNetNumber.TryParseInt32(s.AsSpan(), style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
+            if (DotNetNumber.TryParseInt32((ReadOnlySpan<char>)s, style, NumberFormatInfo.GetInstance(provider), out int i) != DotNetNumber.ParsingStatus.OK
                 || (uint)(i - sbyte.MinValue - ((int)(style & NumberStyle.AllowHexSpecifier) >> 2)) > byte.MaxValue)
 #else
             // For hex number styles AllowHexSpecifier >> 2 == 0x80 and cancels out MinValue so the check is effectively: (uint)i > byte.MaxValue
@@ -2346,7 +2346,7 @@ namespace J2N.Numerics
             return true;
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to its 8-bit signed integer equivalent.
         /// A return value indicates whether the conversion succeeded.

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -3017,14 +3017,35 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the current single instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatSingle(value, format, provider, destination, out charsWritten);
         }
 
-        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
-        internal static bool TryFormat(float value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        /// <summary>
+        /// Tries to format the value of the <paramref name="value"/> into the provided span of characters.
+        /// </summary>
+        /// <param name="value">The single number to format.</param>
+        /// <param name="destination">The span in which to write this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in
+        /// <paramref name="destination"/>.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string that
+        /// defines the acceptable format for <paramref name="destination"/>.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// <paramref name="destination"/>.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        public static bool TryFormat(float value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
             return DotNetNumber.TryFormatSingle(value, format, provider, destination, out charsWritten);
         }

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -3013,6 +3013,20 @@ namespace J2N.Numerics
 
         #endregion ToString
 
+        #region TryFormat
+
+#if FEATURE_SPAN
+
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatSingle(value, format, provider, destination, out charsWritten);
+        }
+
+#endif
+
+        #endregion TryFormat
+
         #region Compare
 
         /// <summary>

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -932,7 +932,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its single-precision floating-point number equivalent.
@@ -1327,7 +1327,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseSingle(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent.
@@ -1898,7 +1898,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -932,7 +932,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its single-precision floating-point number equivalent.
@@ -1327,7 +1327,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseSingle(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent.
@@ -1898,7 +1898,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -1102,7 +1102,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1135,6 +1135,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1182,8 +1186,21 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
+        ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
+        ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
+        ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
+        ///         required for the type suffix characters 'f', 'F', 'd', and 'D' since they would otherwise be interpreted as hexadecimal integral or fractional digits.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>type</i></term>
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1380,7 +1397,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1413,6 +1430,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1460,8 +1481,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1670,7 +1693,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1703,6 +1726,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -1750,8 +1777,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -1962,7 +1991,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -1995,6 +2024,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -2042,8 +2075,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is
@@ -3265,7 +3300,7 @@ namespace J2N.Numerics
         /// <para/>
         /// Or, if <paramref name="style"/> includes <see cref="NumberStyle.AllowHexSpecifier"/>:
         /// <para/>
-        /// [ws] [$] [sign][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
+        /// [ws] [$] [sign][0x][hexdigits,]hexdigits[.[fractional-hexdigits]][P[sign]exponential-digits][type][ws]
         /// <para/>
         /// Elements framed in square brackets ([ and ]) are optional. The following table describes each element.
         /// <para/>
@@ -3298,6 +3333,10 @@ namespace J2N.Numerics
         ///         <term><i>integral-digits</i></term>
         ///         <term>A series of digits ranging from 0 to 9 that specify the integral part of the number. The <i>integral-digits</i> element can be absent
         ///             if the string contains the <i>fractional-digits</i> element.</term>
+        ///     </item>
+        ///     <item>
+        ///         <term><i>0x</i>/></term>
+        ///         <term>The '0x' or '0X' characters, which indicate a hexadecimal number is to immediately follow.</term>
         ///     </item>
         ///     <item>
         ///         <term><i>hexdigits</i></term>
@@ -3345,8 +3384,10 @@ namespace J2N.Numerics
         ///     </item>
         ///     <item>
         ///         <term><i>type</i></term>
-        ///         <term>The 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
-        ///         [real type suffix](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#real-literals)
+        ///         <term>The 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu', which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6453-integer-literals">integral type suffix</a>
+        ///         or 'f', 'F', 'd', 'D', 'm' or 'M' character, which is the
+        ///         <a href="https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/lexical-structure#6454-real-literals">real type suffix</a>
         ///         of the number as specified in the C# language specification. The type suffix can appear in <paramref name="s"/> if <paramref name="style"/>
         ///         includes the <see cref="NumberStyle.AllowTypeSpecifier"/> flag. If <paramref name="style"/> includes the <see cref="NumberStyle.AllowHexSpecifier"/>
         ///         flag, specifying the <see cref="NumberStyle.AllowExponent"/> is required. Including an exponent in the string (prefixed with 'p' or 'P') is

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -3023,6 +3023,12 @@ namespace J2N.Numerics
             return DotNetNumber.TryFormatSingle(value, format, provider, destination, out charsWritten);
         }
 
+        // J2N TODO: Make public and add docs when all of the number types have an implementation, implement ISpanFormattable in net6+
+        internal static bool TryFormat(float value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
+        {
+            return DotNetNumber.TryFormatSingle(value, format, provider, destination, out charsWritten);
+        }
+
 #endif
 
         #endregion TryFormat

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -932,7 +932,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, NumberStyle.Float | NumberStyle.AllowThousands, NumberFormatInfo.CurrentInfo, out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
 
         /// <summary>
         /// Converts the string representation of a number in a character span to its single-precision floating-point number equivalent.
@@ -1327,7 +1327,7 @@ namespace J2N.Numerics
             return DotNetNumber.ParseSingle(s, style, NumberFormatInfo.GetInstance(provider));
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts a character span that contains the string representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent.
@@ -1898,7 +1898,7 @@ namespace J2N.Numerics
             return DotNetNumber.TryParseSingle(s, style, NumberFormatInfo.GetInstance(provider), out result);
         }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
         /// <summary>
         /// Converts the span representation of a number in a specified style and culture-specific format to
         /// its single-precision floating-point number equivalent. A return value indicates whether the

--- a/src/J2N/PropertyExtensions.cs
+++ b/src/J2N/PropertyExtensions.cs
@@ -1089,7 +1089,7 @@ namespace J2N
                 {
                     if (last != current)
                     {
-#if FEATURE_SPAN
+#if FEATURE_SPAN && FEATURE_TEXTWRITER_WRITE_READONLYSPAN
                         bw.Write(comments.AsSpan(last, current - last)); // end - start
 #else
                         bw.Write(comments.Substring(last, current - last)); // end - start
@@ -1123,7 +1123,7 @@ namespace J2N
             }
             if (last != current)
             {
-#if FEATURE_SPAN
+#if FEATURE_SPAN && FEATURE_TEXTWRITER_WRITE_READONLYSPAN
                 bw.Write(comments.AsSpan(last, current - last)); // end - start
 #else
                 bw.Write(comments.Substring(last, current - last)); // end - start

--- a/src/J2N/SingleExtensions.cs
+++ b/src/J2N/SingleExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using J2N.Numerics;
+using J2N.Text;
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -320,7 +321,11 @@ namespace J2N
                     return string.Concat(negative ? info.NegativeSign : "", "0x0", info.NumberDecimalSeparator, "0p0"); //$NON-NLS-1$ //$NON-NLS-2$
             }
 
+#if FEATURE_SPAN
+            ValueStringBuilder hexString = new ValueStringBuilder(32);
+#else
             StringBuilder hexString = new StringBuilder(10);
+#endif
             if (negative)
             {
                 hexString.Append(info.NegativeSign);

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -566,7 +566,7 @@ namespace J2N.Text
 
         #region Append
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
 
         /// <summary>
         /// Appends a copy of the specified <see cref="ReadOnlySpan{Char}"/> to this instance.
@@ -1704,7 +1704,7 @@ namespace J2N.Text
 
         #region Equals
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_STRINGBUILDER_EQUALS_READONLYSPAN
 
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
@@ -1794,7 +1794,7 @@ namespace J2N.Text
 
         #region Insert
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_STRINGBUILDER_INSERT_READONLYSPAN
 
         /// <summary>
         /// Inserts the string representation of a <see cref="ReadOnlySpan{Char}"/> value into this instance at the specified character position.

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -792,7 +792,7 @@ namespace J2N.Text
             if (startIndex > value.Length - charCount) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_IndexLength);
 
-#if FEATURE_SPAN
+#if FEATURE_STRINGBUILDER_INSERT_READONLYSPAN
             return text.Insert(index, value.AsSpan(startIndex, charCount));
 #else
             return text.Insert(index, value.Substring(startIndex, charCount));

--- a/src/J2N/Text/ValueStringBuilder.cs
+++ b/src/J2N/Text/ValueStringBuilder.cs
@@ -1,0 +1,326 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if FEATURE_SPAN
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace J2N.Text
+{
+    internal ref partial struct ValueStringBuilder
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public void EnsureCapacity(int capacity)
+        {
+            // This is not expected to be called this with negative capacity
+            Debug.Assert(capacity >= 0);
+
+            // If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+            if ((uint)capacity > (uint)_chars.Length)
+                Grow(capacity - _pos);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// Does not ensure there is a null char after <see cref="Length"/>
+        /// This overload is pattern matched in the C# 7.3+ compiler so you can omit
+        /// the explicit method call, and write eg "fixed (char* c = builder)"
+        /// </summary>
+        public ref char GetPinnableReference()
+        {
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ref char GetPinnableReference(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        /// <summary>Returns the underlying storage of the builder.</summary>
+        public Span<char> RawChars => _chars;
+
+        /// <summary>
+        /// Returns a span around the contents of the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ReadOnlySpan<char> AsSpan(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return _chars.Slice(0, _pos);
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Dispose();
+                return true;
+            }
+            else
+            {
+                charsWritten = 0;
+                Dispose();
+                return false;
+            }
+        }
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int count = s.Length;
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s
+#if !NET6_0_OR_GREATER
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            if ((uint)pos < (uint)_chars.Length)
+            {
+                _chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int pos = _pos;
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NET6_0_OR_GREATER
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += s.Length;
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        public unsafe void Append(char* value, int length)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, length);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = *value++;
+            }
+            _pos += length;
+        }
+
+        public void Append(ReadOnlySpan<char> value)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative
+            char[] poolArray = ArrayPool<char>.Shared.Rent((int)Math.Max((uint)(_pos + additionalCapacityBeyondPos), (uint)_chars.Length * 2));
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}
+
+#endif

--- a/src/J2N/compatibility/ISpanFormattable.cs
+++ b/src/J2N/compatibility/ISpanFormattable.cs
@@ -1,0 +1,25 @@
+﻿#if FEATURE_SPAN && !NET6_0_OR_GREATER
+
+namespace System
+{
+    /// <summary>
+    /// Provides functionality to format the string representation of an object into
+    /// a span.
+    /// </summary>
+    public interface ISpanFormattable : IFormattable
+    {
+        /// <summary>
+        /// Tries to format the value of the current instance into the provided span of characters.
+        /// </summary>
+        /// <param name="destination">When this method returns, this instance's value formatted as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, the number of characters that were written in destination.</param>
+        /// <param name="format">A span containing the characters that represent a standard or custom format string
+        /// that defines the acceptable format for destination.</param>
+        /// <param name="provider">An optional object that supplies culture-specific formatting information for
+        /// destination.</param>
+        /// <returns><c>true</c> if the formatting was successful; otherwise, <c>false</c>.</returns>
+        bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider);
+    }
+}
+
+#endif

--- a/src/J2N/compatibility/IndexAndRangeSupport.cs
+++ b/src/J2N/compatibility/IndexAndRangeSupport.cs
@@ -1,0 +1,317 @@
+﻿// Source: https://www.meziantou.net/how-to-use-csharp-8-indices-and-ranges-in-dotnet-standard-2-0-and-dotn.htm
+
+#region Copyright 2023 by Gérald Barré, Licensed under the MIT License
+// MIT License
+
+// Copyright (c) 2023 Gérald Barré
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#endregion
+
+// https://github.com/dotnet/runtime/blob/419e949d258ecee4c40a460fb09c66d974229623/src/libraries/System.Private.CoreLib/src/System/Index.cs
+// https://github.com/dotnet/runtime/blob/419e949d258ecee4c40a460fb09c66d974229623/src/libraries/System.Private.CoreLib/src/System/Range.cs
+
+#if NETSTANDARD2_0 || NET45_OR_GREATER
+
+using J2N.Collections;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
+    /// <remarks>
+    /// Index is used by the C# compiler to support the new index syntax
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 } ;
+    /// int lastElement = someArray[^1]; // lastElement = 5
+    /// </code>
+    /// </remarks>
+    internal readonly struct Index : IEquatable<Index>
+    {
+        private readonly int _value;
+
+        /// <summary>Construct an Index using a value and indicating if the index is from the start or from the end.</summary>
+        /// <param name="value">The index value. it has to be zero or positive number.</param>
+        /// <param name="fromEnd">Indicating if the index is from the start or from the end.</param>
+        /// <remarks>
+        /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
+        /// </remarks>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public Index(int value, bool fromEnd = false)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            if (fromEnd)
+                _value = ~value;
+            else
+                _value = value;
+        }
+
+        // The following private constructors mainly created for perf reason to avoid the checks
+        private Index(int value)
+        {
+            _value = value;
+        }
+
+        /// <summary>Create an Index pointing at first element.</summary>
+        public static Index Start => new Index(0);
+
+        /// <summary>Create an Index pointing at beyond last element.</summary>
+        public static Index End => new Index(~0);
+
+        /// <summary>Create an Index from the start at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the start.</param>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static Index FromStart(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(value);
+        }
+
+        /// <summary>Create an Index from the end at the position indicated by the value.</summary>
+        /// <param name="value">The index value from the end.</param>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static Index FromEnd(int value)
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "value must be non-negative");
+            }
+
+            return new Index(~value);
+        }
+
+        /// <summary>Returns the index value.</summary>
+        public int Value
+        {
+            get
+            {
+                if (_value < 0)
+                {
+                    return ~_value;
+                }
+                else
+                {
+                    return _value;
+                }
+            }
+        }
+
+        /// <summary>Indicates whether the index is from the start or the end.</summary>
+        public bool IsFromEnd => _value < 0;
+
+        /// <summary>Calculate the offset from the start using the giving collection length.</summary>
+        /// <param name="length">The length of the collection that the Index will be used with. length has to be a positive value</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter and the returned offset value against negative values.
+        /// we don't validate either the returned offset is greater than the input length.
+        /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
+        /// then used to index a collection will get out of range exception which will be same affect as the validation.
+        /// </remarks>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public int GetOffset(int length)
+        {
+            var offset = _value;
+            if (IsFromEnd)
+            {
+                // offset = length - (~value)
+                // offset = length + (~(~value) + 1)
+                // offset = length + value + 1
+
+                offset += length + 1;
+            }
+            return offset;
+        }
+
+        /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) => value is Index && _value == ((Index)value)._value;
+
+        /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Index other) => _value == other._value;
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode() => _value;
+
+        /// <summary>Converts integer number to an Index.</summary>
+        public static implicit operator Index(int value) => FromStart(value);
+
+        /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            if (IsFromEnd)
+                return "^" + ((uint)Value).ToString();
+
+            return ((uint)Value).ToString();
+        }
+    }
+
+    /// <summary>Represent a range has start and end indexes.</summary>
+    /// <remarks>
+    /// Range is used by the C# compiler to support the range syntax.
+    /// <code>
+    /// int[] someArray = new int[5] { 1, 2, 3, 4, 5 };
+    /// int[] subArray1 = someArray[0..2]; // { 1, 2 }
+    /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
+    /// </code>
+    /// </remarks>
+    internal readonly struct Range : IEquatable<Range>
+    {
+        /// <summary>Represent the inclusive start index of the Range.</summary>
+        public Index Start { get; }
+
+        /// <summary>Represent the exclusive end index of the Range.</summary>
+        public Index End { get; }
+
+        /// <summary>Construct a Range object using the start and end indexes.</summary>
+        /// <param name="start">Represent the inclusive start index of the range.</param>
+        /// <param name="end">Represent the exclusive end index of the range.</param>
+        public Range(Index start, Index end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
+        /// <param name="value">An object to compare with this object</param>
+        public override bool Equals(object? value) =>
+            value is Range r &&
+            r.Start.Equals(Start) &&
+            r.End.Equals(End);
+
+        /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
+        /// <param name="other">An object to compare with this object</param>
+        public bool Equals(Range other) => other.Start.Equals(Start) && other.End.Equals(End);
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return Start.GetHashCode() * 31 + End.GetHashCode();
+        }
+
+        /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
+        public override string ToString()
+        {
+            return Start + ".." + End;
+        }
+
+        /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
+        public static Range StartAt(Index start) => new Range(start, Index.End);
+
+        /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
+        public static Range EndAt(Index end) => new Range(Index.Start, end);
+
+        /// <summary>Create a Range object starting from first element to the end.</summary>
+        public static Range All => new Range(Index.Start, Index.End);
+
+        /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
+        /// <param name="lengthIn">The length of the collection that the range will be used with. length has to be a positive value.</param>
+        /// <param name="offset">The output offset value.</param>
+        /// <param name="length">The output length value</param>
+        /// <remarks>
+        /// For performance reason, we don't validate the input length parameter against negative values.
+        /// It is expected Range will be used with collections which always have non negative length/count.
+        /// We validate the range is inside the length scope though.
+        /// </remarks>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public void GetOffsetAndLength(int lengthIn, out int offset, out int length) // J2N: Using out parameters so we don't have to have a dependency on ValueTuple
+        {
+            int start;
+            var startIndex = Start;
+            if (startIndex.IsFromEnd)
+                start = lengthIn - startIndex.Value;
+            else
+                start = startIndex.Value;
+
+            int end;
+            var endIndex = End;
+            if (endIndex.IsFromEnd)
+                end = lengthIn - endIndex.Value;
+            else
+                end = endIndex.Value;
+
+            if ((uint)end > (uint)lengthIn || (uint)start > (uint)end)
+            {
+                throw new ArgumentOutOfRangeException(nameof(lengthIn));
+            }
+            offset = start;
+            length = end - start;
+        }
+    }
+}
+
+//namespace System.Runtime.CompilerServices
+//{
+//    internal static class RuntimeHelpers
+//    {
+//        /// <summary>
+//        /// Slices the specified array using the specified range.
+//        /// </summary>
+//        public static T[] GetSubArray<T>(T[] array, Range range)
+//        {
+//            if (array == null)
+//            {
+//                throw new ArgumentNullException(nameof(array));
+//            }
+
+//            range.GetOffsetAndLength(array.Length, out int offset, out int length);
+
+//            if (default(T) != null || typeof(T[]) == array.GetType())
+//            {
+//                // We know the type of the array to be exactly T[].
+
+//                if (length == 0)
+//                {
+//                    return Arrays.Empty<T>();
+//                }
+
+//                var dest = new T[length];
+//                Array.Copy(array, offset, dest, 0, length);
+//                return dest;
+//            }
+//            else
+//            {
+//                // The array is actually a U[] where U:T.
+//                var dest = (T[])Array.CreateInstance(array.GetType().GetElementType(), length);
+//                Array.Copy(array, offset, dest, 0, length);
+//                return dest;
+//            }
+//        }
+//    }
+//}
+
+#endif

--- a/tests/J2N.Tests/Globalization/TestNumberStyleExtensions.cs
+++ b/tests/J2N.Tests/Globalization/TestNumberStyleExtensions.cs
@@ -58,10 +58,12 @@ namespace J2N.Globalization
             Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.Float));
             Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.Number));
             Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexNumber));
+            Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.Integer | NumberStyle.AllowTypeSpecifier));
+            Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.Float | NumberStyle.AllowTypeSpecifier));
+            Assert.DoesNotThrow(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier));
 
-            var ex1 = Assert.Throws<ArgumentException>(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.Integer | NumberStyle.AllowTypeSpecifier));
-            var ex2 = Assert.Throws<ArgumentException>(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexFloat));
-            var ex3 = Assert.Throws<ArgumentException>(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexNumber | NumberStyle.Currency));
+            var ex1 = Assert.Throws<ArgumentException>(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexFloat));
+            var ex2 = Assert.Throws<ArgumentException>(() => NumberStyleExtensions.ValidateParseStyleInteger(NumberStyle.HexNumber | NumberStyle.Currency));
         }
 
         [Test]

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -5,6 +5,7 @@
   
   <PropertyGroup>
     <RootNamespace>J2N</RootNamespace>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/J2N.Tests/Numerics/JDK8/FDBigInteger.cs
+++ b/tests/J2N.Tests/Numerics/JDK8/FDBigInteger.cs
@@ -1667,7 +1667,7 @@ namespace J2N.Numerics
             //    magnitude[magnitude.Length - 4 * i - 3] = (byte)(w >> 8);
             //    magnitude[magnitude.Length - 4 * i - 4] = (byte)w;
             //}
-#if FEATURE_READONLYSPAN
+#if FEATURE_BIGINTEGER_CTOR_READONLYSPAN
             for (int i = 0; i < nWords; i++)
             {
                 int w = data[i];

--- a/tests/J2N.Tests/Numerics/JDK8/TestFDBigInteger.cs
+++ b/tests/J2N.Tests/Numerics/JDK8/TestFDBigInteger.cs
@@ -107,7 +107,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestValueOfPow52()
@@ -145,7 +145,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestValueOfMulPow52()
@@ -175,7 +175,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestLeftShift()
@@ -237,7 +237,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestQuoRemIteration()
@@ -281,7 +281,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestCmp()
@@ -341,7 +341,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestAddAndCmp()
@@ -385,7 +385,7 @@ namespace J2N.Numerics
         }
 
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestMultBy10()
@@ -414,7 +414,7 @@ namespace J2N.Numerics
             check(bt * biPow52(p5, p2), r, "multByPow52 returns wrong result");
         }
         [Test]
-#if !FEATURE_READONLYSPAN
+#if !FEATURE_BIGINTEGER_CTOR_READONLYSPAN
         [Ignore("J2N TODO: Little Endian ToBigInteger() is failing to produce the correct results")]
 #endif
         public void TestMultByPow52()

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -1519,7 +1519,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
             //            {
             //                protected override short GetResult(string s, int radix)
@@ -1593,7 +1593,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1645,7 +1645,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
             //            {
             //                protected override bool GetResult(string s, int radix, out byte result)
@@ -1728,7 +1728,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1818,7 +1818,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1876,7 +1876,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1936,7 +1936,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2075,7 +2075,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Decode_ReadOnlySpan : Decode_CharSequence_TestCase
             //            {
             //                protected override Byte GetResult(string s)
@@ -2117,7 +2117,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryDecode_ReadOnlySpan : TryDecode_CharSequence_TestCase
             //            {
             //                protected override bool GetResult(string s, out Byte result)

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -1457,6 +1457,43 @@ namespace J2N.Numerics
                         yield return new TestCaseData((byte)0, "0", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData((byte)0x80, "-128", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData((byte)0x7f, "127", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        yield return new TestCaseData((byte)0x007b, "0x007b", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((byte)0x007b, "0x007bL", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((byte)100, "64L", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)0x007b, "0x007bL  ", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow trailing whitespace
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData((byte)100, "100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100U", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100l", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100u", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((byte)100, "100UL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100Ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100uL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((byte)100, "100LU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100Lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100lU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((byte)100, "100D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((byte)100, "100.0D", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100.0d", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100.0F", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100.0f", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100.0M", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((byte)100, "100.0m", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -1516,6 +1553,47 @@ namespace J2N.Numerics
                         // Custom
 
                         yield return new TestCaseData(typeof(ArgumentException), "80", NumberStyle.HexFloat, NumberFormatInfo.InvariantInfo);
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
 
                     }
                 }

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -160,6 +160,32 @@ namespace J2N.Numerics
             //assertFalse(fixture.Equals("Not a Byte"));
         }
 
+        // J2N: Centralizes ToString()/TryFormat() logic to allow testing all overloads
+
+        private void Test_toString(byte bb, string answer)
+        {
+            // Test for method java.lang.String java.lang.Double.toString(double)
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Byte.ToString(bb, null, J2N.Text.StringFormatter.InvariantCulture) + ")", Byte.ToString(bb, null, J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+            Byte b = new Byte(bb);
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Byte.ToString(b.ToByte(), null, J2N.Text.StringFormatter.InvariantCulture) + ")", Byte.ToString(b.ToByte(), null, J2N.Text.StringFormatter.InvariantCulture).Equals(
+                    answer));
+            assertTrue("Incorrect String representation want " + answer + ", got (" + b.ToString(J2N.Text.StringFormatter.InvariantCulture)
+                    + ")", b.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(b.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(Byte.TryFormat(bb, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
+        }
+
         /**
          * @tests java.lang.Byte#toString()
          */
@@ -167,24 +193,30 @@ namespace J2N.Numerics
         public void Test_toString()
         {
             // J2N: We get a byte value converted to a string, so the result is always positive
-            assertEquals("255", new Byte(unchecked((byte)-1)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", new Byte(unchecked((byte)-1)).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("0", new Byte((byte)0).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("1", new Byte((byte)1).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("255", new Byte((byte)0xFF).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", new Byte((byte)0xFF).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("255", new Byte(unchecked((byte)-1)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", new Byte(unchecked((byte)-1)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("0", new Byte((byte)0).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("1", new Byte((byte)1).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("255", new Byte((byte)0xFF).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", new Byte((byte)0xFF).ToString(J2N.Text.StringFormatter.InvariantCulture));
+
+            Test_toString(unchecked((byte)-1), "255");
+            Test_toString((byte)0, "0");
+            Test_toString((byte)1, "1");
+            Test_toString((byte)0xFF, "255");
         }
 
-        /**
-         * @tests java.lang.Byte#toString(byte)
-         */
-        [Test]
-        public void Test_toStringB()
-        {
-            // J2N: We get a byte value converted to a string, so the result is always positive
-            assertEquals("255", Byte.ToString(unchecked((byte)-1), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", Byte.ToString(unchecked((byte)-1), J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("0", Byte.ToString((byte)0, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("1", Byte.ToString((byte)1, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("255", Byte.ToString((byte)0xFF, J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", Byte.ToString((byte)0xFF, J2N.Text.StringFormatter.InvariantCulture));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Byte#toString(byte)
+        // */
+        //[Test]
+        //public void Test_toStringB()
+        //{
+        //    // J2N: We get a byte value converted to a string, so the result is always positive
+        //    //assertEquals("255", Byte.ToString(unchecked((byte)-1), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", Byte.ToString(unchecked((byte)-1), J2N.Text.StringFormatter.InvariantCulture));
+        //    //assertEquals("0", Byte.ToString((byte)0, J2N.Text.StringFormatter.InvariantCulture));
+        //    //assertEquals("1", Byte.ToString((byte)1, J2N.Text.StringFormatter.InvariantCulture));
+        //    //assertEquals("255", Byte.ToString((byte)0xFF, J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("-1", Byte.ToString((byte)0xFF, J2N.Text.StringFormatter.InvariantCulture));
+        //}
 
         /**
          * @tests java.lang.Byte#valueOf(String)
@@ -960,22 +992,27 @@ namespace J2N.Numerics
         public void Test_toString2()
         {
             // J2N: We get a byte value converted to a string, so the result is always positive
-            assertEquals("Returned incorrect String", "127", new Byte((byte)127).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "129", new Byte(unchecked((byte)-127)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-127", new Byte(unchecked((byte)-127)).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "128", new Byte(unchecked((byte)-128)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-128", new Byte(unchecked((byte)-128)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "127", new Byte((byte)127).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "129", new Byte(unchecked((byte)-127)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-127", new Byte(unchecked((byte)-127)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "128", new Byte(unchecked((byte)-128)).ToString(J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-128", new Byte(unchecked((byte)-128)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+
+            Test_toString((byte)127, "127");
+            Test_toString(unchecked((byte)-127), "129");
+            Test_toString(unchecked((byte)-128), "128");
         }
 
-        /**
-         * @tests java.lang.Byte#toString(byte)
-         */
-        [Test]
-        public void Test_toStringB2()
-        {
-            // J2N: We get a byte value converted to a string, so the result is always positive
-            assertEquals("Returned incorrect String", "127", Byte.ToString((byte)127, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "129", Byte.ToString(unchecked((byte)-127), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-127", Byte.ToString(unchecked((byte)-127), J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "128", Byte.ToString(unchecked((byte)-128), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-128", Byte.ToString(unchecked((byte)-128), J2N.Text.StringFormatter.InvariantCulture));
-        }
+        // J2N: Same values as above, no need to run again
+        ///**
+        // * @tests java.lang.Byte#toString(byte)
+        // */
+        //[Test]
+        //public void Test_toStringB2()
+        //{
+        //    // J2N: We get a byte value converted to a string, so the result is always positive
+        //    assertEquals("Returned incorrect String", "127", Byte.ToString((byte)127, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("Returned incorrect String", "129", Byte.ToString(unchecked((byte)-127), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-127", Byte.ToString(unchecked((byte)-127), J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("Returned incorrect String", "128", Byte.ToString(unchecked((byte)-128), J2N.Text.StringFormatter.InvariantCulture)); // assertEquals("Returned incorrect String", "-128", Byte.ToString(unchecked((byte)-128), J2N.Text.StringFormatter.InvariantCulture));
+        //}
 
         /**
          * @tests java.lang.Byte#valueOf(java.lang.String)

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -1609,11 +1609,15 @@ namespace J2N.Numerics
 
             public abstract class Parse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
+
                 protected abstract byte GetResult(string value, int radix);
 
                 [TestCaseSource("TestParse_CharSequence_Int32_Data")]
                 public virtual void TestParse_CharSequence_Int32(byte expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     var actual = GetResult(value, radix);
                     assertEquals($"Byte.Parse(string, out byte) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1621,6 +1625,8 @@ namespace J2N.Numerics
                 [TestCaseSource("TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     Assert.Throws(expectedExceptionType, () => GetResult(value, radix));
                 }
             }
@@ -1633,16 +1639,17 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override short GetResult(string s, int radix)
-            //                {
-            //                    return Int16.Parse(s.AsSpan(), radix);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+
+                protected override byte GetResult(string s, int radix)
+                {
+                    return Byte.Parse(s.AsSpan(), radix);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 
@@ -1726,11 +1733,15 @@ namespace J2N.Numerics
 
             public abstract class TryParse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
+
                 protected abstract bool GetResult(string value, int radix, out byte result);
 
                 [TestCaseSource("TestParse_CharSequence_Int32_Data")]
                 public virtual void TestTryParse_CharSequence_Int32(byte expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     assertTrue(GetResult(value, radix, out byte actual));
                     assertEquals($"Byte.TryParse(string, out byte) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1738,6 +1749,8 @@ namespace J2N.Numerics
                 [TestCaseSource("TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestTryParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     byte actual = 0;
                     if (expectedExceptionType != typeof(ArgumentOutOfRangeException))
                     {
@@ -1759,16 +1772,17 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override bool GetResult(string s, int radix, out byte result)
-            //                {
-            //                    return Byte.TryParse(s.AsSpan(), radix, out result);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+
+                protected override bool GetResult(string s, int radix, out byte result)
+                {
+                    return Byte.TryParse(s.AsSpan(), radix, out result);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -1593,7 +1593,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1728,7 +1728,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1818,7 +1818,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1876,7 +1876,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1936,7 +1936,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestByte.cs
+++ b/tests/J2N.Tests/Numerics/TestByte.cs
@@ -1593,7 +1593,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1728,7 +1728,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1818,7 +1818,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1876,7 +1876,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1936,7 +1936,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -4225,7 +4225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4400,7 +4400,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Double : TryParse_CharSequence_NumberStyle_IFormatProvider_Double_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4492,7 +4492,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Double : TryParse_CharSequence_Double_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -199,8 +199,12 @@ namespace J2N.Numerics
 
 #if FEATURE_SPAN
             Span<char> buffer = stackalloc char[64];
-            assertTrue(d.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            assertTrue(d.TryFormat(buffer, out int charsWritten, provider: CultureInfo.InvariantCulture));
             string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals(answer, actual);
+
+            assertTrue(Double.TryFormat(dd, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
             assertEquals(answer, actual);
 #endif
         }

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -4225,7 +4225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4400,7 +4400,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Double : TryParse_CharSequence_NumberStyle_IFormatProvider_Double_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4492,7 +4492,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Double : TryParse_CharSequence_Double_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -196,6 +196,13 @@ namespace J2N.Numerics
             Double d = new Double(dd);
             assertEquals(answer, Double.ToString(d.ToDouble(), null, J2N.Text.StringFormatter.InvariantCulture));
             assertEquals(answer, d.ToString(J2N.Text.StringFormatter.InvariantCulture));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(d.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals(answer, actual);
+#endif
         }
 
         /**

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -3286,6 +3286,38 @@ namespace J2N.Numerics
                         yield return new TestCaseData(double.PositiveInfinity, "Infinity", NumberStyle.Float, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(double.PositiveInfinity, "+Infinity", NumberStyle.Float, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(double.NegativeInfinity, "-Infinity", NumberStyle.Float, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData(100d, "100L", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100U", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100l", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100u", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100d, "100UL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100Ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100uL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100d, "100LU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100Lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100lU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100d, "100D", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100d", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100F", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100M", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100m", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100d, "100.0D", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100.0d", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100.0F", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100.0f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100.0M", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100d, "100.0m", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -3939,6 +3971,47 @@ namespace J2N.Numerics
 
                         yield return new TestCaseData(typeof(FormatException), "(1.", NumberStyle.Float | NumberStyle.AllowParentheses | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a complete set of parentheses.");
                         yield return new TestCaseData(typeof(FormatException), "1.)", NumberStyle.Float | NumberStyle.AllowParentheses | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a complete set of parentheses.");
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
                     }
                 }
 

--- a/tests/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/J2N.Tests/Numerics/TestDouble.cs
@@ -4225,7 +4225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4400,7 +4400,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Double : TryParse_CharSequence_NumberStyle_IFormatProvider_Double_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -4492,7 +4492,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Double : TryParse_CharSequence_Double_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -360,28 +360,34 @@ namespace J2N.Numerics
             // Test for method java.lang.String java.lang.Short.toString()
             assertTrue("Invalid string returned", sp.ToString().Equals("18000")
                     && (sn.ToString().Equals("-19000")));
-            assertEquals("Returned incorrect string", "32767", new Int16((short)32767)
-                    .ToString());
-            assertEquals("Returned incorrect string", "-32767", new Int16((short)-32767)
-                    .ToString());
-            assertEquals("Returned incorrect string", "-32768", new Int16((short)-32768)
-                    .ToString());
+
+            //assertEquals("Returned incorrect string", "32767", new Int16((short)32767)
+            //        .ToString());
+            //assertEquals("Returned incorrect string", "-32767", new Int16((short)-32767)
+            //        .ToString());
+            //assertEquals("Returned incorrect string", "-32768", new Int16((short)-32768)
+            //        .ToString());
+
+            Test_toString((short)32767, "32767");
+            Test_toString((short)-32767, "-32767");
+            Test_toString((short)-32768, "-32768");
         }
 
-        /**
-         * @tests java.lang.Short#toString(short)
-         */
-        [Test]
-        public void Test_toStringS2()
-        {
-            // Test for method java.lang.String java.lang.Short.toString(short)
-            assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767)
-                    );
-            assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767)
-                    );
-            assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768)
-                    );
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Short#toString(short)
+        // */
+        //[Test]
+        //public void Test_toStringS2()
+        //{
+        //    // Test for method java.lang.String java.lang.Short.toString(short)
+        //    assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767)
+        //            );
+        //    assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767)
+        //            );
+        //    assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768)
+        //            );
+        //}
 
         /**
          * @tests java.lang.Short#valueOf(java.lang.String)
@@ -591,29 +597,61 @@ namespace J2N.Numerics
             //assertFalse(fixture.Equals("Not a Short"));
         }
 
+        // J2N: Centralizes ToString()/TryFormat() logic to allow testing all overloads
+
+        private void Test_toString(short ss, string answer)
+        {
+            // Test for method java.lang.String java.lang.Double.toString(double)
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int16.ToString(ss, null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int16.ToString(ss, null, J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+            Int16 s = new Int16(ss);
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int16.ToString(s.ToInt16(), null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int16.ToString(s.ToInt16(), null, J2N.Text.StringFormatter.InvariantCulture).Equals(
+                    answer));
+            assertTrue("Incorrect String representation want " + answer + ", got (" + s.ToString(J2N.Text.StringFormatter.InvariantCulture)
+                    + ")", s.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(s.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(Int16.TryFormat(ss, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
+        }
+
         /**
          * @tests java.lang.Short#toString()
          */
         [Test]
         public void Test_toString()
         {
-            assertEquals("-1", new Int16((short)-1).ToString());
-            assertEquals("0", new Int16((short)0).ToString());
-            assertEquals("1", new Int16((short)1).ToString());
-            assertEquals("-1", new Int16(unchecked((short)0xFFFF)).ToString());
+            //assertEquals("-1", new Int16((short)-1).ToString());
+            //assertEquals("0", new Int16((short)0).ToString());
+            //assertEquals("1", new Int16((short)1).ToString());
+            //assertEquals("-1", new Int16(unchecked((short)0xFFFF)).ToString());
+
+            Test_toString((short)-1, "-1");
+            Test_toString((short)0, "0");
+            Test_toString((short)1, "1");
+            Test_toString(unchecked((short)0xFFFF), "-1");
         }
 
-        /**
-         * @tests java.lang.Short#toString(short)
-         */
-        [Test]
-        public void Test_toStringS()
-        {
-            assertEquals("-1", Int16.ToString((short)-1));
-            assertEquals("0", Int16.ToString((short)0));
-            assertEquals("1", Int16.ToString((short)1));
-            assertEquals("-1", Int16.ToString(unchecked((short)0xFFFF)));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Short#toString(short)
+        // */
+        //[Test]
+        //public void Test_toStringS()
+        //{
+        //    assertEquals("-1", Int16.ToString((short)-1));
+        //    assertEquals("0", Int16.ToString((short)0));
+        //    assertEquals("1", Int16.ToString((short)1));
+        //    assertEquals("-1", Int16.ToString(unchecked((short)0xFFFF)));
+        //}
 
         /**
          * @tests java.lang.Short#valueOf(String)

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -1472,7 +1472,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1607,7 +1607,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1697,7 +1697,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1755,7 +1755,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1815,7 +1815,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -1472,7 +1472,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1607,7 +1607,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1697,7 +1697,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1755,7 +1755,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1815,7 +1815,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -1491,11 +1491,14 @@ namespace J2N.Numerics
 
             public abstract class Parse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract short GetResult(string value, int radix);
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public virtual void TestParse_CharSequence_Int32(short expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     var actual = GetResult(value, radix);
                     assertEquals($"Int16.Parse(string, IFormatProvider) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1503,6 +1506,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     Assert.Throws(expectedExceptionType, () => GetResult(value, radix));
                 }
             }
@@ -1515,16 +1520,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override short GetResult(string s, int radix)
-            //                {
-            //                    return Int16.Parse(s.AsSpan(), radix);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override short GetResult(string s, int radix)
+                {
+                    return Int16.Parse(s.AsSpan(), radix);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 
@@ -1608,11 +1613,15 @@ namespace J2N.Numerics
 
             public abstract class TryParse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
+
                 protected abstract bool GetResult(string value, int radix, out short result);
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public virtual void TestTryParse_CharSequence_Int32(short expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     assertTrue(GetResult(value, radix, out short actual));
                     assertEquals($"Int16.TryParse(string, out short) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1620,6 +1629,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestTryParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     short actual = 0;
                     if (expectedExceptionType != typeof(ArgumentOutOfRangeException))
                     {
@@ -1641,16 +1652,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override bool GetResult(string s, int radix, out short result)
-            //                {
-            //                    return Int16.TryParse(s.AsSpan(), radix, out result);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override bool GetResult(string s, int radix, out short result)
+                {
+                    return Int16.TryParse(s.AsSpan(), radix, out result);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -1398,7 +1398,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
             //            {
             //                protected override short GetResult(string s, int radix)
@@ -1472,7 +1472,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1524,7 +1524,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
             //            {
             //                protected override bool GetResult(string s, int radix, out short result)
@@ -1607,7 +1607,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1697,7 +1697,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1755,7 +1755,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1815,7 +1815,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1955,7 +1955,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Decode_ReadOnlySpan : Decode_CharSequence_TestCase
             //            {
             //                protected override Int16 GetResult(string s)
@@ -1997,7 +1997,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryDecode_ReadOnlySpan : TryDecode_CharSequence_TestCase
             //            {
             //                protected override bool GetResult(string s, out Int16 result)

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -375,11 +375,11 @@ namespace J2N.Numerics
         public void Test_toStringS2()
         {
             // Test for method java.lang.String java.lang.Short.toString(short)
-            assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767, CultureInfo.InvariantCulture)
+            assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767)
                     );
-            assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767, CultureInfo.InvariantCulture)
+            assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767)
                     );
-            assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768, CultureInfo.InvariantCulture)
+            assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768)
                     );
         }
 
@@ -391,9 +391,9 @@ namespace J2N.Numerics
         {
             // Test for method java.lang.Short
             // java.lang.Short.valueOf(java.lang.String)
-            assertEquals("Returned incorrect short", -32768, Int16.GetInstance("-32768", CultureInfo.InvariantCulture)
+            assertEquals("Returned incorrect short", -32768, Int16.GetInstance("-32768", J2N.Text.StringFormatter.InvariantCulture)
                     .ToInt16());
-            assertEquals("Returned incorrect short", 32767, Int16.GetInstance("32767", CultureInfo.InvariantCulture)
+            assertEquals("Returned incorrect short", 32767, Int16.GetInstance("32767", J2N.Text.StringFormatter.InvariantCulture)
                     .ToInt16());
         }
 

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -1344,6 +1344,43 @@ namespace J2N.Numerics
                         yield return new TestCaseData((short)0, "0", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(unchecked((short)0x8000), "-32768", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData((short)0x7fff, "32767", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        yield return new TestCaseData((short)0x007b, "0x007b", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((short)0x007b, "0x007bL", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((short)100, "64L", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)0x007b, "0x007bL  ", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow trailing whitespace
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData((short)100, "100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100U", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100l", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100u", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((short)100, "100UL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100Ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100uL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((short)100, "100LU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100Lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100lU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((short)100, "100D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((short)100, "100.0D", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100.0d", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100.0F", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100.0f", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100.0M", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((short)100, "100.0m", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -1397,6 +1434,49 @@ namespace J2N.Numerics
                         yield return new TestCaseData(typeof(OverflowException), "32768", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(typeof(OverflowException), "-32769", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(typeof(OverflowException), /*"-8001"*/ "10000", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: 2's complement required
+
+                        // Custom
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 

--- a/tests/J2N.Tests/Numerics/TestInt16.cs
+++ b/tests/J2N.Tests/Numerics/TestInt16.cs
@@ -375,11 +375,11 @@ namespace J2N.Numerics
         public void Test_toStringS2()
         {
             // Test for method java.lang.String java.lang.Short.toString(short)
-            assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767)
+            assertEquals("Returned incorrect string", "32767", Int16.ToString((short)32767, CultureInfo.InvariantCulture)
                     );
-            assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767)
+            assertEquals("Returned incorrect string", "-32767", Int16.ToString((short)-32767, CultureInfo.InvariantCulture)
                     );
-            assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768)
+            assertEquals("Returned incorrect string", "-32768", Int16.ToString((short)-32768, CultureInfo.InvariantCulture)
                     );
         }
 
@@ -391,9 +391,9 @@ namespace J2N.Numerics
         {
             // Test for method java.lang.Short
             // java.lang.Short.valueOf(java.lang.String)
-            assertEquals("Returned incorrect short", -32768, Int16.GetInstance("-32768", J2N.Text.StringFormatter.InvariantCulture)
+            assertEquals("Returned incorrect short", -32768, Int16.GetInstance("-32768", CultureInfo.InvariantCulture)
                     .ToInt16());
-            assertEquals("Returned incorrect short", 32767, Int16.GetInstance("32767", J2N.Text.StringFormatter.InvariantCulture)
+            assertEquals("Returned incorrect short", 32767, Int16.GetInstance("32767", CultureInfo.InvariantCulture)
                     .ToInt16());
         }
 

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -1984,6 +1984,43 @@ namespace J2N.Numerics
                         yield return new TestCaseData(0, "0", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(unchecked((int)0x80000000), "-2147483648", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(0x7fffffff, "2147483647", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        yield return new TestCaseData(0x007b, "0x007b", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData(0x007b, "0x007bL", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData(100, "64L", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(0x007b, "0x007bL  ", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow trailing whitespace
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData(100, "100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100U", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100l", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100u", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100, "100UL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100Ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100uL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100, "100LU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100Lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100lU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100, "100D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100, "100.0D", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100.0d", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100.0F", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100.0f", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100.0M", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100, "100.0m", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -2039,6 +2076,49 @@ namespace J2N.Numerics
                         yield return new TestCaseData(typeof(OverflowException), "-2147483649", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(typeof(OverflowException), /*"-80000001"*/ "100000000", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N:  2's complement required
                         yield return new TestCaseData(typeof(OverflowException), "9999999999", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -2133,12 +2133,15 @@ namespace J2N.Numerics
 
             public abstract class Parse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract int GetResult(string value, int radix);
 
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public virtual void TestParse_CharSequence_Int32(int expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     var actual = GetResult(value, radix);
                     assertEquals($"Int32.Parse(string, IFormatProvider) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -2147,6 +2150,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     Assert.Throws(expectedExceptionType, () => GetResult(value, radix));
                 }
             }
@@ -2159,16 +2164,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override int GetResult(string s, int radix)
-            //                {
-            //                    return Int32.Parse(s.AsSpan(), radix);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override int GetResult(string s, int radix)
+                {
+                    return Int32.Parse(s.AsSpan(), radix);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 
@@ -2337,12 +2342,15 @@ namespace J2N.Numerics
 
             public abstract class TryParse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract bool GetResult(string value, int radix, out int result);
 
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public virtual void TestTryParse_CharSequence_Int32(int expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     assertTrue(GetResult(value, radix, out int actual));
                     assertEquals($"Int32.TryParse(string, out int) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -2351,6 +2359,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestTryParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     int actual = 0;
                     if (expectedExceptionType != typeof(ArgumentOutOfRangeException))
                     {
@@ -2372,16 +2382,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override bool GetResult(string s, int radix, out int result)
-            //                {
-            //                    return Int32.TryParse(s.AsSpan(), radix, out result);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override bool GetResult(string s, int radix, out int result)
+                {
+                    return Int32.TryParse(s.AsSpan(), radix, out result);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -637,7 +637,7 @@ namespace J2N.Numerics
 
             Int32 i = new Int32(-80001);
 
-            assertEquals("Returned incorrect String", "-80001", i.ToString());
+            assertEquals("Returned incorrect String", "-80001", i.ToString(CultureInfo.InvariantCulture));
         }
 
         /**
@@ -648,23 +648,37 @@ namespace J2N.Numerics
         {
             // Test for method java.lang.String java.lang.Integer.toString(int)
 
-            assertEquals("Returned incorrect String", "-80765", Int32.ToString(-80765)
-                    );
-            assertEquals("Returned incorrect octal string", "2147483647", Int32.ToString(
-                    int.MaxValue));
-            assertEquals("Returned incorrect octal string", "-2147483647", Int32.ToString(
-                    -int.MaxValue));
-            assertEquals("Returned incorrect octal string", "-2147483648", Int32.ToString(
-                    int.MinValue));
+            //assertEquals("Returned incorrect String", "-80765", Int32.ToString(-80765)
+            //        );
+            //assertEquals("Returned incorrect octal string", "2147483647", Int32.ToString(
+            //        int.MaxValue));
+            //assertEquals("Returned incorrect octal string", "-2147483647", Int32.ToString(
+            //        -int.MaxValue));
+            //assertEquals("Returned incorrect octal string", "-2147483648", Int32.ToString(
+            //        int.MinValue));
+
+            //// Test for HARMONY-6068
+            //assertEquals("Returned incorrect octal String", "-1000", Int32.ToString(-1000));
+            //assertEquals("Returned incorrect octal String", "1000", Int32.ToString(1000));
+            //assertEquals("Returned incorrect octal String", "0", Int32.ToString(0));
+            //assertEquals("Returned incorrect octal String", "708", Int32.ToString(708));
+            //assertEquals("Returned incorrect octal String", "-100", Int32.ToString(-100));
+            //assertEquals("Returned incorrect octal String", "-1000000008", Int32.ToString(-1000000008));
+            //assertEquals("Returned incorrect octal String", "2000000008", Int32.ToString(2000000008));
+
+            Test_toString(-80765, "-80765");
+            Test_toString(int.MaxValue, "2147483647");
+            Test_toString(-int.MaxValue, "-2147483647");
+            Test_toString(int.MinValue, "-2147483648");
 
             // Test for HARMONY-6068
-            assertEquals("Returned incorrect octal String", "-1000", Int32.ToString(-1000));
-            assertEquals("Returned incorrect octal String", "1000", Int32.ToString(1000));
-            assertEquals("Returned incorrect octal String", "0", Int32.ToString(0));
-            assertEquals("Returned incorrect octal String", "708", Int32.ToString(708));
-            assertEquals("Returned incorrect octal String", "-100", Int32.ToString(-100));
-            assertEquals("Returned incorrect octal String", "-1000000008", Int32.ToString(-1000000008));
-            assertEquals("Returned incorrect octal String", "2000000008", Int32.ToString(2000000008));
+            Test_toString(-1000, "-1000");
+            Test_toString(1000, "1000");
+            Test_toString(0, "0");
+            Test_toString(708, "708");
+            Test_toString(-100, "-100");
+            Test_toString(-1000000008, "-1000000008");
+            Test_toString(2000000008, "2000000008");
         }
 
         // J2N: Moved to IntegralNumberExtensions
@@ -994,29 +1008,61 @@ namespace J2N.Numerics
             //assertFalse(fixture.Equals("Not a Integer"));
         }
 
+        // J2N: Centralizes ToString()/TryFormat() logic to allow testing all overloads
+
+        private void Test_toString(int ii, string answer)
+        {
+            // Test for method java.lang.String java.lang.Double.toString(double)
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int32.ToString(ii, null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int32.ToString(ii, null, J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+            Int32 i = new Int32(ii);
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int32.ToString(i.ToInt32(), null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int32.ToString(i.ToInt32(), null, J2N.Text.StringFormatter.InvariantCulture).Equals(
+                    answer));
+            assertTrue("Incorrect String representation want " + answer + ", got (" + i.ToString(J2N.Text.StringFormatter.InvariantCulture)
+                    + ")", i.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(i.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(Int32.TryFormat(ii, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
+        }
+
         /**
          * @tests java.lang.Integer#toString()
          */
         [Test]
         public void Test_toString() // J2N TODO: Culture tests
         {
-            assertEquals("-1", new Int32(-1).ToString());
-            assertEquals("0", new Int32(0).ToString());
-            assertEquals("1", new Int32(1).ToString());
-            assertEquals("-1", new Int32(unchecked((int)0xFFFFFFFF)).ToString());
+            //assertEquals("-1", new Int32(-1).ToString());
+            //assertEquals("0", new Int32(0).ToString());
+            //assertEquals("1", new Int32(1).ToString());
+            //assertEquals("-1", new Int32(unchecked((int)0xFFFFFFFF)).ToString());
+
+            Test_toString((int)-1, "-1");
+            Test_toString((int)0, "0");
+            Test_toString((int)1, "1");
+            Test_toString(unchecked((int)0xFFFFFFFF), "-1");
         }
 
-        /**
-         * @tests java.lang.Integer#toString
-         */
-        [Test]
-        public void Test_toStringI() // J2N TODO: Culture tests
-        {
-            assertEquals("-1", Int32.ToString(-1));
-            assertEquals("0", Int32.ToString(0));
-            assertEquals("1", Int32.ToString(1));
-            assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Integer#toString
+        // */
+        //[Test]
+        //public void Test_toStringI() // J2N TODO: Culture tests
+        //{
+        //    assertEquals("-1", Int32.ToString(-1));
+        //    assertEquals("0", Int32.ToString(0));
+        //    assertEquals("1", Int32.ToString(1));
+        //    assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)));
+        //}
 
         /**
          * @tests java.lang.Integer#valueOf(String)

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -2109,7 +2109,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2193,7 +2193,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2335,7 +2335,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2393,7 +2393,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2453,7 +2453,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -2034,7 +2034,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
             //            {
             //                protected override int GetResult(string s, int radix)
@@ -2109,7 +2109,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2193,7 +2193,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2247,7 +2247,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
             //            {
             //                protected override bool GetResult(string s, int radix, out int result)
@@ -2335,7 +2335,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2393,7 +2393,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2453,7 +2453,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2999,7 +2999,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Decode_ReadOnlySpan : Decode_CharSequence_TestCase
             //            {
             //                protected override Int32 GetResult(string s)
@@ -3041,7 +3041,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryDecode_ReadOnlySpan : TryDecode_CharSequence_TestCase
             //            {
             //                protected override bool GetResult(string s, out Int32 result)

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -2109,7 +2109,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2193,7 +2193,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2335,7 +2335,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2393,7 +2393,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2453,7 +2453,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -1012,10 +1012,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toStringI() // J2N TODO: Culture tests
         {
-            assertEquals("-1", Int32.ToString(-1));
-            assertEquals("0", Int32.ToString(0));
-            assertEquals("1", Int32.ToString(1));
-            assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)));
+            assertEquals("-1", Int32.ToString(-1), CultureInfo.InvariantCulture);
+            assertEquals("0", Int32.ToString(0), CultureInfo.InvariantCulture);
+            assertEquals("1", Int32.ToString(1), CultureInfo.InvariantCulture);
+            assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)), CultureInfo.InvariantCulture);
         }
 
         /**
@@ -1024,34 +1024,34 @@ namespace J2N.Numerics
         [Test]
         public void Test_valueOfLjava_lang_String()
         {
-            assertEquals(new Int32(0), Int32.GetInstance("0", J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals(new Int32(1), Int32.GetInstance("1", J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals(new Int32(-1), Int32.GetInstance("-1", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int32(0), Int32.GetInstance("0", CultureInfo.InvariantCulture));
+            assertEquals(new Int32(1), Int32.GetInstance("1", CultureInfo.InvariantCulture));
+            assertEquals(new Int32(-1), Int32.GetInstance("-1", CultureInfo.InvariantCulture));
 
             try
             {
-                Int32.GetInstance("0x1", J2N.Text.StringFormatter.InvariantCulture);
+                Int32.GetInstance("0x1", CultureInfo.InvariantCulture);
                 fail("Expected FormatException with hex string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance("9.2", J2N.Text.StringFormatter.InvariantCulture);
+                Int32.GetInstance("9.2", CultureInfo.InvariantCulture);
                 fail("Expected FormatException with floating point string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance("", J2N.Text.StringFormatter.InvariantCulture);
+                Int32.GetInstance("", CultureInfo.InvariantCulture);
                 fail("Expected FormatException with empty string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance(null, J2N.Text.StringFormatter.InvariantCulture);
+                Int32.GetInstance(null, CultureInfo.InvariantCulture);
                 fail("Expected FormatException with null string.");
             }
             catch (ArgumentNullException e) { } // J2N: .NET throws ArgumentNullException rather than FormatException in this case

--- a/tests/J2N.Tests/Numerics/TestInt32.cs
+++ b/tests/J2N.Tests/Numerics/TestInt32.cs
@@ -1012,10 +1012,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toStringI() // J2N TODO: Culture tests
         {
-            assertEquals("-1", Int32.ToString(-1), CultureInfo.InvariantCulture);
-            assertEquals("0", Int32.ToString(0), CultureInfo.InvariantCulture);
-            assertEquals("1", Int32.ToString(1), CultureInfo.InvariantCulture);
-            assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)), CultureInfo.InvariantCulture);
+            assertEquals("-1", Int32.ToString(-1));
+            assertEquals("0", Int32.ToString(0));
+            assertEquals("1", Int32.ToString(1));
+            assertEquals("-1", Int32.ToString(unchecked((int)0xFFFFFFFF)));
         }
 
         /**
@@ -1024,34 +1024,34 @@ namespace J2N.Numerics
         [Test]
         public void Test_valueOfLjava_lang_String()
         {
-            assertEquals(new Int32(0), Int32.GetInstance("0", CultureInfo.InvariantCulture));
-            assertEquals(new Int32(1), Int32.GetInstance("1", CultureInfo.InvariantCulture));
-            assertEquals(new Int32(-1), Int32.GetInstance("-1", CultureInfo.InvariantCulture));
+            assertEquals(new Int32(0), Int32.GetInstance("0", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int32(1), Int32.GetInstance("1", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int32(-1), Int32.GetInstance("-1", J2N.Text.StringFormatter.InvariantCulture));
 
             try
             {
-                Int32.GetInstance("0x1", CultureInfo.InvariantCulture);
+                Int32.GetInstance("0x1", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected FormatException with hex string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance("9.2", CultureInfo.InvariantCulture);
+                Int32.GetInstance("9.2", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected FormatException with floating point string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance("", CultureInfo.InvariantCulture);
+                Int32.GetInstance("", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected FormatException with empty string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int32.GetInstance(null, CultureInfo.InvariantCulture);
+                Int32.GetInstance(null, J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected FormatException with null string.");
             }
             catch (ArgumentNullException e) { } // J2N: .NET throws ArgumentNullException rather than FormatException in this case

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -1906,12 +1906,15 @@ namespace J2N.Numerics
 
             public abstract class Parse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract long GetResult(string value, int radix);
 
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public void TestParse_String_Int32(long expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     var actual = GetResult(value, radix);
                     assertEquals($"Int64.Parse(string, IFormatProvider) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1919,6 +1922,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     Assert.Throws(expectedExceptionType, () => GetResult(value, radix));
                 }
             }
@@ -1931,17 +1936,16 @@ namespace J2N.Numerics
                 }
             }
 
-
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override long GetResult(string value, int radix)
-            //                {
-            //                    return Int64.Parse(value.AsSpan(), radix);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override long GetResult(string value, int radix)
+                {
+                    return Int64.Parse(value.AsSpan(), radix);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 
@@ -2024,12 +2028,15 @@ namespace J2N.Numerics
 
             public abstract class TryParse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract bool GetResult(string value, int radix, out long result);
 
 
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_Data")]
                 public void TestTryParse_String_Int32(long expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     assertTrue(GetResult(value, radix, out long actual));
                     assertEquals($"Int64.Parse(string, IFormatProvider) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -2037,6 +2044,8 @@ namespace J2N.Numerics
                 [TestCaseSource(typeof(ParseTestCase), "TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestTryParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     long actual = 0;
                     if (expectedExceptionType != typeof(ArgumentOutOfRangeException))
                     {
@@ -2058,17 +2067,16 @@ namespace J2N.Numerics
                 }
             }
 
-
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override bool GetResult(string s, int radix, out long result)
-            //                {
-            //                    return Int64.TryParse(s.AsSpan(), radix, out result);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override bool GetResult(string s, int radix, out long result)
+                {
+                    return Int64.TryParse(s.AsSpan(), radix, out result);
+                }
+            }
+#endif
 
             #endregion TryParse_CharSequence_Int32
 

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -1810,7 +1810,7 @@ namespace J2N.Numerics
 
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
             //            {
             //                protected override long GetResult(string value, int radix)
@@ -1883,7 +1883,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1937,7 +1937,7 @@ namespace J2N.Numerics
 
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
             //            {
             //                protected override bool GetResult(string s, int radix, out long result)
@@ -2017,7 +2017,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2107,7 +2107,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2165,7 +2165,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2225,7 +2225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2915,7 +2915,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Decode_ReadOnlySpan : Decode_CharSequence_TestCase
             //            {
             //                protected override Int64 GetResult(string s)
@@ -2957,7 +2957,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryDecode_ReadOnlySpan : TryDecode_CharSequence_TestCase
             //            {
             //                protected override bool GetResult(string s, out Int64 result)

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -770,10 +770,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toString()
         {
-            assertEquals("-1", new Int64(-1).ToString(CultureInfo.InvariantCulture));
-            assertEquals("0", new Int64(0).ToString(CultureInfo.InvariantCulture));
-            assertEquals("1", new Int64(1).ToString(CultureInfo.InvariantCulture));
-            assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF)).ToString(CultureInfo.InvariantCulture));
+            assertEquals("-1", new Int64(-1).ToString());
+            assertEquals("0", new Int64(0).ToString());
+            assertEquals("1", new Int64(1).ToString());
+            assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF)).ToString());
         }
 
         /**
@@ -782,10 +782,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toStringJ()
         {
-            assertEquals("-1", Int64.ToString(-1), CultureInfo.InvariantCulture);
-            assertEquals("0", Int64.ToString(0), CultureInfo.InvariantCulture);
-            assertEquals("1", Int64.ToString(1), CultureInfo.InvariantCulture);
-            assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)), CultureInfo.InvariantCulture);
+            assertEquals("-1", Int64.ToString(-1));
+            assertEquals("0", Int64.ToString(0));
+            assertEquals("1", Int64.ToString(1));
+            assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)));
         }
 
         /**
@@ -794,34 +794,34 @@ namespace J2N.Numerics
         [Test]
         public void Test_valueOfLjava_lang_String()
         {
-            assertEquals(new Int64(0), Int64.GetInstance("0", CultureInfo.InvariantCulture));
-            assertEquals(new Int64(1), Int64.GetInstance("1", CultureInfo.InvariantCulture));
-            assertEquals(new Int64(-1), Int64.GetInstance("-1", CultureInfo.InvariantCulture));
+            assertEquals(new Int64(0), Int64.GetInstance("0", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int64(1), Int64.GetInstance("1", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int64(-1), Int64.GetInstance("-1", J2N.Text.StringFormatter.InvariantCulture));
 
             try
             {
-                Int64.GetInstance("0x1", CultureInfo.InvariantCulture);
+                Int64.GetInstance("0x1", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected NumberFormatException with hex string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance("9.2", CultureInfo.InvariantCulture);
+                Int64.GetInstance("9.2", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected NumberFormatException with floating point string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance("", CultureInfo.InvariantCulture);
+                Int64.GetInstance("", J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected NumberFormatException with empty string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance(null, CultureInfo.InvariantCulture);
+                Int64.GetInstance(null, J2N.Text.StringFormatter.InvariantCulture);
                 fail("Expected NumberFormatException with null string.");
             }
             catch (ArgumentNullException e) { } // J2N: .NET throws ArgumentNullException rather than FormatException in this case

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -1883,7 +1883,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2017,7 +2017,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2107,7 +2107,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2165,7 +2165,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2225,7 +2225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -770,10 +770,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toString()
         {
-            assertEquals("-1", new Int64(-1).ToString());
-            assertEquals("0", new Int64(0).ToString());
-            assertEquals("1", new Int64(1).ToString());
-            assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF)).ToString());
+            assertEquals("-1", new Int64(-1).ToString(CultureInfo.InvariantCulture));
+            assertEquals("0", new Int64(0).ToString(CultureInfo.InvariantCulture));
+            assertEquals("1", new Int64(1).ToString(CultureInfo.InvariantCulture));
+            assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF)).ToString(CultureInfo.InvariantCulture));
         }
 
         /**
@@ -782,10 +782,10 @@ namespace J2N.Numerics
         [Test]
         public void Test_toStringJ()
         {
-            assertEquals("-1", Int64.ToString(-1));
-            assertEquals("0", Int64.ToString(0));
-            assertEquals("1", Int64.ToString(1));
-            assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)));
+            assertEquals("-1", Int64.ToString(-1), CultureInfo.InvariantCulture);
+            assertEquals("0", Int64.ToString(0), CultureInfo.InvariantCulture);
+            assertEquals("1", Int64.ToString(1), CultureInfo.InvariantCulture);
+            assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)), CultureInfo.InvariantCulture);
         }
 
         /**
@@ -794,34 +794,34 @@ namespace J2N.Numerics
         [Test]
         public void Test_valueOfLjava_lang_String()
         {
-            assertEquals(new Int64(0), Int64.GetInstance("0", J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals(new Int64(1), Int64.GetInstance("1", J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals(new Int64(-1), Int64.GetInstance("-1", J2N.Text.StringFormatter.InvariantCulture));
+            assertEquals(new Int64(0), Int64.GetInstance("0", CultureInfo.InvariantCulture));
+            assertEquals(new Int64(1), Int64.GetInstance("1", CultureInfo.InvariantCulture));
+            assertEquals(new Int64(-1), Int64.GetInstance("-1", CultureInfo.InvariantCulture));
 
             try
             {
-                Int64.GetInstance("0x1", J2N.Text.StringFormatter.InvariantCulture);
+                Int64.GetInstance("0x1", CultureInfo.InvariantCulture);
                 fail("Expected NumberFormatException with hex string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance("9.2", J2N.Text.StringFormatter.InvariantCulture);
+                Int64.GetInstance("9.2", CultureInfo.InvariantCulture);
                 fail("Expected NumberFormatException with floating point string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance("", J2N.Text.StringFormatter.InvariantCulture);
+                Int64.GetInstance("", CultureInfo.InvariantCulture);
                 fail("Expected NumberFormatException with empty string.");
             }
             catch (FormatException e) { }
 
             try
             {
-                Int64.GetInstance(null, J2N.Text.StringFormatter.InvariantCulture);
+                Int64.GetInstance(null, CultureInfo.InvariantCulture);
                 fail("Expected NumberFormatException with null string.");
             }
             catch (ArgumentNullException e) { } // J2N: .NET throws ArgumentNullException rather than FormatException in this case

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -795,6 +795,12 @@ namespace J2N.Numerics
 #endif
         }
 
+        [Test]
+        public void Test_ToString_AllowTypeSpecifier()
+        {
+            assertEquals(100L, Int64.Parse("100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, CultureInfo.InvariantCulture));
+        }
+
         /**
          * @tests java.lang.Long#toString()
          */
@@ -1753,6 +1759,43 @@ namespace J2N.Numerics
                         yield return new TestCaseData(-1L, "-1", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
 
                         //yield return new TestCaseData(0L, null, NumberStyle.Integer, NumberFormatInfo.InvariantInfo); // J2N: Match .NET behavior where null will result in 0
+
+                        // Custom
+
+                        yield return new TestCaseData(0x007bL, "0x007b", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData(0x007bL, "0x007bL", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData(100L, "64L", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(0x007bL, "0x007bL  ", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow trailing whitespace
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData(100L, "100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100U", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100l", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100u", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100L, "100UL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100Ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100uL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100L, "100LU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100Lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100lU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100L, "100D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100L, "100.0D", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100.0d", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100.0F", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100.0f", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100.0M", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100L, "100.0m", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -1806,6 +1849,49 @@ namespace J2N.Numerics
                         yield return new TestCaseData(typeof(FormatException), "9.2", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(typeof(FormatException), "", NumberStyle.Integer, NumberFormatInfo.InvariantInfo); // J2N: .NET throws ArgumentOutOfRangeException rather than FormatException in this case, but since it is inconsistent with long.Parse() we are going with FormatException.
                         yield return new TestCaseData(typeof(ArgumentNullException), null, NumberStyle.Integer, NumberFormatInfo.InvariantInfo); // J2N: Match .NET behavior where null will result in 0
+
+                        // Custom
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -453,31 +453,36 @@ namespace J2N.Numerics
         [Test]
         public void Test_toString2()
         {
-            // Test for method java.lang.String java.lang.Long.toString()
-            Int64 l = new Int64(89000000005L);
-            assertEquals("Returned incorrect String",
-                    "89000000005", l.ToString());
-            assertEquals("Returned incorrect String", "-9223372036854775808", new Int64(long.MinValue)
-                    .ToString());
-            assertEquals("Returned incorrect String", "9223372036854775807", new Int64(long.MaxValue)
-                    .ToString());
+            //// Test for method java.lang.String java.lang.Long.toString()
+            //Int64 l = new Int64(89000000005L);
+            //assertEquals("Returned incorrect String",
+            //        "89000000005", l.ToString());
+            //assertEquals("Returned incorrect String", "-9223372036854775808", new Int64(long.MinValue)
+            //        .ToString());
+            //assertEquals("Returned incorrect String", "9223372036854775807", new Int64(long.MaxValue)
+            //        .ToString());
+
+            Test_toString(89000000005L, "89000000005");
+            Test_toString(long.MinValue, "-9223372036854775808");
+            Test_toString(long.MaxValue, "9223372036854775807");
         }
 
-        /**
-         * @tests java.lang.Long#toString(long)
-         */
-        [Test]
-        public void Test_toStringJ2()
-        {
-            // Test for method java.lang.String java.lang.Long.toString(long)
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Long#toString(long)
+        // */
+        //[Test]
+        //public void Test_toStringJ2()
+        //{
+        //    // Test for method java.lang.String java.lang.Long.toString(long)
 
-            assertEquals("Returned incorrect String", "89000000005", Int64.ToString(89000000005L)
-                    );
-            assertEquals("Returned incorrect String", "-9223372036854775808", Int64.ToString(long.MinValue)
-                    );
-            assertEquals("Returned incorrect String", "9223372036854775807", Int64.ToString(long.MaxValue)
-                    );
-        }
+        //    assertEquals("Returned incorrect String", "89000000005", Int64.ToString(89000000005L)
+        //            );
+        //    assertEquals("Returned incorrect String", "-9223372036854775808", Int64.ToString(long.MinValue)
+        //            );
+        //    assertEquals("Returned incorrect String", "9223372036854775807", Int64.ToString(long.MaxValue)
+        //            );
+        //}
 
         // J2N: Moved to IntegralNumberExtensions
         ///**
@@ -764,29 +769,61 @@ namespace J2N.Numerics
             //assertFalse(fixture.Equals("Not a Long"));
         }
 
+        // J2N: Centralizes ToString()/TryFormat() logic to allow testing all overloads
+
+        private void Test_toString(long ll, string answer)
+        {
+            // Test for method java.lang.String java.lang.Double.toString(double)
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int64.ToString(ll, null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int64.ToString(ll, null, J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+            Int64 l = new Int64(ll);
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + Int64.ToString(l.ToInt32(), null, J2N.Text.StringFormatter.InvariantCulture) + ")", Int64.ToString(l.ToInt64(), null, J2N.Text.StringFormatter.InvariantCulture).Equals(
+                    answer));
+            assertTrue("Incorrect String representation want " + answer + ", got (" + l.ToString(J2N.Text.StringFormatter.InvariantCulture)
+                    + ")", l.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(l.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(Int64.TryFormat(ll, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
+        }
+
         /**
          * @tests java.lang.Long#toString()
          */
         [Test]
         public void Test_toString()
         {
-            assertEquals("-1", new Int64(-1).ToString());
-            assertEquals("0", new Int64(0).ToString());
-            assertEquals("1", new Int64(1).ToString());
-            assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF)).ToString());
+            //assertEquals("-1", new Int64(-1).ToString());
+            //assertEquals("0", new Int64(0).ToString());
+            //assertEquals("1", new Int64(1).ToString());
+            //assertEquals("-1", new Int64(unchecked((int)0xFFFFFFFF))).ToString());
+
+            Test_toString(-1, "-1");
+            Test_toString(0, "0");
+            Test_toString(1, "1");
+            Test_toString(unchecked((int)0xFFFFFFFF), "-1");
         }
 
-        /**
-         * @tests java.lang.Long#toString
-         */
-        [Test]
-        public void Test_toStringJ()
-        {
-            assertEquals("-1", Int64.ToString(-1));
-            assertEquals("0", Int64.ToString(0));
-            assertEquals("1", Int64.ToString(1));
-            assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Long#toString
+        // */
+        //[Test]
+        //public void Test_toStringJ()
+        //{
+        //    assertEquals("-1", Int64.ToString(-1));
+        //    assertEquals("0", Int64.ToString(0));
+        //    assertEquals("1", Int64.ToString(1));
+        //    assertEquals("-1", Int64.ToString(unchecked((int)0xFFFFFFFF)));
+        //}
 
         /**
          * @tests java.lang.Long#valueOf(String)

--- a/tests/J2N.Tests/Numerics/TestInt64.cs
+++ b/tests/J2N.Tests/Numerics/TestInt64.cs
@@ -1883,7 +1883,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2017,7 +2017,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2107,7 +2107,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2165,7 +2165,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2225,7 +2225,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -1551,7 +1551,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1686,7 +1686,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1776,7 +1776,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1834,7 +1834,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1894,7 +1894,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -1551,7 +1551,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1686,7 +1686,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1776,7 +1776,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1834,7 +1834,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1894,7 +1894,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -1567,11 +1567,14 @@ namespace J2N.Numerics
 
             public abstract class Parse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract sbyte GetResult(string value, int radix);
 
                 [TestCaseSource("TestParse_CharSequence_Int32_Data")]
                 public virtual void TestParse_CharSequence_Int32(sbyte expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     var actual = GetResult(value, radix);
                     assertEquals($"SByte.Parse(string, out sbyte) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1579,6 +1582,8 @@ namespace J2N.Numerics
                 [TestCaseSource("TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     Assert.Throws(expectedExceptionType, () => GetResult(value, radix));
                 }
             }
@@ -1591,16 +1596,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override short GetResult(string s, int radix)
-            //                {
-            //                    return Int16.Parse(s.AsSpan(), radix);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override sbyte GetResult(string s, int radix)
+                {
+                    return SByte.Parse(s.AsSpan(), radix);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 
@@ -1684,11 +1689,14 @@ namespace J2N.Numerics
 
             public abstract class TryParse_CharSequence_Int32_TestCase : ParseTestCase
             {
+                protected virtual bool IsNullableType => true;
                 protected abstract bool GetResult(string value, int radix, out sbyte result);
 
                 [TestCaseSource("TestParse_CharSequence_Int32_Data")]
                 public virtual void TestTryParse_CharSequence_Int32(sbyte expected, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     assertTrue(GetResult(value, radix, out sbyte actual));
                     assertEquals($"SByte.TryParse(string, out sbyte) failed. String: \"{value}\" Result: {actual}", expected, actual);
                 }
@@ -1696,6 +1704,8 @@ namespace J2N.Numerics
                 [TestCaseSource("TestParse_CharSequence_Int32_ForException_Data")]
                 public virtual void TestTryParse_CharSequence_Int32_ForException(Type expectedExceptionType, string value, int radix)
                 {
+                    Assume.That(IsNullableType || (!IsNullableType && value != null), "null is not supported by this character sequence type.");
+
                     sbyte actual = 0;
                     if (expectedExceptionType != typeof(ArgumentOutOfRangeException))
                     {
@@ -1717,16 +1727,16 @@ namespace J2N.Numerics
                 }
             }
 
-            // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_SPAN
-            //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
-            //            {
-            //                protected override bool GetResult(string s, int radix, out sbyte result)
-            //                {
-            //                    return SByte.TryParse(s.AsSpan(), radix, out result);
-            //                }
-            //            }
-            //#endif
+#if FEATURE_SPAN
+            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
+            {
+                protected override bool IsNullableType => false;
+                protected override bool GetResult(string s, int radix, out sbyte result)
+                {
+                    return SByte.TryParse(s.AsSpan(), radix, out result);
+                }
+            }
+#endif
 
             #endregion Parse_CharSequence_Int32
 

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -1477,7 +1477,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Parse_ReadOnlySpan_Int32 : Parse_CharSequence_Int32_TestCase
             //            {
             //                protected override short GetResult(string s, int radix)
@@ -1551,7 +1551,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_Int32_Int32_Int32_Int32 : Parse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1603,7 +1603,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload (not supported in .NET anyway)
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryParse_ReadOnlySpan_Int32 : TryParse_CharSequence_Int32_TestCase
             //            {
             //                protected override bool GetResult(string s, int radix, out sbyte result)
@@ -1686,7 +1686,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Int32_Int32_Int32_Int32 : TryParse_CharSequence_Int32_Int32_Int32_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1776,7 +1776,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : Parse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1834,7 +1834,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_TestCase : TryParse_CharSequence_NumberStyle_IFormatProvider_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -1894,7 +1894,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_TestCase : TryParse_CharSequence_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -2033,7 +2033,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class Decode_ReadOnlySpan : Decode_CharSequence_TestCase
             //            {
             //                protected override SByte GetResult(string s)
@@ -2075,7 +2075,7 @@ namespace J2N.Numerics
             }
 
             // J2N: ReadOnlySpan<char> not supported at this time on this overload
-            //#if FEATURE_READONLYSPAN
+            //#if FEATURE_SPAN
             //            public class TryDecode_ReadOnlySpan : TryDecode_CharSequence_TestCase
             //            {
             //                protected override bool GetResult(string s, out SByte result)

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -1415,6 +1415,43 @@ namespace J2N.Numerics
                         yield return new TestCaseData((sbyte)0, "0", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData(unchecked((sbyte)0x80), "-128", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
                         yield return new TestCaseData((sbyte)0x7f, "127", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // Custom
+
+                        yield return new TestCaseData((sbyte)0x007b, "0x007b", NumberStyle.HexNumber, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((sbyte)0x007b, "0x007bL", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow 0x to be specified in the string
+                        yield return new TestCaseData((sbyte)100, "64L", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)0x007b, "0x007bL  ", NumberStyle.HexNumber | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo); // J2N: Allow trailing whitespace
+
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData((sbyte)100, "100L", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100U", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100l", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100u", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((sbyte)100, "100UL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100Ul", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100uL", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((sbyte)100, "100LU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100Lu", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100lU", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((sbyte)100, "100D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData((sbyte)100, "100.0D", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100.0d", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100.0F", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100.0f", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100.0M", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData((sbyte)100, "100.0m", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -1474,6 +1511,47 @@ namespace J2N.Numerics
                         // Custom
 
                         yield return new TestCaseData(typeof(ArgumentException), "80", NumberStyle.HexFloat, NumberFormatInfo.InvariantInfo);
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Integer, NumberFormatInfo.InvariantInfo);
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Integer | NumberStyle.AllowDecimalPoint | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
 
                     }
                 }

--- a/tests/J2N.Tests/Numerics/TestSByte.cs
+++ b/tests/J2N.Tests/Numerics/TestSByte.cs
@@ -160,29 +160,61 @@ namespace J2N.Numerics
             //assertFalse(fixture.Equals("Not a SByte"));
         }
 
+        // J2N: Centralizes ToString()/TryFormat() logic to allow testing all overloads
+
+        private void Test_toString(sbyte bb, string answer)
+        {
+            // Test for method java.lang.String java.lang.Double.toString(double)
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + SByte.ToString(bb, null, J2N.Text.StringFormatter.InvariantCulture) + ")", SByte.ToString(bb, null, J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+            SByte b = new SByte(bb);
+            assertTrue("Incorrect String representation want " + answer + ", got ("
+                    + SByte.ToString(b.ToSByte(), null, J2N.Text.StringFormatter.InvariantCulture) + ")", SByte.ToString(b.ToSByte(), null, J2N.Text.StringFormatter.InvariantCulture).Equals(
+                    answer));
+            assertTrue("Incorrect String representation want " + answer + ", got (" + b.ToString(J2N.Text.StringFormatter.InvariantCulture)
+                    + ")", b.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(b.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(SByte.TryFormat(bb, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
+        }
+
         /**
          * @tests java.lang.Byte#toString()
          */
         [Test]
         public void Test_toString()
         {
-            assertEquals("-1", new SByte((sbyte)-1).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("0", new SByte((sbyte)0).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("1", new SByte((sbyte)1).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("-1", new SByte(unchecked((sbyte)0xFF)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("-1", new SByte((sbyte)-1).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("0", new SByte((sbyte)0).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("1", new SByte((sbyte)1).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("-1", new SByte(unchecked((sbyte)0xFF)).ToString(J2N.Text.StringFormatter.InvariantCulture));
+
+            Test_toString((sbyte)-1, "-1");
+            Test_toString((sbyte)0, "0");
+            Test_toString((sbyte)1, "1");
+            Test_toString(unchecked((sbyte)0xFF), "-1");
         }
 
-        /**
-         * @tests java.lang.Byte#toString(byte)
-         */
-        [Test]
-        public void Test_toStringB()
-        {
-            assertEquals("-1", SByte.ToString((sbyte)-1, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("0", SByte.ToString((sbyte)0, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("1", SByte.ToString((sbyte)1, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("-1", SByte.ToString(unchecked((sbyte)0xFF), J2N.Text.StringFormatter.InvariantCulture));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Byte#toString(byte)
+        // */
+        //[Test]
+        //public void Test_toStringB()
+        //{
+        //    assertEquals("-1", SByte.ToString((sbyte)-1, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("0", SByte.ToString((sbyte)0, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("1", SByte.ToString((sbyte)1, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("-1", SByte.ToString(unchecked((sbyte)0xFF), J2N.Text.StringFormatter.InvariantCulture));
+        //}
 
         /**
          * @tests java.lang.Byte#valueOf(String)
@@ -913,21 +945,26 @@ namespace J2N.Numerics
         [Test]
         public void Test_toString2()
         {
-            assertEquals("Returned incorrect String", "127", new SByte((sbyte)127).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "-127", new SByte((sbyte)-127).ToString(J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "-128", new SByte((sbyte)-128).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "127", new SByte((sbyte)127).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "-127", new SByte((sbyte)-127).ToString(J2N.Text.StringFormatter.InvariantCulture));
+            //assertEquals("Returned incorrect String", "-128", new SByte((sbyte)-128).ToString(J2N.Text.StringFormatter.InvariantCulture));
+
+            Test_toString((sbyte)127, "127");
+            Test_toString((sbyte)-127, "-127");
+            Test_toString((sbyte)-128, "-128");
         }
 
-        /**
-         * @tests java.lang.Byte#toString(byte)
-         */
-        [Test]
-        public void Test_toStringB2()
-        {
-            assertEquals("Returned incorrect String", "127", SByte.ToString((sbyte)127, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "-127", SByte.ToString((sbyte)-127, J2N.Text.StringFormatter.InvariantCulture));
-            assertEquals("Returned incorrect String", "-128", SByte.ToString((sbyte)-128, J2N.Text.StringFormatter.InvariantCulture));
-        }
+        // J2N: Same values as above. No need to run again.
+        ///**
+        // * @tests java.lang.Byte#toString(byte)
+        // */
+        //[Test]
+        //public void Test_toStringB2()
+        //{
+        //    assertEquals("Returned incorrect String", "127", SByte.ToString((sbyte)127, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("Returned incorrect String", "-127", SByte.ToString((sbyte)-127, J2N.Text.StringFormatter.InvariantCulture));
+        //    assertEquals("Returned incorrect String", "-128", SByte.ToString((sbyte)-128, J2N.Text.StringFormatter.InvariantCulture));
+        //}
 
         /**
          * @tests java.lang.Byte#valueOf(java.lang.String)

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -2135,24 +2135,35 @@ namespace J2N.Numerics
                         yield return new TestCaseData(float.NegativeInfinity, "-Infinity", NumberStyle.Float, NumberFormatInfo.InvariantInfo);
 
 
-                        // J2N TODO: If/when the integral type parsers are ported, use similar tests to these to confirm them
-                        //yield return new TestCaseData(1.8f, "1.8e0u", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0l", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0L", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0UL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0uL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0Ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0LU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0lU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        //yield return new TestCaseData(1.8f, "1.8e0Lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        // Tests for AllowTypeSpecifier
+                        yield return new TestCaseData(100f, "100L", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100U", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100l", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100u", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
 
+                        yield return new TestCaseData(100f, "100UL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100Ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100uL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
 
-                        // Decimal type specifier
+                        yield return new TestCaseData(100f, "100LU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100Lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100lU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
 
-                        yield return new TestCaseData(1.8f, "1.8e0m", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
-                        yield return new TestCaseData(1.8f, "1.8e0M", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100F", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100M", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100m", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+
+                        yield return new TestCaseData(100f, "100.0D", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100.0d", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100.0F", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100.0f", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100.0M", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
+                        yield return new TestCaseData(100f, "100.0m", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo);
                     }
                 }
 
@@ -2685,6 +2696,47 @@ namespace J2N.Numerics
                         yield return new TestCaseData(typeof(ArgumentException), "(0x1.8p1)", NumberStyle.HexFloat | NumberStyle.AllowParentheses, NumberFormatInfo.InvariantInfo, "NumberStyle.HexFloat doesn't allow parentheses.");
                         yield return new TestCaseData(typeof(ArgumentException), "(0x1.8)", NumberStyle.HexFloat | NumberStyle.AllowParentheses, NumberFormatInfo.InvariantInfo, "NumberStyle.HexFloat doesn't allow parentheses.");
                         yield return new TestCaseData(typeof(ArgumentException), "(0x1.)", NumberStyle.HexFloat | NumberStyle.AllowParentheses, NumberFormatInfo.InvariantInfo, "NumberStyle.HexFloat doesn't allow parentheses.");
+
+                        // Tests for AllowTypeSpecifier
+
+                        yield return new TestCaseData(typeof(FormatException), "100L", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100U", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100l", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100u", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        yield return new TestCaseData(typeof(FormatException), "100UL", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100ul", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100Ul", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100uL", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        yield return new TestCaseData(typeof(FormatException), "100LU", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100lu", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100Lu", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+                        yield return new TestCaseData(typeof(FormatException), "100lU", NumberStyle.Float, NumberFormatInfo.InvariantInfo, "Requires AllowTypeSpecifier");
+
+                        // These are not valid ways of specifying long or unsigned types (they do not compile with a decimal point)
+                        yield return new TestCaseData(typeof(FormatException), "100.0L", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0U", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0l", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0u", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0UL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0Ul", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0uL", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        yield return new TestCaseData(typeof(FormatException), "100.0LU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0Lu", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+                        yield return new TestCaseData(typeof(FormatException), "100.0lU", NumberStyle.Float | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Not a valid integral type");
+
+                        // We need to use AllowDecimalPoint for these to work.
+                        yield return new TestCaseData(typeof(FormatException), "100.0D", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0d", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0F", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0f", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0M", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
+                        yield return new TestCaseData(typeof(FormatException), "100.0m", NumberStyle.Integer | NumberStyle.AllowTypeSpecifier, NumberFormatInfo.InvariantInfo, "Requires AllowDecimalPoint");
                     }
                 }
 

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -1443,6 +1443,10 @@ namespace J2N.Numerics
             assertTrue(f.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
             string actual = buffer.Slice(0, charsWritten).ToString();
             assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+
+            assertTrue(Single.TryFormat(ff, buffer, out charsWritten, provider: CultureInfo.InvariantCulture));
+            actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
 #endif
         }
 

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -1269,7 +1269,7 @@ namespace J2N.Numerics
                 }
             }
         }
-#else
+#endif
         [Test]
         public static void Test_ToString()
         {
@@ -1281,7 +1281,6 @@ namespace J2N.Numerics
                 }
             }
         }
-#endif
 
         private static void ToString(float f, string format, IFormatProvider provider, string expected)
         {
@@ -1438,6 +1437,13 @@ namespace J2N.Numerics
                     answer));
             assertTrue("Incorrect String representation want " + answer + ", got (" + f.ToString(J2N.Text.StringFormatter.InvariantCulture)
                     + ")", f.ToString(J2N.Text.StringFormatter.InvariantCulture).Equals(answer));
+
+#if FEATURE_SPAN
+            Span<char> buffer = stackalloc char[64];
+            assertTrue(f.TryFormat(buffer, out int charsWritten, ReadOnlySpan<char>.Empty, CultureInfo.InvariantCulture));
+            string actual = buffer.Slice(0, charsWritten).ToString();
+            assertEquals("Incorrect String representation want " + answer + ", got (" + actual + ")", answer, actual);
+#endif
         }
 
         /**

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -2889,7 +2889,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider
             {
                 protected override bool IsNullableType => false;
@@ -3055,7 +3055,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Single : TryParse_CharSequence_NumberStyle_IFormatProvider_Single_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -3143,7 +3143,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_NUMBER_PARSE_READONLYSPAN
+#if FEATURE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Single : TryParse_CharSequence_Single_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -2889,7 +2889,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider
             {
                 protected override bool IsNullableType => false;
@@ -3055,7 +3055,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Single : TryParse_CharSequence_NumberStyle_IFormatProvider_Single_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -3143,7 +3143,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_NUMBER_PARSE_READONLYSPAN
             public class TryParse_ReadOnlySpan_Single : TryParse_CharSequence_Single_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/J2N.Tests/Numerics/TestSingle.cs
@@ -2889,7 +2889,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class Parse_ReadOnlySpan_NumberStyle_IFormatProvider : Parse_CharSequence_NumberStyle_IFormatProvider
             {
                 protected override bool IsNullableType => false;
@@ -3055,7 +3055,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_NumberStyle_IFormatProvider_Single : TryParse_CharSequence_NumberStyle_IFormatProvider_Single_TestCase
             {
                 protected override bool IsNullableType => false;
@@ -3143,7 +3143,7 @@ namespace J2N.Numerics
                 }
             }
 
-#if FEATURE_READONLYSPAN
+#if FEATURE_SPAN
             public class TryParse_ReadOnlySpan_Single : TryParse_CharSequence_Single_TestCase
             {
                 protected override bool IsNullableType => false;

--- a/tests/J2N.Tests/Text/TestValueStringBuilder.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilder.cs
@@ -1,0 +1,320 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if FEATURE_SPAN
+
+using NUnit.Framework;
+using System.Text;
+using System;
+
+namespace J2N.Text
+{
+    internal class TestValueStringBuilder
+    {
+        [Test]
+        public void Ctor_Default_CanAppend()
+        {
+            var vsb = default(ValueStringBuilder);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Ctor_Span_CanAppend()
+        {
+            var vsb = new ValueStringBuilder(new char[1]);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Ctor_InitialCapacity_CanAppend()
+        {
+            var vsb = new ValueStringBuilder(1);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Append_Char_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i);
+                vsb.Append((char)i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Append_String_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                sb.Append(s);
+                vsb.Append(s);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Theory]
+        [TestCase(0, 4 * 1024 * 1024)]
+        [TestCase(1025, 4 * 1024 * 1024)]
+        [TestCase(3 * 1024 * 1024, 6 * 1024 * 1024)]
+        public void Append_String_Large_MatchesStringBuilder(int initialLength, int stringLength)
+        {
+            var sb = new StringBuilder(initialLength);
+            var vsb = new ValueStringBuilder(new char[initialLength]);
+
+            string s = new string('a', stringLength);
+            sb.Append(s);
+            vsb.Append(s);
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Append_CharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i, i);
+                vsb.Append((char)i, i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public unsafe void Append_PtrInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                fixed (char* p = s)
+                {
+                    sb.Append(p, s.Length);
+                    vsb.Append(p, s.Length);
+                }
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void AppendSpan_DataAppendedCorrectly()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+
+            for (int i = 1; i <= 1000; i++)
+            {
+                string s = i.ToString();
+
+                sb.Append(s);
+
+                Span<char> span = vsb.AppendSpan(s.Length);
+                Assert.AreEqual(sb.Length, vsb.Length);
+
+                s.AsSpan().CopyTo(span);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Insert_IntCharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            var rand = new Random(42);
+
+            for (int i = 1; i <= 100; i++)
+            {
+                int index = rand.Next(sb.Length);
+                sb.Insert(index, new string((char)i, 1), i);
+                vsb.Insert(index, (char)i, i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void AsSpan_ReturnsCorrectValue_DoesntClearBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                sb.Append(s);
+                vsb.Append(s);
+            }
+
+            var resultString = vsb.AsSpan().ToString();
+            Assert.AreEqual(sb.ToString(), resultString);
+
+            Assert.AreNotEqual(0, sb.Length);
+            Assert.AreEqual(sb.Length, vsb.Length);
+        }
+
+        [Test]
+        public void ToString_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            string s = vsb.ToString();
+            Assert.AreEqual(Text1, s);
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public void TryCopyTo_FailsWhenDestinationIsTooSmall_SucceedsWhenItsLargeEnough()
+        {
+            var vsb = new ValueStringBuilder();
+
+            const string Text = "expected text";
+            vsb.Append(Text);
+            Assert.AreEqual(Text.Length, vsb.Length);
+
+            Span<char> dst = new char[Text.Length - 1];
+            Assert.False(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.AreEqual(0, charsWritten);
+            Assert.AreEqual(0, vsb.Length);
+        }
+
+        [Test]
+        public void TryCopyTo_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            Span<char> dst = new char[Text1.Length];
+            Assert.True(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.AreEqual(Text1.Length, charsWritten);
+            Assert.AreEqual(Text1, dst.ToString());
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public void Dispose_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            vsb.Dispose();
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public unsafe void Indexer()
+        {
+            const string Text1 = "foobar";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+
+            Assert.AreEqual('b', vsb[3]);
+            vsb[3] = 'c';
+            Assert.AreEqual('c', vsb[3]);
+        }
+
+        [Test]
+        public void EnsureCapacity_IfRequestedCapacityWins()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            var builder = new ValueStringBuilder(stackalloc char[32]);
+
+            builder.EnsureCapacity(65);
+
+            Assert.AreEqual(128, builder.Capacity);
+        }
+
+        [Test]
+        public void EnsureCapacity_IfBufferTimesTwoWins()
+        {
+            var builder = new ValueStringBuilder(stackalloc char[32]);
+
+            builder.EnsureCapacity(33);
+
+            Assert.AreEqual(64, builder.Capacity);
+        }
+
+        [Test]
+        public void EnsureCapacity_NoAllocIfNotNeeded()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            var builder = new ValueStringBuilder(stackalloc char[64]);
+
+            builder.EnsureCapacity(16);
+
+            Assert.AreEqual(64, builder.Capacity);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## New APIs added for `netstandard2.0` and `net45` targets only

- All `Parse()`/`TryParse()` overloads that accept `ReadOnlySpan<char>` on `net6.0`

## APIs added < `net6.0`

```c#
namespace System
{
    public interface ISpanFormattable
    {
         bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
    }
}
```

## New APIs

```c#
namespace J2N.Numerics
{
    public sealed class Byte
    {
        public static byte Parse(ReadOnlySpan<char> s, int radix)
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(byte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryParse(ReadOnlySpan<char> s, int radix, out byte result)
    }

    public sealed class Double
    {
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(double value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
    }

    public sealed class Int16
    {
        public static short Parse(ReadOnlySpan<char> s, int radix)
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(short value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryParse(ReadOnlySpan<char> s, int radix, out short result)
    }

    public sealed class Int32
    {
        public static int Parse(ReadOnlySpan<char> s, int radix)
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(int value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryParse(ReadOnlySpan<char> s, int radix, out int result)
    }

    public sealed class Int64
    {
        public static long Parse(ReadOnlySpan<char> s, int radix)
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(long value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryParse(ReadOnlySpan<char> s, int radix, out long result)
    }

    public abstract class Number
    {
        public virtual bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
    }

    public sealed class SByte
    {
        public static sbyte Parse(ReadOnlySpan<char> s, int radix)
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(sbyte value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryParse(ReadOnlySpan<char> s, int radix, out sbyte result)
    }

    public sealed class Single
    {
        public override bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
        public static bool TryFormat(float value, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
    }
}
```

## New Features

- Support `AllowTypeSpecifier` on integral types
    - Decimal format (base 10 - without `AllowHexSpecifier`) allows 'D', 'd', 'F', 'f', 'M', 'm', 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu' after the number
    - Hex format (with `AllowHexSpecifier`) allows 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu' after the number
 - Extended support for `AllowTypeSpecifier` on decimal types to include 'UL', 'Ul', 'uL', 'ul', 'LU', 'Lu', 'lU', or 'lu' after the number in addition to 'D', 'd', 'F', 'f', 'M', and 'm'
 - Adds a dependency on `System.Memory` for `netstandard2.0` and `net45` (primarily to allow `Span<T>` and `ReadOnlySpan<T>` support)

## Optimizations

- `ValueStringBuilder` ported from .NET 6.0 to replace `StringBuilder` in number formatters
- Re-added unsafe pointers that were in the original .NET 6.0 formatters

## Code Cleanup

- Removes `FEATURE_READONLYSPAN` and normalizes all of the code to use `FEATURE_SPAN`
