### PR TITLE
PERFORMANCE: J2N.Text.ValueStringBuilderChunkIndexer: Use ArrayPool for upperBounds array

### DIFF
--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -671,7 +671,7 @@ namespace J2N
                 throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
             using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
 #else
@@ -902,7 +902,7 @@ namespace J2N
                 throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
             using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
 #else
@@ -1348,7 +1348,7 @@ namespace J2N
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
             using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
 #else
@@ -1627,7 +1627,7 @@ namespace J2N
             if (codePointOffset >= 0)
             {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-                var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: true);
+                using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: true);
 #elif FEATURE_ARRAYPOOL
                 using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq, iterateForward: true);
 #else
@@ -1652,7 +1652,7 @@ namespace J2N
             else
             {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-                var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: false);
+                using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: false);
 #elif FEATURE_ARRAYPOOL
                 using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq, iterateForward: false);
 #else

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -142,7 +142,7 @@ namespace J2N.Text
             if (value is null) return 1;
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var valueIndexer = new ValueStringBuilderChunkIndexer(value);
+            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
             using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
 #else

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -506,7 +506,7 @@ namespace J2N.Text
                 return CompareToOrdinal(text, stringBuffer.builder);
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -550,7 +550,7 @@ namespace J2N.Text
             if (value is null) return 1;
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -595,8 +595,8 @@ namespace J2N.Text
             if (value is null) return 1;
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
-            var valueIndexer = new ValueStringBuilderChunkIndexer(value);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
             using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
@@ -644,7 +644,7 @@ namespace J2N.Text
             if (value is null) return 1;
 
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -893,7 +893,7 @@ namespace J2N.Text
         private static int IndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -928,7 +928,7 @@ namespace J2N.Text
         private static int IndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -1592,7 +1592,7 @@ namespace J2N.Text
         private static int LastIndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -1650,7 +1650,7 @@ namespace J2N.Text
         private static int LastIndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
 #if FEATURE_STRINGBUILDER_GETCHUNKS
-            var textIndexer = new ValueStringBuilderChunkIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
             using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
 #else
@@ -1773,14 +1773,23 @@ namespace J2N.Text
                 }
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 var textIndexer = new ValueStringBuilderChunkIndexer(text);
+                try
 #else // J2N: ValueStringBuilderArrayPoolIndexer doesn't provide any write advantage over StringBuilder
                 var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
-                // copy the chars based on the new length
-                for (int i = 0; i < stringLength; i++)
                 {
-                    textIndexer[i + startIndex] = newValue[i];
+                    // copy the chars based on the new length
+                    for (int i = 0; i < stringLength; i++)
+                    {
+                        textIndexer[i + startIndex] = newValue[i];
+                    }
                 }
+#if FEATURE_STRINGBUILDER_GETCHUNKS
+                finally
+                {
+                    textIndexer.Dispose();
+                }
+#endif
                 return text;
             }
             if (startIndex == end)
@@ -1829,6 +1838,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             var forwardTextIndexer = new ValueStringBuilderChunkIndexer(text);
             var reverseTextIndexer = new ValueStringBuilderChunkIndexer(text, iterateForward: false);
+            try
 #elif FEATURE_ARRAYPOOL
             var forwardTextIndexer = new ValueStringBuilderArrayPoolIndexer(text);
             var reverseTextIndexer = new ValueStringBuilderArrayPoolIndexer(text, iterateForward: false);
@@ -1911,7 +1921,7 @@ namespace J2N.Text
                 }
                 return text;
             }
-#if !FEATURE_STRINGBUILDER_GETCHUNKS && FEATURE_ARRAYPOOL
+#if FEATURE_STRINGBUILDER_GETCHUNKS || FEATURE_ARRAYPOOL
             finally
             {
                 forwardTextIndexer.Dispose();

--- a/tests/J2N.Tests/Text/TestValueStringBuilderChunkIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderChunkIndexer.cs
@@ -12,7 +12,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello, World!");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             try
@@ -41,7 +41,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('H', indexer[0]);
@@ -58,9 +58,16 @@ namespace J2N.Text
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
             var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            try
+            {
 
-            // Act
-            indexer[7] = 'X';
+                // Act
+                indexer[7] = 'X';
+            }
+            finally
+            {
+                indexer.Dispose();
+            }
 
             // Assert
             Assert.AreEqual("Hello, Xorld!", stringBuilder.ToString());
@@ -72,7 +79,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act
             indexer.Reset(iterateForward: false);
@@ -123,8 +130,8 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            var indexerForward = new ValueStringBuilderChunkIndexer(stringBuilder, iterateForward: true);
-            var indexerBackward = new ValueStringBuilderChunkIndexer(stringBuilder, iterateForward: false);
+            using var indexerForward = new ValueStringBuilderChunkIndexer(stringBuilder, iterateForward: true);
+            using var indexerBackward = new ValueStringBuilderChunkIndexer(stringBuilder, iterateForward: false);
 
             // Act & Assert
             Assert.IsTrue(indexerForward.IterateForward);
@@ -136,7 +143,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('H', indexer[0]);
@@ -153,7 +160,7 @@ namespace J2N.Text
             var stringBuilder = new StringBuilder();
             stringBuilder.Append("Hello, ");
             stringBuilder.Append("World!");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('W', indexer[7]);
@@ -169,7 +176,7 @@ namespace J2N.Text
             stringBuilder.Append("Beautiful, ");
             stringBuilder.Append("Amazing, ");
             stringBuilder.Append("World!");
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('W', indexer[27]);
@@ -177,20 +184,22 @@ namespace J2N.Text
         }
 
         [Test]
-        public void AccessingIndexInMoreThan16Chunks_ReturnsCorrectValue()
+        public void AccessingIndexInMoreThan32Chunks_ReturnsCorrectValue()
         {
             // Arrange
             var stringBuilder = new StringBuilder();
-            for (int i = 0; i < 20; i++)
+            for (int i = 0; i < 40; i++)
             {
                 stringBuilder.Append(new string((char)('a' + i), 50));
             }
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('b', indexer[99]);
             Assert.AreEqual('r', indexer[860]);
             Assert.AreEqual('t', indexer[999]);
+            Assert.AreEqual('\u0081', indexer[32 * 50 + 1]);
+            Assert.AreEqual('\u0088', indexer[39 * 50 + 1]);
         }
 
         [Test]
@@ -198,7 +207,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder(new string('a', 70000));
-            var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
 
             // Act & Assert
             Assert.AreEqual('a', indexer[69999]);
@@ -214,13 +223,20 @@ namespace J2N.Text
             stringBuilder.Append("Amazing, ");
             stringBuilder.Append("World!");
             var indexer = new ValueStringBuilderChunkIndexer(stringBuilder);
+            try
+            {
 
-            // Act
-            indexer[7] = 'X';
-            indexer[14] = 'V';
-            indexer[20] = 'A';
-            indexer[27] = 'Z';
-            indexer[32] = '?';
+                // Act
+                indexer[7] = 'X';
+                indexer[14] = 'V';
+                indexer[20] = 'A';
+                indexer[27] = 'Z';
+                indexer[32] = '?';
+            }
+            finally
+            {
+                indexer.Dispose();
+            }
 
             // Assert
             Assert.AreEqual("Hello, XeautifVl, AmAzing, Zorld?", stringBuilder.ToString());


### PR DESCRIPTION
The `upperBounds` array is allocated only if we exceed 32 chunks or 65535 characters,. Being that this is a ref struct that is used once per method call, it makes sense to reuse the array if we spill over these values to make optimal use of memory.

This makes `ValueStringBuilderChunkIndexer` disposable, but it is a fair tradeoff for what we gain.