### PR TITLE
PERFORMANCE: J2N.Text.StringBuilderExtensions: Optimizations

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -18,6 +18,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_ENCODINGPROVIDERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_CHARPTR</DefineConstants>
 
     <DebugType>portable</DebugType>
   </PropertyGroup>
@@ -109,6 +110,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_CHARPTR</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -2551,7 +2551,7 @@ namespace J2N.Text
         /// <para/>
         /// Let <c>n</c> be the character length of this character sequence
         /// (not the length in <see cref="char"/> values) just prior to
-        /// execution of the <see cref="Reverse"/> method. Then the
+        /// execution of the <see cref="Reverse()"/> method. Then the
         /// character at index <c>k</c> in the new character sequence is
         /// equal to the character at index <c>n-k-1</c> in the old
         /// character sequence.

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -1769,10 +1769,15 @@ namespace J2N.Text
                     // replacing with more characters...need some room
                     text.Insert(startIndex, new char[-diff]);
                 }
+#if FEATURE_STRINGBUILDER_GETCHUNKS
+                var textIndexer = new ValueStringBuilderChunkIndexer(text);
+#else // J2N: ValueStringBuilderArrayPoolIndexer doesn't provide any write advantage over StringBuilder
+                var textIndexer = text; // .NET 4.0 - don't care to optimize
+#endif
                 // copy the chars based on the new length
                 for (int i = 0; i < stringLength; i++)
                 {
-                    text[i + startIndex] = newValue[i];
+                    textIndexer[i + startIndex] = newValue[i];
                 }
                 return text;
             }

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -506,7 +506,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -550,7 +550,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -596,8 +596,8 @@ namespace J2N.Text
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
             var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
-            using var valueIndexer = new ValueStringArrayPoolIndexer(value);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
 #endif
 #if FEATURE_STRINGBUILDER_GETCHUNKS || FEATURE_ARRAYPOOL
             int length = Math.Min(text.Length, value.Length);
@@ -644,7 +644,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -893,7 +893,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -928,7 +928,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1592,7 +1592,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1650,7 +1650,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1828,8 +1828,8 @@ namespace J2N.Text
             var forwardTextIndexer = new ValueStringBuilderChunkIndexer(text);
             var reverseTextIndexer = new ValueStringBuilderChunkIndexer(text, iterateForward: false);
 #elif FEATURE_ARRAYPOOL
-            var forwardTextIndexer = new ValueStringArrayPoolIndexer(text);
-            var reverseTextIndexer = new ValueStringArrayPoolIndexer(text, iterateForward: false);
+            var forwardTextIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            var reverseTextIndexer = new ValueStringBuilderArrayPoolIndexer(text, iterateForward: false);
             try
 #else
             var forwardTextIndexer = text; // .NET 4.0 - don't care to optimize

--- a/src/J2N/Text/ValueStringBuilderArrayPoolIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderArrayPoolIndexer.cs
@@ -27,14 +27,14 @@ namespace J2N.Text
     /// <para/>
     /// Do not call any operations that mutate the <see cref="StringBuilder"/>, such as <see cref="StringBuilder.Append(string?)"/>,
     /// <see cref="StringBuilder.Insert(int, string?)"/>. If the state of the <see cref="StringBuilder"/> changes, the behavior
-    /// is undefined and you must create a new instance of <see cref="ValueStringArrayPoolIndexer"/> to read the changes.
+    /// is undefined and you must create a new instance of <see cref="ValueStringBuilderArrayPoolIndexer"/> to read the changes.
     /// <para/>
     /// This type is disposable and the user is responsible for calling <see cref="Dispose()"/> after use.
     /// <para/>
-    /// For .NET Core 3.x and higher, the ValueStringBuilderChunkIndexer should be favored over this approach.
+    /// For .NET Core 3.x and higher, the <see cref="ValueStringBuilderChunkIndexer"/> should be favored over this approach.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs have performance issues with readonly fields.")]
-    internal ref struct ValueStringArrayPoolIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
+    internal ref struct ValueStringBuilderArrayPoolIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
     {
         public const int ChunkLength = 512;
 
@@ -47,7 +47,7 @@ namespace J2N.Text
         private int currentUpperBound;
         private bool iterateForward;
 
-        public ValueStringArrayPoolIndexer(StringBuilder stringBuilder, bool iterateForward = true)
+        public ValueStringBuilderArrayPoolIndexer(StringBuilder stringBuilder, bool iterateForward = true)
         {
             this.stringBuilder = stringBuilder ?? throw new ArgumentNullException(nameof(stringBuilder));
             this.iterateForward = iterateForward;

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -494,6 +494,9 @@ namespace J2N.Text
 
             str = "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
             reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba", str);
+
+            str = new string('z', 1000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00" + new string('p', 3000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('p', 3000) + "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('z', 1000), str);
         }
 
         /**

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -1227,6 +1227,9 @@ namespace J2N.Text
                 assertEquals(fixture.IndexOf(searchFor, StringComparison.CurrentCulture), sb.IndexOf(searchFor, StringComparison.CurrentCulture));
                 assertEquals(6, sb.IndexOf(searchFor, StringComparison.Ordinal));
                 assertEquals(6, sb.IndexOf(searchFor, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase), sb.IndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.InvariantCulture), sb.IndexOf(searchFor, StringComparison.InvariantCulture));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase), sb.IndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1242,6 +1245,9 @@ namespace J2N.Text
                 assertEquals(fixture.IndexOf(searchFor, StringComparison.CurrentCulture), sb.IndexOf(searchFor, StringComparison.CurrentCulture));
                 assertEquals(LargeUnicodeString.Length + 6, sb.IndexOf(searchFor, StringComparison.Ordinal));
                 assertEquals(LargeUnicodeString.Length + 6, sb.IndexOf(searchFor, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase), sb.IndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.InvariantCulture), sb.IndexOf(searchFor, StringComparison.InvariantCulture));
+                assertEquals(fixture.IndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase), sb.IndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1257,6 +1263,9 @@ namespace J2N.Text
                 assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.CurrentCulture), sb.IndexOf(searchFor, 4, StringComparison.CurrentCulture));
                 assertEquals(6, sb.IndexOf(searchFor, 4, StringComparison.Ordinal));
                 assertEquals(6, sb.IndexOf(searchFor, 4, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.CurrentCultureIgnoreCase), sb.IndexOf(searchFor, 4, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.InvariantCulture), sb.IndexOf(searchFor, 4, StringComparison.InvariantCulture));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.InvariantCultureIgnoreCase), sb.IndexOf(searchFor, 4, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1272,6 +1281,9 @@ namespace J2N.Text
                 assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.CurrentCulture), sb.IndexOf(searchFor, 4, StringComparison.CurrentCulture));
                 assertEquals(LargeUnicodeString.Length + 6, sb.IndexOf(searchFor, 4, StringComparison.Ordinal));
                 assertEquals(LargeUnicodeString.Length + 6, sb.IndexOf(searchFor, 4, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.CurrentCultureIgnoreCase), sb.IndexOf(searchFor, 4, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.InvariantCulture), sb.IndexOf(searchFor, 4, StringComparison.InvariantCulture));
+                assertEquals(fixture.IndexOf(searchFor, 4, StringComparison.InvariantCultureIgnoreCase), sb.IndexOf(searchFor, 4, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1288,6 +1300,9 @@ namespace J2N.Text
                 assertEquals(fixture.LastIndexOf(searchFor, StringComparison.CurrentCulture), sb.LastIndexOf(searchFor, StringComparison.CurrentCulture));
                 assertEquals(6, sb.LastIndexOf(searchFor, StringComparison.Ordinal));
                 assertEquals(6, sb.LastIndexOf(searchFor, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase), sb.LastIndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.InvariantCulture), sb.LastIndexOf(searchFor, StringComparison.InvariantCulture));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase), sb.LastIndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1303,6 +1318,9 @@ namespace J2N.Text
                 assertEquals(fixture.LastIndexOf(searchFor, StringComparison.CurrentCulture), sb.LastIndexOf(searchFor, StringComparison.CurrentCulture));
                 assertEquals(6, sb.LastIndexOf(searchFor, StringComparison.Ordinal));
                 assertEquals(6, sb.LastIndexOf(searchFor, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase), sb.LastIndexOf(searchFor, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.InvariantCulture), sb.LastIndexOf(searchFor, StringComparison.InvariantCulture));
+                assertEquals(fixture.LastIndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase), sb.LastIndexOf(searchFor, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1318,6 +1336,9 @@ namespace J2N.Text
                 assertEquals(fixture.LastIndexOf(searchFor, 20, StringComparison.CurrentCulture), sb.LastIndexOf(searchFor, 20, StringComparison.CurrentCulture));
                 assertEquals(6, sb.LastIndexOf(searchFor, 20, StringComparison.Ordinal));
                 assertEquals(6, sb.LastIndexOf(searchFor, 20, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, 20, StringComparison.CurrentCultureIgnoreCase), sb.LastIndexOf(searchFor, 20, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, 20, StringComparison.InvariantCulture), sb.LastIndexOf(searchFor, 20, StringComparison.InvariantCulture));
+                assertEquals(fixture.LastIndexOf(searchFor, 20, StringComparison.InvariantCultureIgnoreCase), sb.LastIndexOf(searchFor, 20, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 
@@ -1333,6 +1354,9 @@ namespace J2N.Text
                 assertEquals(fixture.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.CurrentCulture), sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.CurrentCulture));
                 assertEquals(6, sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.Ordinal));
                 assertEquals(6, sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.OrdinalIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.CurrentCultureIgnoreCase), sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.CurrentCultureIgnoreCase));
+                assertEquals(fixture.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.InvariantCulture), sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.InvariantCulture));
+                assertEquals(fixture.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.InvariantCultureIgnoreCase), sb.LastIndexOf(searchFor, LargeUnicodeString.Length - 20, StringComparison.InvariantCultureIgnoreCase));
             }
         }
 

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -800,6 +800,238 @@ namespace J2N.Text
 
 #endif
 
+        [Test]
+        public void Test_Insert_ICharSequence()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: "ab".AsCharSequence())); // J2N: charSequence label is required to get to this overload over object overload. See https://stackoverflow.com/a/26885473
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: "cd".AsCharSequence()));
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo"); ;
+            assertSame(sb, sb.Insert(1, charSequence: (ICharSequence)null));
+            // assertEquals("null", sb.ToString());
+            assertEquals("foo", sb.ToString());
+        }
+
+        [Test]
+        public void Test_Insert_ICharSequence_Custom()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: new MyCharSequence("ab")));
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: new MyCharSequence("cd")));
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: (ICharSequence)null));
+            // assertEquals("null", sb.ToString());
+            assertEquals("foo", sb.ToString()); // J2N: Changed the behavior to be a no-op rather than appending the string "null"
+
+            // J2N: Check long strings that will be appended in chunks in certain cases
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, charSequence: new MyCharSequence(longString1));
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, charSequence: new MyCharSequence(longString2));
+            assertEquals("fo" + longString2 + 'o', sb.ToString());
+        }
+
+        [Test]
+        public void Test_Insert_ICharSequence_Int32_Int32()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "ab".AsCharSequence(), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "cd".AsCharSequence(), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "abcd".AsCharSequence(), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "abcd".AsCharSequence(), 2, 4 - 2)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            try
+            {
+                assertSame(sb, sb.Insert(1, (ICharSequence)null, 0, 2)); // J2N: Changed the behavior to throw an exception (to match .NET Core 3.0's Append(StringBuilder,int,int) overload) rather than appending the string "null"
+                fail("no NPE");
+            }
+            catch (ArgumentNullException e)
+            {
+                // Expected
+            }
+            //assertEquals("nu", sb.ToString());
+            assertEquals("foo", sb.ToString());
+
+
+            // J2N: Check long strings that will be appended in chunks in certain cases
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new MyCharSequence(longString1), 0, longString1.Length);
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new MyCharSequence(longString2), 0, longString2.Length);
+            assertEquals("fo" + longString2 + 'o', sb.ToString());
+        }
+
+        [Test]
+        public void Test_Insert_ICharSequence_Int32_Int32_Custom()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new MyCharSequence("ab"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new MyCharSequence("cd"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new MyCharSequence("abcd"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new MyCharSequence("abcd"), 2, 4 - 2)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            try
+            {
+                assertSame(sb, sb.Insert(1, (ICharSequence)null, 0, 2)); // J2N: Changed the behavior to throw an exception (to match .NET Core 3.0's Append(StringBuilder,int,int) overload) rather than appending the string "null"
+                fail("no NPE");
+            }
+            catch (ArgumentNullException e)
+            {
+                // Expected
+            }
+            //assertEquals("nu", sb.ToString());
+            assertEquals("foo", sb.ToString());
+
+
+            // J2N: Check long strings that will be appended in chunks on certain TFMs
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new MyCharSequence(longString1), 0, longString1.Length);
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new MyCharSequence(longString2), 0, longString2.Length);
+            assertEquals("fo" + longString2 + 'o', sb.ToString());
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new MyCharSequence(longString2), 0, 1550);
+            assertEquals('f' + new string('z', 1000) + new string('y', 550) + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new MyCharSequence(longString2), 1000, 550 + 6999);
+            assertEquals("fo" + new string('y', 550) + new string('r', 6999) + 'o', sb.ToString());
+        }
+
+        [Test]
+        public void Test_Insert_StringBuilder()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, charSequence: new StringBuilder("ab")));
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new StringBuilder("cd")));
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, (StringBuilder)null));
+            // assertEquals("null", sb.ToString());
+            assertEquals("foo", sb.ToString()); // J2N: Changed the behavior to be a no-op rather than appending the string "null"
+
+            // J2N: Check long strings that will be appended in chunks on certain TFMs
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new StringBuilder(longString1));
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new StringBuilder(longString2));
+            assertEquals("fo" + longString2 + "o", sb.ToString());
+        }
+
+        [Test]
+        public void Test_Insert_StringBuilder_Int32_Int32()
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new StringBuilder("ab"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new StringBuilder("cd"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new StringBuilder("abcd"), 0, 2 - 0)); // J2N: corrected 3rd parameter
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, new StringBuilder("abcd"), 2, 4 - 2)); // J2N: corrected 3rd parameter
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            try
+            {
+                assertSame(sb, sb.Insert(1, (StringBuilder)null, 0, 2)); // J2N: Changed the behavior to throw an exception (to match .NET Core 3.0) rather than appending the string "null"
+                fail("no NPE");
+            }
+            catch (ArgumentNullException e)
+            {
+                // Expected
+            }
+            //assertEquals("nu", sb.ToString());
+            assertEquals("foo", sb.ToString());
+
+            // J2N: Check long strings that will be appended in chunks on certain TFMs
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new StringBuilder(longString1), 0, longString1.Length);
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new StringBuilder(longString2), 0, longString2.Length);
+            assertEquals("fo" + longString2 + "o", sb.ToString());
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, new StringBuilder(longString2), 0, 1550);
+            assertEquals('f' + new string('z', 1000) + new string('y', 550) + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, new StringBuilder(longString2), 1000, 550 + 6999);
+            assertEquals("fo" + new string('y', 550) + new string('r', 6999) + 'o', sb.ToString());
+        }
+
+#if FEATURE_SPAN
+
+        [Test]
+        public void Test_Insert_ReadOnlySpan() // J2N Specific to cover missing overload in older .NET TFMs
+        {
+            StringBuilder sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "ab".AsSpan()));
+            assertEquals("faboo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "cd".AsSpan()));
+            assertEquals("fcdoo", sb.ToString());
+            sb = new StringBuilder("foo");
+            assertSame(sb, sb.Insert(1, "".AsSpan()));
+            assertEquals("foo", sb.ToString());
+
+            // J2N: Check long strings that will be appended in chunks on certain TFMs
+            string longString1 = new string('a', 2000) + new string('b', 200) + new string('c', 699) + new string('d', 3000);
+            string longString2 = new string('z', 1000) + new string('y', 550) + new string('r', 6999) + new string('f', 300);
+
+            sb = new StringBuilder("foo");
+            sb.Insert(1, longString1.AsSpan());
+            assertEquals('f' + longString1 + "oo", sb.ToString());
+            sb = new StringBuilder("foo");
+            sb.Insert(2, longString2.AsSpan());
+            assertEquals("fo" + longString2 + 'o', sb.ToString());
+        }
+
+#endif
+
         /**
          * @tests java.lang.StringBuilder.indexOf(String)
          */

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -85,6 +85,59 @@ namespace J2N.Text
         }
 
         [Test]
+        public virtual void TestInsertCodePointBmp()
+        {
+            var sb = new StringBuilder("foo bar");
+            int codePoint = 97; // a
+
+            sb.InsertCodePoint(2, codePoint);
+
+            Assert.AreEqual("foao bar", sb.ToString());
+        }
+
+        [Test]
+        public virtual void TestInsertCodePointUnicode()
+        {
+            var sb = new StringBuilder("foo bar");
+            int codePoint = 3594; // ช
+
+            sb.InsertCodePoint(2, codePoint);
+
+            Assert.AreEqual("foชo bar", sb.ToString());
+        }
+
+        [Test]
+        public virtual void TestInsertCodePointUTF16Surrogates()
+        {
+            var sb = new StringBuilder("foo bar");
+            int codePoint = 176129; // '\uD86C', '\uDC01' (𫀁)
+
+            sb.InsertCodePoint(2, codePoint);
+
+            Assert.AreEqual("fo𫀁o bar", sb.ToString());
+        }
+
+        [Test]
+        public virtual void TestInsertCodePointTooHigh()
+        {
+            var sb = new StringBuilder("foo bar");
+            int codePoint = Character.MaxCodePoint + 1;
+
+            Assert.Throws<ArgumentException>(() => sb.InsertCodePoint(2, codePoint));
+        }
+
+        [Test]
+        public virtual void TestInsertCodePointTooLow()
+        {
+            var sb = new StringBuilder("foo bar");
+            int codePoint = Character.MinCodePoint - 1;
+
+            Assert.Throws<ArgumentException>(() => sb.InsertCodePoint(2, codePoint));
+        }
+
+
+
+        [Test]
         public void TestCompareToOrdinal()
         {
             StringBuilder target = null;

--- a/tests/J2N.Tests/Text/TestValueStringBuilderArrayPoolIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderArrayPoolIndexer.cs
@@ -11,7 +11,7 @@ namespace J2N.Text
         public void SequentialAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
             for (int i = 0; i < sb.Length; i++)
             {
                 char expected = sb[i];
@@ -24,7 +24,7 @@ namespace J2N.Text
         public void SequentialAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringArrayPoolIndexer(sb);
+            var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
             try
             {
                 for (int i = 0; i < sb.Length; i++)
@@ -44,7 +44,7 @@ namespace J2N.Text
         public void RandomAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
             Assert.AreEqual('4', indexer[3]);
             Assert.AreEqual('8', indexer[7]);
         }
@@ -53,7 +53,7 @@ namespace J2N.Text
         public void RandomAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringArrayPoolIndexer(sb);
+            var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
             try
             {
                 indexer[3] = 'X';
@@ -72,7 +72,7 @@ namespace J2N.Text
         public void ResettingIterators_SwitchingDirections_Successful()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
             Assert.AreEqual(true, indexer.IterateForward);
 
             // Switching direction from forward to backward
@@ -88,7 +88,7 @@ namespace J2N.Text
         public void InvalidIndex_ThrowsException()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
 
             try
             {
@@ -114,7 +114,7 @@ namespace J2N.Text
         public void GetBounds_SingleChunk_ReturnsCorrectBounds()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb))
             {
                 indexer.Reset(iterateForward: true);
                 //indexer.IterateForward = true;
@@ -131,9 +131,9 @@ namespace J2N.Text
         public void GetBounds_MultipleChunks_ReturnsCorrectBounds()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using (var indexer = new ValueStringArrayPoolIndexer(sb, iterateForward: true))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb, iterateForward: true))
             {
-                int expectedChunkCount = (int)Math.Ceiling((double)sb.Length / ValueStringArrayPoolIndexer.ChunkLength);
+                int expectedChunkCount = (int)Math.Ceiling((double)sb.Length / ValueStringBuilderArrayPoolIndexer.ChunkLength);
                 Assert.AreEqual(expectedChunkCount, indexer.ChunkCount);
 
 
@@ -142,12 +142,12 @@ namespace J2N.Text
                     indexer.GetBounds(i, out int lowerBound, out int upperBound);
                     if (i < expectedChunkCount - 1)
                     {
-                        Assert.AreEqual(ValueStringArrayPoolIndexer.ChunkLength * i, lowerBound);
-                        Assert.AreEqual((ValueStringArrayPoolIndexer.ChunkLength * (i + 1)) - 1, upperBound);
+                        Assert.AreEqual(ValueStringBuilderArrayPoolIndexer.ChunkLength * i, lowerBound);
+                        Assert.AreEqual((ValueStringBuilderArrayPoolIndexer.ChunkLength * (i + 1)) - 1, upperBound);
                     }
                     else // Last chunk
                     {
-                        Assert.AreEqual(ValueStringArrayPoolIndexer.ChunkLength * i, lowerBound);
+                        Assert.AreEqual(ValueStringBuilderArrayPoolIndexer.ChunkLength * i, lowerBound);
                         Assert.AreEqual(sb.Length - 1, upperBound);
                     }
                 }
@@ -158,7 +158,7 @@ namespace J2N.Text
         public void IsWithinBounds_SingleChunk_ReturnsTrueForValidIndex()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb))
             {
                 indexer.Reset(iterateForward: true);
                 //indexer.IterateForward = true;
@@ -173,7 +173,7 @@ namespace J2N.Text
         public void IsWithinBounds_SingleChunk_ReturnsFalseForInvalidIndex()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb))
             {
                 indexer.Reset(iterateForward: true);
                 //indexer.IterateForward = true;
@@ -188,10 +188,10 @@ namespace J2N.Text
         public void IsWithinBounds_MultipleChunks_ReturnsTrueForValidIndex()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using (var indexer = new ValueStringArrayPoolIndexer(sb, iterateForward: true))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb, iterateForward: true))
             {
                 // Multiple chunks scenario
-                bool result = indexer.IsWithinBounds(1, ValueStringArrayPoolIndexer.ChunkLength * 2 - 10);
+                bool result = indexer.IsWithinBounds(1, ValueStringBuilderArrayPoolIndexer.ChunkLength * 2 - 10);
                 Assert.IsTrue(result);
             }
         }
@@ -200,7 +200,7 @@ namespace J2N.Text
         public void IsWithinBounds_MultipleChunks_ReturnsFalseForInvalidIndex()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using (var indexer = new ValueStringArrayPoolIndexer(sb))
+            using (var indexer = new ValueStringBuilderArrayPoolIndexer(sb))
             {
                 indexer.Reset(iterateForward: true);
                 //indexer.IterateForward = true;
@@ -220,7 +220,7 @@ namespace J2N.Text
             stringBuilder.Append("Beautiful, ").Append(new string('a', 1024));
             stringBuilder.Append("Amazing, ").Append(new string('a', 1024));
             stringBuilder.Append("World!");
-            var indexer = new ValueStringArrayPoolIndexer(stringBuilder);
+            var indexer = new ValueStringBuilderArrayPoolIndexer(stringBuilder);
 
             // Act
             indexer[7 + 1024] = 'X';
@@ -245,7 +245,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            var indexer = new ValueStringArrayPoolIndexer(stringBuilder);
+            var indexer = new ValueStringBuilderArrayPoolIndexer(stringBuilder);
 
             // Act
             indexer.Reset(iterateForward: false);


### PR DESCRIPTION
New APIs:

```c#
namespace J2N.Text
{
    public static class StringBuilderExtensions
    {
        public static StringBuilder Append(this StringBuilder text, ReadOnlySpan<char> charSequence);
        public static StringBuilder Insert(this StringBuilder text, int index, ReadOnlySpan<char> charSequence);
        public static StringBuilder InsertCodePoint(this StringBuilder text, int index, int codePoint);
    }
}
```

Optimized APIs:

- Append()
- AppendCodePoint()
- CompareToOrdinal()
- IndexOf()
- Insert()
- LastIndexOf()
- Replace()
- Reverse()

This also fixes several bugs in `ValueStringBuilderArrayPoolIndexer` and fixes #58.

These optimizations take advantage of `ArrayPool`, `ValueStringBuilderArrayPoolIndexer`, and `ValueStringBuilderChunkIndexer` to provide faster indexing through the `StringBuilder` class.