### PR TITLE
J2N.Text: Added ISpanAppendable interface and AppendableExtensions class

### DIFF
--- a/src/J2N/Text/AppendableExtensions.cs
+++ b/src/J2N/Text/AppendableExtensions.cs
@@ -1,0 +1,67 @@
+﻿#if FEATURE_SPAN
+using System;
+using System.Buffers;
+
+namespace J2N.Text
+{
+    /// <summary>
+    /// Extensions to the <see cref="IAppendable"/> interface.
+    /// </summary>
+    public static class AppendableExtensions
+    {
+        private const int CharPoolBufferSize = 512;
+
+        /// <summary>
+        /// Appends the string representation of a specified read-only character span to this <paramref name="appendable"/>.
+        /// </summary>
+        /// <param name="appendable">This <see cref="IAppendable"/>.</param>
+        /// <param name="value">The read-only character span to append.</param>
+        /// <returns>A reference to this <see cref="IAppendable"/> instance after the append operation is completed.</returns>
+        /// <remarks>
+        /// If the <paramref name="appendable"/> supports <see cref="ISpanAppendable"/>, the optimized
+        /// <see cref="ISpanAppendable.Append(ReadOnlySpan{char})"/> method is called on the <paramref name="appendable"/> implementation.
+        /// If not, a <see cref="T:char[]"/> is obtained from the shared array pool and used to provide the chars via the
+        /// <see cref="IAppendable.Append(char[], int, int)"/> method. For larger strings, the data is appended in chunks
+        /// up to 512 characters long.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="appendable"/> is <c>null</c>.</exception>
+        public static T Append<T>(this T appendable, ReadOnlySpan<char> value) where T : IAppendable
+        {
+            if (appendable is null)
+                throw new ArgumentNullException(nameof(appendable));
+
+            if (appendable is ISpanAppendable spanAppendable)
+            {
+                spanAppendable.Append(value);
+                return appendable;
+            }
+
+            int startIndex = 0;
+            int remainingCount = value.Length;
+
+            char[] buffer = ArrayPool<char>.Shared.Rent(Math.Min(remainingCount, CharPoolBufferSize));
+            try
+            {
+                while (remainingCount > 0)
+                {
+                    // Determine the chunk size for the current iteration
+                    int chunkLength = Math.Min(remainingCount, CharPoolBufferSize);
+
+                    // Copy the chunk to the buffer
+                    value.Slice(startIndex, chunkLength).CopyTo(buffer);
+
+                    appendable.Append(buffer, 0, chunkLength);
+
+                    startIndex += chunkLength;
+                    remainingCount -= chunkLength;
+                }
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer);
+            }
+            return appendable;
+        }
+    }
+}
+#endif

--- a/src/J2N/Text/ISpanAppendable.cs
+++ b/src/J2N/Text/ISpanAppendable.cs
@@ -1,0 +1,28 @@
+﻿#if FEATURE_SPAN
+using System;
+
+namespace J2N.Text
+{
+    /// <summary>
+    /// Provides functionality to append the characters from <see cref="ReadOnlySpan{T}"/> to an
+    /// <see cref="IAppendable"/> implementation.
+    /// </summary>
+    public interface ISpanAppendable : IAppendable
+    {
+        /// <summary>
+        /// Appends the string representation of a specified read-only character span to this instance.
+        /// <para/>
+        /// <see cref="IAppendable"/> types that implement this interface will be called by the
+        /// <see cref="AppendableExtensions.Append{T}(T, ReadOnlySpan{char})"/> to provide a better
+        /// optimized implementation than the default, which uses a <see cref="T:char[]"/> buffer obtained
+        /// from the shared array pool and calls the <see cref="IAppendable.Append(char[], int, int)"/>
+        /// method to perform the append operation (in chunks).
+        /// </summary>
+        /// <param name="value">The read-only character span to append.</param>
+        /// <returns>A reference to this instance after the append operation is completed.</returns>
+        /// <seealso cref="AppendableExtensions"/>
+        /// <seealso cref="AppendableExtensions.Append{T}(T, ReadOnlySpan{char})"/>
+        ISpanAppendable Append(ReadOnlySpan<char> value);
+    }
+}
+#endif

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -67,6 +67,9 @@ namespace J2N.Text
     [Serializable]
 #endif
     public sealed class StringBuffer : IAppendable, ICharSequence
+#if FEATURE_SPAN
+        , ISpanAppendable
+#endif
     {
         private const int DefaultCapacity = 16;
 
@@ -566,7 +569,7 @@ namespace J2N.Text
 
         #region Append
 
-#if FEATURE_STRINGBUILDER_APPEND_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Appends a copy of the specified <see cref="ReadOnlySpan{Char}"/> to this instance.
@@ -2652,6 +2655,14 @@ namespace J2N.Text
         IAppendable IAppendable.Append(ICharSequence? value, int startIndex, int count) => Append(value, startIndex, count);
 
         #endregion IAppendable Members
+
+        #region ISpanAppendable Members
+
+#if FEATURE_SPAN
+        ISpanAppendable ISpanAppendable.Append(ReadOnlySpan<char> value) => Append(value);
+#endif
+
+        #endregion ISpanAppendable Members
 
         #region ICharSequence Members
 

--- a/src/J2N/Text/StringBuilderCharSequence.cs
+++ b/src/J2N/Text/StringBuilderCharSequence.cs
@@ -33,6 +33,9 @@ namespace J2N.Text
         IEquatable<ICharSequence>,
         IEquatable<CharArrayCharSequence>, IEquatable<StringBuilderCharSequence>, IEquatable<StringCharSequence>,
         IEquatable<string>, IEquatable<StringBuilder>, IEquatable<char[]>
+#if FEATURE_SPAN
+        , ISpanAppendable
+#endif
     {
         /// <summary>
         /// Initializes a new instance of <see cref="StringBuilderCharSequence"/> with a new backing <see cref="StringBuilder"/>.
@@ -771,6 +774,23 @@ namespace J2N.Text
             return this;
         }
 
+#if FEATURE_SPAN
+        /// <summary>
+        /// Appends the string representation of a specified <see cref="ReadOnlySpan{T}"/> of Unicode characters to this instance.
+        /// </summary>
+        /// <param name="value">The <see cref="ReadOnlySpan{T}"/> containing the characters to append.</param>
+        /// <returns>A reference to this instance after the append operation has completed.</returns>
+        /// <exception cref="InvalidOperationException"><see cref="Value"/> is <c>null</c>.</exception>
+        public StringBuilderCharSequence Append(ReadOnlySpan<char> value)
+        {
+            if (Value is null)
+                throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
+
+            Value.Append(value);
+            return this;
+        }
+#endif
+
         IAppendable IAppendable.Append(char value) => this.Append(value);
 
         IAppendable IAppendable.Append(string? value) => this.Append(value);
@@ -788,6 +808,10 @@ namespace J2N.Text
         IAppendable IAppendable.Append(ICharSequence? value) => this.Append(value);
 
         IAppendable IAppendable.Append(ICharSequence? value, int startIndex, int count) => this.Append(value, startIndex, count);
+
+#if FEATURE_SPAN
+        ISpanAppendable ISpanAppendable.Append(ReadOnlySpan<char> value) => this.Append(value);
+#endif
 
         #endregion
     }

--- a/tests/J2N.Tests/Text/TestAppendableExtensions.cs
+++ b/tests/J2N.Tests/Text/TestAppendableExtensions.cs
@@ -1,0 +1,201 @@
+﻿#if FEATURE_SPAN
+using NUnit.Framework;
+using System;
+using System.Text;
+#nullable enable
+
+namespace J2N.Text
+{
+    public class TestAppendableExtensions
+    {
+        // Helper method to create a fake IAppendable implementation using StringBuilder
+        private static IAppendable CreateStringBuilderAppendable()
+        {
+            return new StringBuilderAppendable(new StringBuilder());
+        }
+
+        // Helper method to create a fake IAppendable implementation using StringBuilder
+        // that also implements ISpanAppendable
+        private static ISpanAppendable CreateSpanStringBuilderAppendable()
+        {
+            return new SpanStringBuilderAppendable(new StringBuilder());
+        }
+
+        // Helper class to implement IAppendable using StringBuilder
+        private class StringBuilderAppendable : IAppendable
+        {
+            private readonly StringBuilder _sb;
+
+            public StringBuilderAppendable(StringBuilder sb)
+            {
+                _sb = sb;
+            }
+
+            public IAppendable Append(char value)
+            {
+                _sb.Append(value);
+                return this;
+            }
+
+            public IAppendable Append(string? value)
+            {
+                _sb.Append(value);
+                return this;
+            }
+
+            public IAppendable Append(string? value, int startIndex, int count)
+            {
+                _sb.Append(value, startIndex, count);
+                return this;
+            }
+
+            public IAppendable Append(StringBuilder? value)
+            {
+                _sb.Append(value);
+                return this;
+            }
+
+            public IAppendable Append(StringBuilder? value, int startIndex, int count)
+            {
+                _sb.Append(value, startIndex, count);
+                return this;
+            }
+
+            public IAppendable Append(char[]? value)
+            {
+                _sb.Append(value);
+                return this;
+            }
+
+            public IAppendable Append(char[]? value, int startIndex, int count)
+            {
+                _sb.Append(value, startIndex, count);
+                return this;
+            }
+
+            public IAppendable Append(ICharSequence? value)
+            {
+                // Implementation for ICharSequence can be added if needed
+                throw new NotImplementedException();
+            }
+
+            public IAppendable Append(ICharSequence? value, int startIndex, int count)
+            {
+                // Implementation for ICharSequence can be added if needed
+                throw new NotImplementedException();
+            }
+
+            public IAppendable Append(ReadOnlySpan<char> value)
+            {
+                _sb.Append(value);
+                return this;
+            }
+
+            public override string ToString()
+            {
+                return _sb.ToString();
+            }
+        }
+
+        // Helper class to implement IAppendable and ISpanAppendable using StringBuilder
+        private class SpanStringBuilderAppendable : StringBuilderAppendable, ISpanAppendable
+        {
+            public SpanStringBuilderAppendable(StringBuilder sb) : base(sb) { }
+
+            ISpanAppendable ISpanAppendable.Append(ReadOnlySpan<char> value)
+            {
+                base.Append(value);
+                return this;
+            }
+        }
+
+        [Test]
+        public void TestAppendWithIAppendable()
+        {
+            // Arrange
+            var appendable = CreateStringBuilderAppendable();
+            var inputString = "Hello, World!";
+
+            // Act
+            appendable.Append(inputString.AsSpan());
+
+            // Assert
+            Assert.AreEqual(inputString, appendable.ToString());
+        }
+
+        [Test]
+        public void TestAppendWithISpanAppendable()
+        {
+            // Arrange
+            var appendable = CreateSpanStringBuilderAppendable();
+            var inputString = "Hello, World!";
+
+            // Act
+            appendable.Append(inputString.AsSpan());
+
+            // Assert
+            Assert.AreEqual(inputString, appendable.ToString());
+        }
+
+        [Test]
+        public void TestAppendSliceWithIAppendable()
+        {
+            // Arrange
+            var appendable = CreateStringBuilderAppendable();
+            var inputString = "Hello, World!";
+            var startIndex = 0;
+            var count = 5;
+
+            // Act
+            appendable.Append(inputString.AsSpan(startIndex, count));
+
+            // Assert
+            Assert.AreEqual(inputString.Substring(startIndex, count), appendable.ToString());
+        }
+
+        [Test]
+        public void TestAppendSliceWithISpanAppendable()
+        {
+            // Arrange
+            var appendable = CreateSpanStringBuilderAppendable();
+            var inputString = "Hello, World!";
+            var startIndex = 0;
+            var count = 5;
+
+            // Act
+            appendable.Append(inputString.AsSpan(startIndex, count));
+
+            // Assert
+            Assert.AreEqual(inputString.Substring(startIndex, count), appendable.ToString());
+        }
+
+        [Test]
+        public void TestAppendLargeStringWithIAppendable()
+        {
+            // Arrange
+            var appendable = CreateStringBuilderAppendable();
+            var inputString = new string('A', 1537);
+
+            // Act
+            appendable.Append(inputString.AsSpan());
+
+            // Assert
+            Assert.AreEqual(inputString, appendable.ToString());
+        }
+
+        [Test]
+        public void TestAppendLargeStringWithISpanAppendable()
+        {
+            // Arrange
+            var appendable = CreateSpanStringBuilderAppendable();
+            var inputString = new string('A', 1537);
+
+            // Act
+            appendable.Append(inputString.AsSpan());
+
+            // Assert
+            Assert.AreEqual(inputString, appendable.ToString());
+        }
+    }
+}
+#endif

--- a/tests/J2N.Tests/Text/TestStringBuffer.cs
+++ b/tests/J2N.Tests/Text/TestStringBuffer.cs
@@ -263,6 +263,26 @@ namespace J2N.Text
             assertEquals(string.Empty, sb.ToString()); // J2N: To match .NET, appending null is a no-op
         }
 
+#if FEATURE_SPAN
+        /**
+         * @tests java.lang.StringBuffer.Append(CharSequence)
+         */
+        [Test]
+        public void Test_Append_ReadOnlySpan()
+        {
+            StringBuffer sb = new StringBuffer();
+            assertSame(sb, sb.Append("ab".AsSpan()));
+            assertEquals("ab", sb.ToString());
+            sb.Length = (0);
+            assertSame(sb, sb.Append("cd".AsSpan()));
+            assertEquals("cd", sb.ToString());
+            sb.Length = (0);
+            assertSame(sb, sb.Append((ReadOnlySpan<char>)null));
+            //assertEquals("null", sb.ToString());
+            assertEquals(string.Empty, sb.ToString()); // J2N: To match .NET, appending null is a no-op
+        }
+#endif
+
         /**
          * @tests java.lang.StringBuffer.Append(CharSequence, int, int)
          */


### PR DESCRIPTION
Added `ISpanAppendable` interface and `AppendableExtensions` class to provide an extension method `IAppendable.Append(ReadOnlySpan<char>)` without a breaking change to `IAppendable`.