### PR TITLE
J2N.Character: Added ReadOnlySpan<char> overloads for working with codepoints

### DIFF
--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -583,13 +583,13 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 0 || index >= len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             char high = seq[index++];
             if (index >= len)
@@ -621,13 +621,13 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this char[] seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 0 || index >= len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             char high = seq[index++];
             if (index >= len)
@@ -659,13 +659,13 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 0 || index >= len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             char high = seq[index++];
             if (index >= len)
@@ -697,13 +697,13 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this string seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 0 || index >= len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             char high = seq[index++];
             if (index >= len)
@@ -713,6 +713,43 @@ namespace J2N
                 return ToCodePoint(high, low);
             return high;
         }
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Returns the code point at <paramref name="index"/> in the specified sequence of
+        /// character units. If the unit at <paramref name="index"/> is a high-surrogate unit,
+        /// <c><paramref name="index"/> + 1</c> is less than the length of the sequence and the unit at
+        /// <c><paramref name="index"/> + 1</c> is a low-surrogate unit, then the supplementary code
+        /// point represented by the pair is returned; otherwise the <see cref="char"/>
+        /// value at <paramref name="index"/> is returned.
+        /// </summary>
+        /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
+        /// <param name="index">the position in <paramref name="seq"/> from which to retrieve the code
+        /// point.</param>
+        /// <returns>the Unicode code point or <see cref="char"/> value at <paramref name="index"/> in
+        /// <paramref name="seq"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is greater than or equal to the length of <paramref name="seq"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="index"/> is less than zero.
+        /// </exception>
+        public static int CodePointAt(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        {
+            int len = seq.Length;
+            if (index < 0 || index >= len)
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
+
+            char high = seq[index++];
+            if (index >= len)
+                return high;
+            char low = seq[index];
+            if (char.IsSurrogatePair(high, low))
+                return ToCodePoint(high, low);
+            return high;
+        }
+#endif
 
         /// <summary>
         /// Returns the code point at <paramref name="index"/> in the specified array of
@@ -736,7 +773,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="limit"/> is less than zero or greater than the length of <paramref name="seq"/>.
         /// </exception>
-        public static int CodePointAt(this char[] seq, int index, int limit)
+        public static int CodePointAt(this char[] seq, int index, int limit) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
@@ -770,13 +807,13 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 1 || index > len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
             char low = seq[--index];
             if (--index < 0)
@@ -805,13 +842,13 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this char[] seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 1 || index > len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
             char low = seq[--index];
             if (--index < 0)
@@ -840,13 +877,13 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 1 || index > len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
             char low = seq[--index];
             if (--index < 0)
@@ -875,13 +912,13 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this string seq, int index) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (index < 1 || index > len)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
             char low = seq[--index];
             if (--index < 0)
@@ -893,6 +930,40 @@ namespace J2N
             }
             return low;
         }
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Returns the code point that precedes <paramref name="index"/> in the specified
+        /// sequence of character units. If the unit at <c><paramref name="index"/> - 1</c> is a
+        /// low-surrogate unit, <c><paramref name="index"/> - 2</c> is not negative and the unit at
+        /// <c><paramref name="index"/> - 2</c> is a high-surrogate unit, then the supplementary code
+        /// point represented by the pair is returned; otherwise the <see cref="char"/>
+        /// value at <c><paramref name="index"/> - 1</c> is returned.
+        /// </summary>
+        /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
+        /// <param name="index">The position in <paramref name="seq"/> following the code
+        /// point that should be returned.</param>
+        /// <returns>The Unicode code point or <see cref="char"/> value before <paramref name="index"/>
+        /// in <paramref name="seq"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
+        /// the length of <paramref name="seq"/>.</exception>
+        public static int CodePointBefore(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        {
+            int len = seq.Length;
+            if (index < 1 || index > len)
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
+
+            char low = seq[--index];
+            if (--index < 0)
+                return low;
+            char high = seq[index];
+            if (char.IsSurrogatePair(high, low))
+            {
+                return ToCodePoint(high, low);
+            }
+            return low;
+        }
+#endif
 
         /// <summary>
         /// Returns the code point that preceds the <paramref name="index"/> in the specified
@@ -1052,15 +1123,15 @@ namespace J2N
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static int CodePointCount(this ICharSequence seq, int startIndex, int length) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointCount(this ICharSequence seq, int startIndex, int length) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
+                throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (startIndex + length > len)
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
@@ -1100,15 +1171,15 @@ namespace J2N
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static int CodePointCount(this char[] seq, int startIndex, int length) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointCount(this char[] seq, int startIndex, int length) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
+                throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (startIndex + length > len)
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
@@ -1148,15 +1219,15 @@ namespace J2N
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static int CodePointCount(this StringBuilder seq, int startIndex, int length) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointCount(this StringBuilder seq, int startIndex, int length) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
+                throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (startIndex + length > len)
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
@@ -1196,15 +1267,15 @@ namespace J2N
         /// <para/>
         /// <paramref name="startIndex"/> or <paramref name="length"/> is less than zero.
         /// </exception>
-        public static int CodePointCount(this string seq, int startIndex, int length) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointCount(this string seq, int startIndex, int length) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int len = seq.Length;
             if (startIndex < 0)
-                throw new ArgumentOutOfRangeException(nameof(startIndex));
+                throw new ArgumentOutOfRangeException(nameof(startIndex), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (length < 0)
-                throw new ArgumentOutOfRangeException(nameof(length));
+                throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (startIndex + length > len)
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
@@ -1222,6 +1293,31 @@ namespace J2N
             return n;
         }
 
+#if FEATURE_SPAN
+        /// <summary>
+        /// Returns the number of Unicode code points in the text range of the specified char sequence.
+        /// The text range begins at 0 and extends for the number
+        /// of characters specified in <paramref name="seq"/>.
+        /// Unpaired surrogates within the text range count as one code point each.
+        /// </summary>
+        /// <param name="seq">The char sequence.</param>
+        public static int CodePointCount(this ReadOnlySpan<char> seq) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        {
+            int endIndex = seq.Length;
+            int n = endIndex;
+            for (int i = 0; i < endIndex;)
+            {
+                if (char.IsHighSurrogate(seq[i++]) && i < endIndex
+                    && char.IsLowSurrogate(seq[i]))
+                {
+                    n--;
+                    i++;
+                }
+            }
+            return n;
+        }
+#endif
+
         /// <summary>
         /// Returns the index within the given char sequence that is offset from the given <paramref name="index"/> by
         /// <paramref name="codePointOffset"/> code points. Unpaired surrogates within the text range given by 
@@ -1246,13 +1342,13 @@ namespace J2N
         /// <paramref name="codePointOffset"/> is negative and the subsequence before <paramref name="index"/> has fewer than
         /// the absolute value of <paramref name="codePointOffset"/> code points.
         /// </exception>
-        public static int OffsetByCodePoints(this ICharSequence seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int OffsetByCodePoints(this ICharSequence seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int length = seq.Length;
             if (index < 0 || index > length)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             int x = index;
             if (codePointOffset >= 0)
@@ -1318,13 +1414,13 @@ namespace J2N
         /// <paramref name="codePointOffset"/> is negative and the subsequence before <paramref name="index"/> has fewer than
         /// the absolute value of <paramref name="codePointOffset"/> code points.
         /// </exception>
-        public static int OffsetByCodePoints(this char[] seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int OffsetByCodePoints(this char[] seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int length = seq.Length;
             if (index < 0 || index > length)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             int x = index;
             if (codePointOffset >= 0)
@@ -1390,13 +1486,13 @@ namespace J2N
         /// <paramref name="codePointOffset"/> is negative and the subsequence before <paramref name="index"/> has fewer than
         /// the absolute value of <paramref name="codePointOffset"/> code points.
         /// </exception>
-        public static int OffsetByCodePoints(this StringBuilder seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int OffsetByCodePoints(this StringBuilder seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int length = seq.Length;
             if (index < 0 || index > length)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             int x = index;
             if (codePointOffset >= 0)
@@ -1462,13 +1558,13 @@ namespace J2N
         /// <paramref name="codePointOffset"/> is negative and the subsequence before <paramref name="index"/> has fewer than
         /// the absolute value of <paramref name="codePointOffset"/> code points.
         /// </exception>
-        public static int OffsetByCodePoints(this string seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int OffsetByCodePoints(this string seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             int length = seq.Length;
             if (index < 0 || index > length)
-                throw new ArgumentOutOfRangeException(nameof(index));
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
             int x = index;
             if (codePointOffset >= 0)
@@ -1509,6 +1605,77 @@ namespace J2N
             }
             return x;
         }
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Returns the index within the given char sequence that is offset from the given <paramref name="index"/> by
+        /// <paramref name="codePointOffset"/> code points. Unpaired surrogates within the text range given by 
+        /// <paramref name="index"/> and <paramref name="codePointOffset"/> count as one code point each.
+        /// </summary>
+        /// <param name="seq">The character sequence.</param>
+        /// <param name="index">The index to be offset.</param>
+        /// <param name="codePointOffset">The number of code points to look backwards or forwards; may
+        /// be a negative or positive value.</param>
+        /// <returns>The index within the char sequence, offset by <paramref name="codePointOffset"/> code points.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is less than zero or greater than the length of the character sequence <paramref name="seq"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="codePointOffset"/> is positive and the subsequence starting with <paramref name="index"/> has fewer than
+        /// <paramref name="codePointOffset"/> code points.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="codePointOffset"/> is negative and the subsequence before <paramref name="index"/> has fewer than
+        /// the absolute value of <paramref name="codePointOffset"/> code points.
+        /// </exception>
+        public static int OffsetByCodePoints(this ReadOnlySpan<char> seq, int index, int codePointOffset) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        {
+            int length = seq.Length;
+            if (index < 0 || index > length)
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
+
+            int x = index;
+            if (codePointOffset >= 0)
+            {
+                int i;
+                for (i = 0; x < length && i < codePointOffset; i++)
+                {
+                    if (char.IsHighSurrogate(seq[x++]))
+                    {
+                        if (x < length && char.IsLowSurrogate(seq[x]))
+                        {
+                            x++;
+                        }
+                    }
+                }
+                if (i < codePointOffset)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(codePointOffset));
+                }
+            }
+            else
+            {
+                int i;
+                for (i = codePointOffset; x > 0 && i < 0; i++)
+                {
+                    if (char.IsLowSurrogate(seq[--x]))
+                    {
+                        if (x > 0 && char.IsHighSurrogate(seq[x - 1]))
+                        {
+                            x--;
+                        }
+                    }
+                }
+                if (i < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(codePointOffset));
+                }
+            }
+            return x;
+        }
+#endif
 
         /// <summary>
         /// Returns the index within the given <see cref="char"/> subarray <paramref name="seq"/> that is offset from the given <paramref name="index"/>
@@ -1555,9 +1722,9 @@ namespace J2N
             if (seq == null)
                 throw new ArgumentNullException(nameof(seq));
             if (start < 0)
-                throw new ArgumentOutOfRangeException(nameof(start));
+                throw new ArgumentOutOfRangeException(nameof(start), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (count < 0)
-                throw new ArgumentOutOfRangeException(nameof(count));
+                throw new ArgumentOutOfRangeException(nameof(count), SR2.ArgumentOutOfRange_NeedNonNegNum);
             if (count > seq.Length - start || index < start || index > start + count)
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable CA2208 // Instantiate argument exceptions correctly
@@ -1568,6 +1735,9 @@ namespace J2N
             return OffsetByCodePointsImpl(seq, start, count, index, codePointOffset);
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static int OffsetByCodePointsImpl(char[] seq, int start, int count,
                                           int index, int codePointOffset)
         {

--- a/src/J2N/Resources/Strings.Designer.cs
+++ b/src/J2N/Resources/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace J2N.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -430,11 +430,20 @@ namespace J2N.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Index was out of range. Must be non-negative and less than the size of the collection..
+        ///   Looks up a localized string similar to Index was out of range. Must be non-negative and less than the size of the string/array/collection..
         /// </summary>
         internal static string ArgumentOutOfRange_Index {
             get {
                 return ResourceManager.GetString("ArgumentOutOfRange_Index", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Index was out of range. Must be at least 1 and less than or equal to the size of the string/array/collection..
+        /// </summary>
+        internal static string ArgumentOutOfRange_IndexBefore {
+            get {
+                return ResourceManager.GetString("ArgumentOutOfRange_IndexBefore", resourceCulture);
             }
         }
         

--- a/src/J2N/Resources/Strings.resx
+++ b/src/J2N/Resources/Strings.resx
@@ -127,7 +127,10 @@
     <value>Count must be positive and count must refer to a location within the string/array/collection.</value>
   </data>
   <data name="ArgumentOutOfRange_Index" xml:space="preserve">
-    <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
+    <value>Index was out of range. Must be non-negative and less than the size of the string/array/collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_IndexBefore" xml:space="preserve">
+    <value>Index was out of range. Must be at least 1 and less than or equal to the size of the string/array/collection.</value>
   </data>
   <data name="ArgumentOutOfRange_IndexLength" xml:space="preserve">
     <value>Index and length must refer to a location within the string.</value>

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -295,6 +295,41 @@ namespace J2N
             }
         }
 
+#if FEATURE_SPAN
+        [Test]
+        public void Test_codePointAt_ReadOnlySpanI()
+        {
+
+            assertEquals('a', Character.CodePointAt("abc".AsSpan(), 0));
+            assertEquals('b', Character.CodePointAt("abc".AsSpan(), 1));
+            assertEquals('c', Character.CodePointAt("abc".AsSpan(), 2));
+            assertEquals(0x10000, Character.CodePointAt(
+                    "\uD800\uDC00".AsSpan(), 0));
+            assertEquals('\uDC00', Character.CodePointAt(
+                    "\uD800\uDC00".AsSpan(), 1));
+
+            // J2N: ReadOnlySpan<char> is a value type - null not allowed
+
+            try
+            {
+                Character.CodePointAt("abc".AsSpan(), -1);
+                fail("No IOOBE, negative index.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.CodePointAt("abc".AsSpan(), 4);
+                fail("No IOOBE, index too large.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+        }
+#endif
+
         [Test]
         public void Test_codePointAt_CI()
         {
@@ -555,8 +590,40 @@ namespace J2N
             }
         }
 
+#if FEATURE_SPAN
+        [Test]
+        public void Test_codePointBefore_ReadOnlySpanI()
+        {
 
+            assertEquals('a', Character.CodePointBefore("abc".AsSpan(), 1));
+            assertEquals('b', Character.CodePointBefore("abc".AsSpan(), 2));
+            assertEquals('c', Character.CodePointBefore("abc".AsSpan(), 3));
+            assertEquals(0x10000, Character.CodePointBefore(
+                    "\uD800\uDC00".AsSpan(), 2));
+            assertEquals('\uD800', Character.CodePointBefore(
+                    "\uD800\uDC00".AsSpan(), 1));
 
+            // J2N: ReadOnlySpan<char> is a value type - null not allowed
+
+            try
+            {
+                Character.CodePointBefore("abc".AsSpan(), 0);
+                fail("No IOOBE, index below one.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.CodePointBefore("abc".AsSpan(), 4);
+                fail("No IOOBE, index too large.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+        }
+#endif
 
 
         [Test]
@@ -930,6 +997,20 @@ namespace J2N
             }
         }
 
+#if FEATURE_SPAN
+        [Test]
+        public void Test_codePointCount_ReadOnlySpanII()
+        {
+            assertEquals(1, Character.CodePointCount("\uD800\uDC00".AsSpan(0, 2 - 0))); // end - start
+            assertEquals(1, Character.CodePointCount("\uD800\uDC01".AsSpan(0, 2 - 0))); // end - start
+            assertEquals(1, Character.CodePointCount("\uD801\uDC01".AsSpan(0, 2 - 0))); // end - start
+            assertEquals(1, Character.CodePointCount("\uDBFF\uDFFF".AsSpan(0, 2 - 0))); // end - start
+
+            assertEquals(3, Character.CodePointCount("a\uD800\uDC00b".AsSpan(0, 4 - 0))); // end - start
+            assertEquals(4, Character.CodePointCount("a\uD800\uDC00b\uD800".AsSpan(0, 5 - 0))); // end - start
+        }
+#endif
+
         [Test]
         public void Test_offsetByCodePoints_ICharSequenceII()
         {
@@ -1222,6 +1303,73 @@ namespace J2N
             }
         }
 
+#if FEATURE_SPAN
+        [Test]
+        public void Test_offsetByCodePoints_ReadOnlySpanII()
+        {
+            int result = Character.OffsetByCodePoints("a\uD800\uDC00b".AsSpan(), 0, 2);
+            assertEquals(3, result);
+
+            result = Character.OffsetByCodePoints("abcd".AsSpan(), 3, -1);
+            assertEquals(2, result);
+
+            result = Character.OffsetByCodePoints("a\uD800\uDC00b".AsSpan(), 0, 3);
+            assertEquals(4, result);
+
+            result = Character.OffsetByCodePoints("a\uD800\uDC00b".AsSpan(), 3, -1);
+            assertEquals(1, result);
+
+            result = Character.OffsetByCodePoints("a\uD800\uDC00b".AsSpan(), 3, 0);
+            assertEquals(3, result);
+
+            result = Character.OffsetByCodePoints("\uD800\uDC00bc".AsSpan(), 3, 0);
+            assertEquals(3, result);
+
+            result = Character.OffsetByCodePoints("a\uDC00bc".AsSpan(), 3, -1);
+            assertEquals(2, result);
+
+            result = Character.OffsetByCodePoints("a\uD800bc".AsSpan(), 3, -1);
+            assertEquals(2, result);
+
+            // J2N: ReadOnlySpan<char> is a value type - null not allowed
+
+            try
+            {
+                Character.OffsetByCodePoints("abc".AsSpan(), -1, 1);
+                fail();
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.OffsetByCodePoints("abc".AsSpan(), 4, 1);
+                fail();
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.OffsetByCodePoints("abc".AsSpan(), 1, 3);
+                fail();
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.OffsetByCodePoints("abc".AsSpan(), 1, -2);
+                fail();
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+        }
+#endif
 
 
         [Test]


### PR DESCRIPTION
Added ReadOnlySpan<char> overloads for CodePointAt, CodePointBefore, CodePointCount, and OffsetByCodePoints + tests

## New APIs

```c#
namespace J2N
{
    public static class Character
    {
        public static int CodePointAt(this ReadOnlySpan<char> seq, int index)
        public static int CodePointBefore(this ReadOnlySpan<char> seq, int index)
        public static int CodePointCount(this ReadOnlySpan<char> seq)
        public static int OffsetByCodePoints(this ReadOnlySpan<char> seq, int index, int codePointOffset)
    }
}
```
