### PR TITLE
J2N.Text: Added ValueStringBuilderArrayPoolIndexer + tests

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -130,6 +130,7 @@
   <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
 
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>

--- a/src/J2N/Text/ValueStringBuilderArrayPoolIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderArrayPoolIndexer.cs
@@ -1,0 +1,211 @@
+﻿#if FEATURE_ARRAYPOOL
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace J2N.Text
+{
+    using SR = J2N.Resources.Strings;
+
+    /// <summary>
+    /// A decorator for <see cref="StringBuilder"/> to track access to the last used chunk so it doesn't have to be looked up
+    /// when iterating forward or reverse through the <see cref="StringBuilder"/>. Supports both reads and writes.
+    /// The purpose is to chunk the <see cref="char"/>s from the <see cref="StringBuilder"/> into a pooled array. The
+    /// interface is similar to the <see cref="StringBuilder"/> so
+    /// business logic doesn't have to be rewritten to iterate a <see cref="StringBuilder"/> via index. The performance of
+    /// the <see cref="StringBuilder.this[int]"/> indexer is very poor and this is intended as a direct replacement.
+    /// <para/>
+    /// Usage Note: This works as a drop-in replacement for <see cref="StringBuilder"/> in cases where we are looping either forward
+    /// or backward through the <see cref="char"/>s, without the need to add additional business logic to deal with switching chunks.
+    /// <para/>
+    /// Both sequential and random access are supported, however, sequential access is optimized. If the business logic simultaneously
+    /// iterates both forward and backward, it is recommended to create 2 separate instances (one specifying <see cref="iterateForward"/>=false)
+    /// to ensure looking up chunks in the <see cref="StringBuilder"/> is a rare operation. Writes are done to the underlying memory of the
+    /// <see cref="StringBuilder"/>, so using multiple instances for tracking both directions will immediately show the changes.
+    /// <para/>
+    /// Do not call any operations that mutate the <see cref="StringBuilder"/>, such as <see cref="StringBuilder.Append(string?)"/>,
+    /// <see cref="StringBuilder.Insert(int, string?)"/>. If the state of the <see cref="StringBuilder"/> changes, the behavior
+    /// is undefined and you must create a new instance of <see cref="ValueStringArrayPoolIndexer"/> to read the changes.
+    /// <para/>
+    /// This type is disposable and the user is responsible for calling <see cref="Dispose()"/> after use.
+    /// <para/>
+    /// For .NET Core 3.x and higher, the ValueStringBuilderChunkIndexer should be favored over this approach.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs have performance issues with readonly fields.")]
+    internal ref struct ValueStringArrayPoolIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
+    {
+        public const int ChunkLength = 1024;
+
+        private /*readonly*/ StringBuilder stringBuilder;
+        private /*readonly*/ int lastChunkLength;
+        private char[] currentChunk;
+        private int chunkCount;
+        private int currentChunkIndex;
+        private int currentLowerBound;
+        private int currentUpperBound;
+        private bool iterateForward;
+
+        public ValueStringArrayPoolIndexer(StringBuilder stringBuilder, bool iterateForward = true)
+        {
+            this.stringBuilder = stringBuilder ?? throw new ArgumentNullException(nameof(stringBuilder));
+            this.iterateForward = iterateForward;
+
+            chunkCount = 0;
+            currentChunkIndex = -1;
+            currentLowerBound = 0;
+            currentUpperBound = 0;
+            currentChunk = ArrayPool<char>.Shared.Rent(ChunkLength);
+
+            int length = stringBuilder.Length;
+            chunkCount = (int)Math.Ceiling((double)length / ChunkLength);
+            int remainder = (chunkCount * ChunkLength) - length;
+            lastChunkLength = ChunkLength - remainder;
+
+            Reset();
+        }
+
+        internal int ChunkCount => chunkCount; // internal for testing
+        internal int LastChunkLength => lastChunkLength; // internal for testing
+        public void Dispose()
+        {
+            ArrayPool<char>.Shared.Return(currentChunk);
+        }
+
+        internal void GetBounds(int chunkIndex, out int lowerBound, out int upperBound) // internal for testing
+        {
+            Debug.Assert(chunkIndex >= 0);
+            Debug.Assert(chunkIndex < chunkCount);
+
+            lowerBound = chunkIndex * ChunkLength;
+            upperBound = ((chunkIndex + 1) * ChunkLength) - 1;
+
+            // Fix last chunk upper bound
+            if (chunkIndex == chunkCount - 1)
+            {
+                int lastIndex = stringBuilder.Length - 1;
+                if (upperBound > lastIndex)
+                    upperBound = lastIndex;
+            }
+        }
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        internal bool IsWithinBounds(int chunkIndex, int index)
+        {
+            GetBounds(chunkIndex, out int lowerBound, out int upperBound);
+            return index >= lowerBound && index <= upperBound;
+        }
+
+        private void SetCurrentChunkFromIndex(int index)
+        {
+            if (iterateForward)
+            {
+                // Scan forward first
+                for (int i = currentChunkIndex + 1; i < chunkCount; i++)
+                {
+                    if (IsWithinBounds(i, index))
+                    {
+                        SetChunk(i);
+                        return;
+                    }
+                }
+                for (int i = currentChunkIndex - 1; i >= 0; i--)
+                {
+                    if (IsWithinBounds(i, index))
+                    {
+                        SetChunk(i);
+                        return;
+                    }
+                }
+            }
+            else
+            {
+                // Scan backward first
+                for (int i = currentChunkIndex - 1; i >= 0; i--)
+                {
+                    if (IsWithinBounds(i, index))
+                    {
+                        SetChunk(i);
+                        return;
+                    }
+                }
+                for (int i = currentChunkIndex + 1; i < chunkCount; i++)
+                {
+                    if (IsWithinBounds(i, index))
+                    {
+                        SetChunk(i);
+                        return;
+                    }
+                }
+            }
+        }
+
+        private void SetChunk(int chunkIndex)
+        {
+            if (currentChunkIndex == chunkIndex)
+                return;
+
+            GetBounds(chunkIndex, out int lowerBound, out int upperBound);
+            currentLowerBound = lowerBound;
+            currentUpperBound = upperBound;
+            currentChunkIndex = chunkIndex;
+            stringBuilder.CopyTo(lowerBound, currentChunk, 0, chunkIndex == chunkCount - 1 ? lastChunkLength : ChunkLength);
+        }
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public void Reset()
+        {
+            int chunkIndex = iterateForward ? 0 : chunkCount - 1;
+            SetChunk(chunkIndex);
+        }
+
+        public void Reset(bool iterateForward)
+        {
+            this.iterateForward = iterateForward;
+            Reset();
+        }
+
+        public bool IterateForward => iterateForward;
+
+        public char this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                if ((uint)index >= (uint)stringBuilder.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
+                }
+
+                if (index < currentLowerBound || index > currentUpperBound)
+                {
+                    SetCurrentChunkFromIndex(index);
+                }
+
+                return currentChunk[index - currentLowerBound];
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                if ((uint)index >= (uint)stringBuilder.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
+                }
+
+                if (index < currentLowerBound || index > currentUpperBound)
+                {
+                    SetCurrentChunkFromIndex(index);
+                }
+
+                stringBuilder[index] = currentChunk[index - currentLowerBound] = value;
+            }
+        }
+    }
+}
+#endif

--- a/tests/J2N.Tests/Text/TestValueStringBuilderArrayPoolIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderArrayPoolIndexer.cs
@@ -1,0 +1,292 @@
+﻿#if FEATURE_ARRAYPOOL
+using NUnit.Framework;
+using System;
+using System.Text;
+
+namespace J2N.Text
+{
+    public class TestValueStringBuilderArrayPoolIndexer
+    {
+        [Test]
+        public void SequentialAccess_ReadsCorrectly()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            for (int i = 0; i < sb.Length; i++)
+            {
+                char expected = sb[i];
+                char actual = indexer[i];
+                Assert.AreEqual(expected, actual);
+            }
+        }
+
+        [Test]
+        public void SequentialAccess_WritesCorrectly()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            var indexer = new ValueStringArrayPoolIndexer(sb);
+            try
+            {
+                for (int i = 0; i < sb.Length; i++)
+                {
+                    indexer[i] = 'X';
+                    char actual = sb[i];
+                    Assert.AreEqual('X', actual);
+                }
+            }
+            finally
+            {
+                indexer.Dispose();
+            }
+        }
+
+        [Test]
+        public void RandomAccess_ReadsCorrectly()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            Assert.AreEqual('4', indexer[3]);
+            Assert.AreEqual('8', indexer[7]);
+        }
+
+        [Test]
+        public void RandomAccess_WritesCorrectly()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            var indexer = new ValueStringArrayPoolIndexer(sb);
+            try
+            {
+                indexer[3] = 'X';
+                indexer[7] = 'Y';
+
+                Assert.AreEqual('X', sb[3]);
+                Assert.AreEqual('Y', sb[7]);
+            }
+            finally
+            {
+                indexer.Dispose();
+            }
+        }
+
+        [Test]
+        public void ResettingIterators_SwitchingDirections_Successful()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            Assert.AreEqual(true, indexer.IterateForward);
+
+            // Switching direction from forward to backward
+            indexer.Reset(false);
+            Assert.AreEqual(false, indexer.IterateForward);
+
+            // Switching direction from backward to forward
+            indexer.Reset(true);
+            Assert.AreEqual(true, indexer.IterateForward);
+        }
+
+        [Test]
+        public void InvalidIndex_ThrowsException()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using var indexer = new ValueStringArrayPoolIndexer(sb);
+
+            try
+            {
+                char _ = indexer[-1];
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsInstanceOf<ArgumentOutOfRangeException>(ex);
+            }
+            try
+            {
+                char _ = indexer[sb.Length];
+                Assert.Fail("Expected exception not thrown");
+            }
+            catch (Exception ex)
+            {
+                Assert.IsInstanceOf<ArgumentOutOfRangeException>(ex);
+            }
+        }
+
+        [Test]
+        public void GetBounds_SingleChunk_ReturnsCorrectBounds()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Single chunk scenario
+                indexer.GetBounds(0, out int lowerBound, out int upperBound);
+
+                Assert.AreEqual(0, lowerBound);
+                Assert.AreEqual(sb.Length - 1, upperBound);
+            }
+        }
+
+        [Test]
+        public void GetBounds_MultipleChunks_ReturnsCorrectBounds()
+        {
+            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Multiple chunks scenario
+                indexer.GetBounds(0, out int lowerBound1, out int upperBound1);
+                indexer.GetBounds(1, out int lowerBound2, out int upperBound2);
+
+                Assert.AreEqual(0, lowerBound1);
+                Assert.AreEqual(ValueStringArrayPoolIndexer.ChunkLength - 1, upperBound1);
+
+                Assert.AreEqual(ValueStringArrayPoolIndexer.ChunkLength, lowerBound2);
+                Assert.AreEqual(sb.Length - 1, upperBound2);
+            }
+        }
+
+        [Test]
+        public void IsWithinBounds_SingleChunk_ReturnsTrueForValidIndex()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Single chunk scenario
+                bool result = indexer.IsWithinBounds(0, 5);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [Test]
+        public void IsWithinBounds_SingleChunk_ReturnsFalseForInvalidIndex()
+        {
+            StringBuilder sb = new StringBuilder("1234567890");
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Single chunk scenario
+                bool result = indexer.IsWithinBounds(0, sb.Length);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [Test]
+        public void IsWithinBounds_MultipleChunks_ReturnsTrueForValidIndex()
+        {
+            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Multiple chunks scenario
+                bool result = indexer.IsWithinBounds(1, 1025);
+                Assert.IsTrue(result);
+            }
+        }
+
+        [Test]
+        public void IsWithinBounds_MultipleChunks_ReturnsFalseForInvalidIndex()
+        {
+            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
+            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            {
+                indexer.Reset(iterateForward: true);
+                //indexer.IterateForward = true;
+
+                // Multiple chunks scenario
+                bool result = indexer.IsWithinBounds(0, sb.Length);
+                Assert.IsFalse(result);
+            }
+        }
+
+        [Test]
+        public void ModifyingValuesInMultipleChunks_ChangesValues()
+        {
+            // Arrange
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append("Hello, ").Append(new string('a', 1024));
+            stringBuilder.Append("Beautiful, ").Append(new string('a', 1024));
+            stringBuilder.Append("Amazing, ").Append(new string('a', 1024));
+            stringBuilder.Append("World!");
+            var indexer = new ValueStringArrayPoolIndexer(stringBuilder);
+
+            // Act
+            indexer[7 + 1024] = 'X';
+            indexer[14 + 1024] = 'V';
+            indexer[20 + 2048] = 'A';
+            indexer[27 + 3072] = 'Z';
+            indexer[32 + 3072] = '?';
+
+            // Assert
+            Assert.AreEqual('X', indexer[7 + 1024]);
+            Assert.AreEqual('V', indexer[14 + 1024]);
+            Assert.AreEqual('A', indexer[20 + 2048]);
+            Assert.AreEqual('Z', indexer[27 + 3072]);
+            Assert.AreEqual('?', indexer[32 + 3072]);
+
+            Assert.AreEqual($"Hello, {new string('a', 1024)}XeautifVl, {new string('a', 1024)}AmAzing, {new string('a', 1024)}Zorld?", stringBuilder.ToString());
+        }
+
+
+        [Test]
+        public void SwitchingToRandomAccessAndBackToSequentialAccess_ReturnsCorrectValues()
+        {
+            // Arrange
+            var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
+            var indexer = new ValueStringArrayPoolIndexer(stringBuilder);
+
+            // Act
+            indexer.Reset(iterateForward: false);
+
+            // Assert
+            Assert.AreEqual('d', indexer[11]);
+            Assert.AreEqual('l', indexer[2]);
+            Assert.AreEqual('o', indexer[4]);
+
+            // Act
+            indexer.Reset();
+
+            // Assert sequential access
+            Assert.AreEqual('H', indexer[0]);
+            Assert.AreEqual('e', indexer[1]);
+            Assert.AreEqual('l', indexer[2]);
+            Assert.AreEqual('l', indexer[3]);
+            Assert.AreEqual('o', indexer[4]);
+            Assert.AreEqual(',', indexer[5]);
+            Assert.AreEqual(' ', indexer[6]);
+            Assert.AreEqual('W', indexer[7]);
+            Assert.AreEqual('o', indexer[8]);
+            Assert.AreEqual('r', indexer[9]);
+            Assert.AreEqual('l', indexer[10]);
+            Assert.AreEqual('d', indexer[11]);
+
+            // Assert random access
+            Assert.AreEqual('W', indexer[7]);
+            Assert.AreEqual('H', indexer[0]);
+
+            // Assert sequential access
+            Assert.AreEqual('H', indexer[0]);
+            Assert.AreEqual('e', indexer[1]);
+            Assert.AreEqual('l', indexer[2]);
+            Assert.AreEqual('l', indexer[3]);
+            Assert.AreEqual('o', indexer[4]);
+            Assert.AreEqual(',', indexer[5]);
+            Assert.AreEqual(' ', indexer[6]);
+            Assert.AreEqual('W', indexer[7]);
+            Assert.AreEqual('o', indexer[8]);
+            Assert.AreEqual('r', indexer[9]);
+            Assert.AreEqual('l', indexer[10]);
+            Assert.AreEqual('d', indexer[11]);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Added `ValueStringBuilderArrayPoolIndexer` + tests, which will be used to optimize methods that iterate through `StringBuilder` via index (in cases where `GetChunks()` is not supported).