### PR TITLE
J2N.Text.StringBuffer: Fixed bugs and added new APIs

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,7 +13,6 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CHARARRAYPOINTERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_CURRENTCULTURE_SETTER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ENCODINGPROVIDERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -76,6 +76,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPENDJOIN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_EQUALS_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_INSERT_READONLYSPAN</DefineConstants>

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -726,7 +726,7 @@ namespace J2N.Text
         {
             lock (syncRoot)
             {
-                builder.Append(charSequence, startIndex, charCount);
+                builder.Append(charSequence?.builder, startIndex, charCount);
                 return this;
             }
         }

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -2337,6 +2337,38 @@ namespace J2N.Text
 
         #endregion Insert
 
+        #region InsertCodePoint
+
+        /// <summary>
+        /// Insert the string representation of the <paramref name="codePoint"/>
+        /// argument to this instance at <paramref name="index"/>.
+        /// <para/>
+        /// The argument is inserted into to the contents of this sequence.
+        /// The length of this sequence increases by <see cref="Character.CharCount(int)"/>.
+        /// <para/>
+        /// The overall effect is exactly as if the argument were
+        /// converted to a <see cref="char"/> array by the method
+        /// <see cref="Character.ToChars(int)"/> and the character in that array
+        /// were then <see cref="Insert(int, char[])">inserted</see> into this
+        /// <see cref="StringBuffer"/>.
+        /// </summary>
+        /// <param name="index">The position in this instance where insertion begins.</param>
+        /// <param name="codePoint">A Unicode code point.</param>
+        /// <returns>This <see cref="StringBuffer"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero or greater
+        /// than the length of this instance.</exception>
+        /// <exception cref="ArgumentException"><paramref name="codePoint"/> is not a valid Unicode code point.</exception>
+        public StringBuffer InsertCodePoint(int index, int codePoint)
+        {
+            lock (syncRoot)
+            {
+                builder.InsertCodePoint(index, codePoint);
+                return this;
+            }
+        }
+
+        #endregion InsertCodePoint
+
         #region IndexOf
 
         /// <summary>

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -902,7 +902,7 @@ namespace J2N.Text
             }
         }
 
-#if FEATURE_CHARARRAYPOINTERS
+#if FEATURE_STRINGBUILDER_APPEND_CHARPTR
         /// <summary>
         /// Appends an array of Unicode characters starting at a specified address to this instance.
         /// </summary>

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -105,7 +105,7 @@ namespace J2N.Text
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         public StringBuffer(string? value)
-            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
+            : this(value, (value?.Length ?? 0) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace J2N.Text
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         public StringBuffer(ICharSequence? value)
-            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
+            : this(value, (value?.Length ?? 0) + DefaultCapacity)
         { }
 
         // .NET Gaps
@@ -131,7 +131,7 @@ namespace J2N.Text
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
         public StringBuffer(ICharSequence? value, int capacity)
-            : this(value, 0, (value is null ? 0 : value.Length), capacity)
+            : this(value, 0, value?.Length ?? 0, capacity)
         { }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace J2N.Text
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         public StringBuffer(StringBuilder? value)
-            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
+            : this(value, (value?.Length ?? 0) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace J2N.Text
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
         public StringBuffer(StringBuilder? value, int capacity)
-            : this(value, 0, (value is null ? 0 : value.Length), capacity)
+            : this(value, 0, value?.Length ?? 0, capacity)
         { }
 
         /// <summary>
@@ -250,7 +250,7 @@ namespace J2N.Text
         /// If <paramref name="value"/> is <c>null</c>, the new <see cref="StringBuffer"/> will
         /// contain the empty string (that is, it contains <see cref="string.Empty"/>).</param>
         public StringBuffer(char[]? value)
-            : this(value, (value is null ? 0 : value.Length) + DefaultCapacity)
+            : this(value, (value?.Length ?? 0) + DefaultCapacity)
         { }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace J2N.Text
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
         public StringBuffer(char[]? value, int capacity)
-            : this(value, 0, (value is null ? 0 : value.Length), capacity)
+            : this(value, 0, value?.Length ?? 0, capacity)
         { }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace J2N.Text
         /// <param name="capacity">The suggested starting size of the <see cref="StringBuffer"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
         public StringBuffer(string? value, int capacity)
-            : this(value, 0, (value is null ? 0 : value.Length), capacity)
+            : this(value, 0, value?.Length ?? 0, capacity)
         { }
 
         /// <summary>

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -686,11 +686,10 @@ namespace J2N.Text
 
             lock (syncRoot)
             {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                    builder.Append(chunk);
+#if FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER
+                builder.Append(value.builder);
 #else
-                builder.Append(value.ToString());
+                builder.Append(charSequence: value.builder);
 #endif
                 return this;
             }
@@ -748,11 +747,10 @@ namespace J2N.Text
 
             lock (syncRoot)
             {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                foreach (ReadOnlyMemory<char> chunk in value.GetChunks())
-                    builder.Append(chunk);
+#if FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER
+                builder.Append(value);
 #else
-                builder.Append(value.ToString());
+                builder.Append(charSequence: value);
 #endif
                 return this;
             }

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -1648,6 +1648,35 @@ namespace J2N.Text
                 builder.CopyTo(sourceIndex, destination, destinationIndex, count);
         }
 
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the characters from a specified segment of this instance to a destination Char span.
+        /// </summary>
+        /// <param name="sourceIndex">The starting position in this instance where characters will be copied
+        /// from. The index is zero-based.</param>
+        /// <param name="destination">The writable span where characters will be copied.</param>
+        /// <param name="count">The number of characters to be copied.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="sourceIndex"/> or <paramref name="count"/> is less than zero.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="sourceIndex"/> is greater than the length of this instance.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="sourceIndex"/> + <paramref name="count"/> is greater than the length of this instance.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="count"/> is greater than the length of <paramref name="destination"/>.
+        /// </exception>
+        public void CopyTo(int sourceIndex, Span<char> destination, int count)
+        {
+            lock (syncRoot)
+                builder.CopyTo(sourceIndex, destination, count);
+        }
+#endif
+
         #endregion
 
         #region Delete

--- a/src/J2N/Text/StringBuffer.cs
+++ b/src/J2N/Text/StringBuffer.cs
@@ -1821,7 +1821,7 @@ namespace J2N.Text
 
         #region Insert
 
-#if FEATURE_STRINGBUILDER_INSERT_READONLYSPAN
+#if FEATURE_SPAN
 
         /// <summary>
         /// Inserts the string representation of a <see cref="ReadOnlySpan{Char}"/> value into this instance at the specified character position.

--- a/src/J2N/Text/StringBuilderCharSequence.cs
+++ b/src/J2N/Text/StringBuilderCharSequence.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Text;
 
-
 namespace J2N.Text
 {
     using SR = J2N.Resources.Strings;
@@ -605,10 +604,10 @@ namespace J2N.Text
 
             if (value != null)
             {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                Value.Append(value); // J2N: This overload uses GetChunks() to transfer the chars
+#if FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER
+                Value.Append(value);
 #else
-                Value.Append(value.ToString());
+                Value.Append(charSequence: value);
 #endif
             }
             return this;
@@ -645,7 +644,7 @@ namespace J2N.Text
                 throw new InvalidOperationException(J2N.SR.Format(SR.InvalidOperation_CannotEditNullObject, nameof(StringBuilder)));
 
             if (value != null)
-                Value.Append(value.ToString(startIndex, count));
+                Value.Append(value, startIndex, count);
             return this;
         }
 

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -240,13 +240,12 @@ namespace J2N.Text
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
-            if (charSequence == null)
+            if (charSequence is null)
                 return text;
 
-            // J2N NOTE: We don't use Span<char> because this Append() overload was added to StringBuilder prior to th CopyTo(int, Span<char> int) overload,
-            // so this will never be called when Span<char> is supported unless called as a static method.
-
-#if FEATURE_ARRAYPOOL
+#if FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER
+            return text.Append(charSequence);
+#elif FEATURE_ARRAYPOOL
             int start = 0;
             int remainingCount = charSequence.Length;
 
@@ -314,15 +313,14 @@ namespace J2N.Text
                 throw new ArgumentOutOfRangeException(nameof(startIndex), SR.ArgumentOutOfRange_NeedNonNegNum);
             if (charCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_NeedNonNegNum);
-            if (charSequence == null)
+            if (charSequence is null)
                 return text;
             if (startIndex > charSequence.Length - charCount) // Checks for int overflow
                 throw new ArgumentOutOfRangeException(nameof(charCount), SR.ArgumentOutOfRange_IndexLength);
 
-            // J2N NOTE: We don't use Span<char> because this Append() overload was added to StringBuilder prior to th CopyTo(int, Span<char> int) overload,
-            // so this will never be called when Span<char> is supported unless called as a static method.
-
-#if FEATURE_ARRAYPOOL
+#if FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER
+            return text.Append(charSequence, startIndex, charCount);
+#elif FEATURE_ARRAYPOOL
             int start = startIndex;
             int remainingCount = charCount;
 


### PR DESCRIPTION
## New APIs:

```c#
namespace J2N.Text
{
    public class StringBuffer
    {
        public void CopyTo(int sourceIndex, Span<char> destination, int count); // .NET Framework 4.5+
        public StringBuffer Insert(int index, ReadOnlySpan<char> value); // New legacy support for .NET Framework 4.5+
        public StringBuffer InsertCodePoint(int index, int codePoint);
    }
}
```

## Bugs Fixed:

- `Directory.Build.Targets`: Removed `FEATURE_CHARARRAYPOINTERS`, which is a duplicate of `FEATURE_STRINGBUILDER_APPEND_CHARPTR`
- `J2N.Text.StringBuffer::Append(StringBuffer, int, int)`: Fixed implementation to correctly pass in `StringBuffer.builder` to the `Append` call

## Performance Optimizations

- Directory.Build.targets: Added `FEATURE_STRINGBUILDER_APPEND_STRINGBUILDER` to optimize for when this overload is available in .NET.
