### PR TITLE
J2N.Text: Added ValueStringBuilderIndexer for end users - optimizes iteration of StringBuilder via index

### DIFF
--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -670,18 +670,11 @@ namespace J2N
             if (index < 0 || index >= len)
                 throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
-#elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
-#else
-            var seqIndexer = seq; // .NET 4.0 - don't care to optimize
-#endif
-
-            char high = seqIndexer[index++];
+            // J2N NOTE: Looking up 1 or 2 characters is faster through the StringBuilder than an indexer
+            char high = seq[index++];
             if (index >= len)
                 return high;
-            char low = seqIndexer[index];
+            char low = seq[index];
             if (char.IsSurrogatePair(high, low))
                 return ToCodePoint(high, low);
             return high;
@@ -901,18 +894,11 @@ namespace J2N
             if (index < 1 || index > len)
                 throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
-#elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
-#else
-            var seqIndexer = seq; // .NET 4.0 - don't care to optimize
-#endif
-
-            char low = seqIndexer[--index];
+            // J2N NOTE: Looking up 1 or 2 characters is faster through the StringBuilder than an indexer
+            char low = seq[--index];
             if (--index < 0)
                 return low;
-            char high = seqIndexer[index];
+            char high = seq[index];
             if (char.IsSurrogatePair(high, low))
             {
                 return ToCodePoint(high, low);
@@ -1347,14 +1333,7 @@ namespace J2N
             if (startIndex + length > len)
                 throw new ArgumentOutOfRangeException(nameof(length), SR2.ArgumentOutOfRange_IndexLength);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
-#elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
-#else
-            var seqIndexer = seq; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var seqIndexer = new ValueStringBuilderIndexer(seq);
             int endIndex = startIndex + length;
             int n = length;
             for (int i = startIndex; i < endIndex;)
@@ -1626,13 +1605,7 @@ namespace J2N
             int x = index;
             if (codePointOffset >= 0)
             {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: true);
-#elif FEATURE_ARRAYPOOL
-                using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq, iterateForward: true);
-#else
-                var seqIndexer = seq; // .NET 4.0 - don't care to optimize
-#endif
+                using var seqIndexer = new ValueStringBuilderIndexer(seq, iterateForward: true);
                 int i;
                 for (i = 0; x < length && i < codePointOffset; i++)
                 {
@@ -1651,13 +1624,7 @@ namespace J2N
             }
             else
             {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: false);
-#elif FEATURE_ARRAYPOOL
-                using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq, iterateForward: false);
-#else
-                var seqIndexer = seq; // .NET 4.0 - don't care to optimize
-#endif
+                using var seqIndexer = new ValueStringBuilderIndexer(seq, iterateForward: false);
                 int i;
                 for (i = codePointOffset; x > 0 && i < 0; i++)
                 {

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -673,7 +673,7 @@ namespace J2N
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
 #else
             var seqIndexer = seq; // .NET 4.0 - don't care to optimize
 #endif
@@ -904,7 +904,7 @@ namespace J2N
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
 #else
             var seqIndexer = seq; // .NET 4.0 - don't care to optimize
 #endif
@@ -1350,7 +1350,7 @@ namespace J2N
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var seqIndexer = new ValueStringBuilderChunkIndexer(seq);
 #elif FEATURE_ARRAYPOOL
-            using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq);
+            using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq);
 #else
             var seqIndexer = seq; // .NET 4.0 - don't care to optimize
 #endif
@@ -1629,7 +1629,7 @@ namespace J2N
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: true);
 #elif FEATURE_ARRAYPOOL
-                using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq, iterateForward: true);
+                using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq, iterateForward: true);
 #else
                 var seqIndexer = seq; // .NET 4.0 - don't care to optimize
 #endif
@@ -1654,7 +1654,7 @@ namespace J2N
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var seqIndexer = new ValueStringBuilderChunkIndexer(seq, iterateForward: false);
 #elif FEATURE_ARRAYPOOL
-                using var seqIndexer = new ValueStringBuilderArrayPoolIndexer(seq, iterateForward: false);
+                using var seqIndexer = new ValueStringBuilderChunkedArrayIndexer(seq, iterateForward: false);
 #else
                 var seqIndexer = seq; // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/CharArrayCharSequence.cs
+++ b/src/J2N/Text/CharArrayCharSequence.cs
@@ -342,7 +342,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
 #elif FEATURE_ARRAYPOOL
-            using var otherIndexer = new ValueStringBuilderArrayPoolIndexer(other);
+            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
 #else
             var otherIndexer = other.ToString(); // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/CharArrayCharSequence.cs
+++ b/src/J2N/Text/CharArrayCharSequence.cs
@@ -339,13 +339,7 @@ namespace J2N.Text
 
             int len = Length;
             if (len != other.Length) return false;
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
-#elif FEATURE_ARRAYPOOL
-            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
-#else
-            var otherIndexer = other.ToString(); // .NET 4.0 - don't care to optimize
-#endif
+            using var otherIndexer = new ValueStringBuilderIndexer(other);
             for (int i = 0; i < len; i++)
             {
                 if (!value[i].Equals(otherIndexer[i])) return false;

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -141,14 +141,7 @@ namespace J2N.Text
             if (str is null) return (value is null) ? 0 : -1;
             if (value is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-#elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-#else
-            var valueIndexer = value; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
             int length = Math.Min(str.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -144,7 +144,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
 #else
             var valueIndexer = value; // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/CharSequenceComparer.cs
+++ b/src/J2N/Text/CharSequenceComparer.cs
@@ -468,7 +468,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -517,7 +517,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -566,7 +566,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -597,7 +597,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var yIndexer = new ValueStringBuilderChunkIndexer(y);
 #elif FEATURE_ARRAYPOOL
-                using var yIndexer = new ValueStringBuilderArrayPoolIndexer(y);
+                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
 #else
                 var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -624,8 +624,8 @@ namespace J2N.Text
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
                 using var yIndexer = new ValueStringBuilderChunkIndexer(y);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
-                using var yIndexer = new ValueStringBuilderArrayPoolIndexer(y);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
+                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
 #else
                 var xIndexer = x.ToString();
                 var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
@@ -694,7 +694,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -739,7 +739,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -768,7 +768,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var yIndexer = new ValueStringBuilderChunkIndexer(y);
 #elif FEATURE_ARRAYPOOL
-                using var yIndexer = new ValueStringBuilderArrayPoolIndexer(y);
+                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
 #else
                 var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -793,8 +793,8 @@ namespace J2N.Text
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
                 using var yIndexer = new ValueStringBuilderChunkIndexer(y);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
-                using var yIndexer = new ValueStringBuilderArrayPoolIndexer(y);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
+                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
 #else
                 var xIndexer = x.ToString();
                 var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
@@ -840,7 +840,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var xIndexer = new ValueStringBuilderChunkIndexer(x);
 #elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderArrayPoolIndexer(x);
+                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
 #else
                 var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -905,7 +905,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                 using var objIndexer = new ValueStringBuilderChunkIndexer(obj);
 #elif FEATURE_ARRAYPOOL
-                using var objIndexer = new ValueStringBuilderArrayPoolIndexer(obj);
+                using var objIndexer = new ValueStringBuilderChunkedArrayIndexer(obj);
 #else
                 var objIndexer = obj.ToString(); // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/CharSequenceComparer.cs
+++ b/src/J2N/Text/CharSequenceComparer.cs
@@ -465,14 +465,7 @@ namespace J2N.Text
                 if (y is StringBuffer yStringBuffer)
                     return Compare(x, yStringBuffer.builder);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int length = Math.Min(x.Length, y.Length);
                 int result;
                 for (int i = 0; i < length; i++)
@@ -514,14 +507,7 @@ namespace J2N.Text
                 if (x is null) return (y is null) ? 0 : -1;
                 if (y is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int length = Math.Min(x.Length, y.Length);
                 int result;
                 for (int i = 0; i < length; i++)
@@ -563,14 +549,7 @@ namespace J2N.Text
                 if (x is null) return (y is null) ? 0 : -1;
                 if (y is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int length = Math.Min(x.Length, y.Length);
                 int result;
                 for (int i = 0; i < length; i++)
@@ -594,14 +573,7 @@ namespace J2N.Text
                 if (x is StringBuffer stringBuffer)
                     return Compare(stringBuffer.builder, y);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var yIndexer = new ValueStringBuilderChunkIndexer(y);
-#elif FEATURE_ARRAYPOOL
-                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
-#else
-                var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var yIndexer = new ValueStringBuilderIndexer(y);
                 int length = Math.Min(x.Length, y.Length);
                 int result;
                 for (int i = 0; i < length; i++)
@@ -620,17 +592,8 @@ namespace J2N.Text
                 if (x == null) return -1;
                 if (y == null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-                using var yIndexer = new ValueStringBuilderChunkIndexer(y);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
-#else
-                var xIndexer = x.ToString();
-                var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
+                using var yIndexer = new ValueStringBuilderIndexer(y);
                 int length = Math.Min(x.Length, y.Length);
                 int result;
                 for (int i = 0; i < length; i++)
@@ -691,14 +654,7 @@ namespace J2N.Text
                 if (y is StringBuffer yStringBuffer)
                     return Equals(x, yStringBuffer.builder);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int len = x.Length;
                 if (len != y.Length) return false;
                 for (int i = 0; i < len; i++)
@@ -736,14 +692,7 @@ namespace J2N.Text
                 if (y is null)
                     return false;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int len = x.Length;
                 if (len != y.Length) return false;
                 for (int i = 0; i < len; i++)
@@ -765,14 +714,7 @@ namespace J2N.Text
                 if (x is StringBuffer stringBuffer)
                     return Equals(stringBuffer.builder, y);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var yIndexer = new ValueStringBuilderChunkIndexer(y);
-#elif FEATURE_ARRAYPOOL
-                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
-#else
-                var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var yIndexer = new ValueStringBuilderIndexer(y);
                 int len = x.Length;
                 if (len != y.Length) return false;
                 for (int i = 0; i < len; i++)
@@ -789,17 +731,8 @@ namespace J2N.Text
                 if (y is null)
                     return false;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-                using var yIndexer = new ValueStringBuilderChunkIndexer(y);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-                using var yIndexer = new ValueStringBuilderChunkedArrayIndexer(y);
-#else
-                var xIndexer = x.ToString();
-                var yIndexer = y.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
+                using var yIndexer = new ValueStringBuilderIndexer(y);
                 int len = x.Length;
                 if (len != y.Length) return false;
                 for (int i = 0; i < len; i++)
@@ -837,14 +770,7 @@ namespace J2N.Text
                 if (y is null)
                     return false;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var xIndexer = new ValueStringBuilderChunkIndexer(x);
-#elif FEATURE_ARRAYPOOL
-                using var xIndexer = new ValueStringBuilderChunkedArrayIndexer(x);
-#else
-                var xIndexer = x.ToString(); // .NET 4.0 - don't care to optimize
-#endif
-
+                using var xIndexer = new ValueStringBuilderIndexer(x);
                 int len = x.Length;
                 if (len != y.Length) return false;
                 for (int i = 0; i < len; i++)
@@ -902,13 +828,7 @@ namespace J2N.Text
                 if (obj is null)
                     return int.MaxValue;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                using var objIndexer = new ValueStringBuilderChunkIndexer(obj);
-#elif FEATURE_ARRAYPOOL
-                using var objIndexer = new ValueStringBuilderChunkedArrayIndexer(obj);
-#else
-                var objIndexer = obj.ToString(); // .NET 4.0 - don't care to optimize
-#endif
+                using var objIndexer = new ValueStringBuilderIndexer(obj);
                 // From Apache Harmony
                 int length = obj.Length;
                 if (length == 0)

--- a/src/J2N/Text/StringBuilderCharSequence.cs
+++ b/src/J2N/Text/StringBuilderCharSequence.cs
@@ -339,7 +339,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
 #else
             var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
 #endif
@@ -369,8 +369,8 @@ namespace J2N.Text
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
             using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
 #elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
-            using var otherIndexer = new ValueStringBuilderArrayPoolIndexer(other);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
+            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
 #else
             var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
             var otherIndexer = other.ToString();
@@ -400,7 +400,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
 #else
             var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/StringBuilderCharSequence.cs
+++ b/src/J2N/Text/StringBuilderCharSequence.cs
@@ -336,13 +336,7 @@ namespace J2N.Text
 
             int len = Length;
             if (len != other.Length) return false;
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-#elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-#else
-            var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
-#endif
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
             for (int i = 0; i < len; i++)
             {
                 if (!valueIndexer[i].Equals(other[i])) return false;
@@ -365,16 +359,8 @@ namespace J2N.Text
 
             int len = Length;
             if (len != other.Length) return false;
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-            using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
-#elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
-#else
-            var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
-            var otherIndexer = other.ToString();
-#endif
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
+            using var otherIndexer = new ValueStringBuilderIndexer(other);
             for (int i = 0; i < len; i++)
             {
                 if (!valueIndexer[i].Equals(otherIndexer[i])) return false;
@@ -397,13 +383,7 @@ namespace J2N.Text
 
             int len = Length;
             if (len != other.Length) return false;
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-#elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-#else
-            var valueIndexer = value.ToString(); // .NET 4.0 - don't care to optimize
-#endif
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
             for (int i = 0; i < len; i++)
             {
                 if (!valueIndexer[i].Equals(other[i])) return false;

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -503,14 +503,7 @@ namespace J2N.Text
             if (value is StringBuffer stringBuffer)
                 return CompareToOrdinal(text, stringBuffer.builder);
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var textIndexer = new ValueStringBuilderIndexer(text);
             int length = Math.Min(text.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)
@@ -547,14 +540,7 @@ namespace J2N.Text
             if (text is null) return (value is null) ? 0 : -1;
             if (value is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var textIndexer = new ValueStringBuilderIndexer(text);
             int length = Math.Min(text.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)
@@ -592,14 +578,8 @@ namespace J2N.Text
             if (text is null) return (value is null) ? 0 : -1;
             if (value is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-#endif
-#if FEATURE_STRINGBUILDER_GETCHUNKS || FEATURE_ARRAYPOOL
+            using var textIndexer = new ValueStringBuilderIndexer(text);
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
             int length = Math.Min(text.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)
@@ -611,11 +591,6 @@ namespace J2N.Text
             // At this point, we have compared all the characters in at least one string.
             // The longer string will be larger.
             return text.Length - value.Length;
-#else
-            // Materialize the string. It is faster to loop through
-            // a string than a StringBuilder.
-            return text.ToString().CompareToOrdinal(value.ToString()); // .NET 4.0 - don't care to optimize
-#endif
         }
 
         /// <summary>
@@ -641,14 +616,7 @@ namespace J2N.Text
             if (text is null) return (value is null) ? 0 : -1;
             if (value is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var textIndexer = new ValueStringBuilderIndexer(text);
             int length = Math.Min(text.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)
@@ -890,14 +858,6 @@ namespace J2N.Text
 #endif
         private static int IndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
             int length = value.Length;
             if (length == 0)
                 return 0;
@@ -905,6 +865,7 @@ namespace J2N.Text
             int maxSearchLength = (textLength - length) + 1;
             char firstChar = value[0];
             int index;
+            using var textIndexer = new ValueStringBuilderIndexer(text);
             for (int i = startIndex; i < maxSearchLength; ++i)
             {
                 if (textIndexer[i] == firstChar)
@@ -925,14 +886,6 @@ namespace J2N.Text
 #endif
         private static int IndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
             int length = value.Length;
             if (length == 0)
                 return 0;
@@ -941,6 +894,7 @@ namespace J2N.Text
             char firstChar = value[0], c1, c2;
             var textInfo = CultureInfo.InvariantCulture.TextInfo;
             int index;
+            using var textIndexer = new ValueStringBuilderIndexer(text);
             for (int i = startIndex; i < maxSearchLength; ++i)
             {
                 if (textIndexer[i] == firstChar)
@@ -1589,14 +1543,6 @@ namespace J2N.Text
 #endif
         private static int LastIndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
             int textLength = text.Length;
             int subCount = value.Length;
 
@@ -1608,6 +1554,7 @@ namespace J2N.Text
                     {
                         startIndex = textLength - subCount; // count and subCount are both >= 1
                     }
+                    using var textIndexer = new ValueStringBuilderIndexer(text);
                     char firstChar = value[0];
                     while (true)
                     {
@@ -1647,14 +1594,6 @@ namespace J2N.Text
 #endif
         private static int LastIndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var textIndexer = new ValueStringBuilderChunkIndexer(text);
-#elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-#else
-            var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
-
             int textLength = text.Length;
             int subCount = value.Length;
 
@@ -1668,6 +1607,7 @@ namespace J2N.Text
                     }
                     char firstChar = value[0], c1, c2;
                     var textInfo = CultureInfo.InvariantCulture.TextInfo;
+                    using var textIndexer = new ValueStringBuilderIndexer(text);
                     while (true)
                     {
                         int i = startIndex;
@@ -1769,12 +1709,8 @@ namespace J2N.Text
                     // replacing with more characters...need some room
                     text.Insert(startIndex, new char[-diff]);
                 }
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                var textIndexer = new ValueStringBuilderChunkIndexer(text);
+                var textIndexer = new ValueStringBuilderIndexer(text);
                 try
-#else // J2N: ValueStringBuilderArrayPoolIndexer doesn't provide any write advantage over StringBuilder
-                var textIndexer = text; // .NET 4.0 - don't care to optimize
-#endif
                 {
                     // copy the chars based on the new length
                     for (int i = 0; i < stringLength; i++)
@@ -1782,12 +1718,10 @@ namespace J2N.Text
                         textIndexer[i + startIndex] = newValue[i];
                     }
                 }
-#if FEATURE_STRINGBUILDER_GETCHUNKS
                 finally
                 {
                     textIndexer.Dispose();
                 }
-#endif
                 return text;
             }
             if (startIndex == end)
@@ -1833,18 +1767,9 @@ namespace J2N.Text
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            var forwardTextIndexer = new ValueStringBuilderChunkIndexer(text);
-            var reverseTextIndexer = new ValueStringBuilderChunkIndexer(text, iterateForward: false);
+            var forwardTextIndexer = new ValueStringBuilderIndexer(text, iterateForward: true);
+            var reverseTextIndexer = new ValueStringBuilderIndexer(text, iterateForward: false);
             try
-#elif FEATURE_ARRAYPOOL
-            var forwardTextIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
-            var reverseTextIndexer = new ValueStringBuilderChunkedArrayIndexer(text, iterateForward: false);
-            try
-#else
-            var forwardTextIndexer = text; // .NET 4.0 - don't care to optimize
-            var reverseTextIndexer = text;
-#endif
             {
                 int count = text.Length;
                 if (count == 0) return text;
@@ -1919,13 +1844,11 @@ namespace J2N.Text
                 }
                 return text;
             }
-#if FEATURE_STRINGBUILDER_GETCHUNKS || FEATURE_ARRAYPOOL
             finally
             {
                 forwardTextIndexer.Dispose();
                 reverseTextIndexer.Dispose();
             }
-#endif
         }
 
         #endregion Reverse

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -506,7 +506,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -550,7 +550,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -596,8 +596,8 @@ namespace J2N.Text
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
 #endif
 #if FEATURE_STRINGBUILDER_GETCHUNKS || FEATURE_ARRAYPOOL
             int length = Math.Min(text.Length, value.Length);
@@ -644,7 +644,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -893,7 +893,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -928,7 +928,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1592,7 +1592,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1650,7 +1650,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var textIndexer = new ValueStringBuilderChunkIndexer(text);
 #elif FEATURE_ARRAYPOOL
-            using var textIndexer = new ValueStringBuilderArrayPoolIndexer(text);
+            using var textIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
 #else
             var textIndexer = text; // .NET 4.0 - don't care to optimize
 #endif
@@ -1838,8 +1838,8 @@ namespace J2N.Text
             var reverseTextIndexer = new ValueStringBuilderChunkIndexer(text, iterateForward: false);
             try
 #elif FEATURE_ARRAYPOOL
-            var forwardTextIndexer = new ValueStringBuilderArrayPoolIndexer(text);
-            var reverseTextIndexer = new ValueStringBuilderArrayPoolIndexer(text, iterateForward: false);
+            var forwardTextIndexer = new ValueStringBuilderChunkedArrayIndexer(text);
+            var reverseTextIndexer = new ValueStringBuilderChunkedArrayIndexer(text, iterateForward: false);
             try
 #else
             var forwardTextIndexer = text; // .NET 4.0 - don't care to optimize

--- a/src/J2N/Text/StringCharSequence.cs
+++ b/src/J2N/Text/StringCharSequence.cs
@@ -336,7 +336,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
 #elif FEATURE_ARRAYPOOL
-            using var otherIndexer = new ValueStringBuilderArrayPoolIndexer(other);
+            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
 #else
             var otherIndexer = other.ToString(); // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/StringCharSequence.cs
+++ b/src/J2N/Text/StringCharSequence.cs
@@ -333,13 +333,7 @@ namespace J2N.Text
 
             int len = Length;
             if (len != other.Length) return false;
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
-#elif FEATURE_ARRAYPOOL
-            using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
-#else
-            var otherIndexer = other.ToString(); // .NET 4.0 - don't care to optimize
-#endif
+            using var otherIndexer = new ValueStringBuilderIndexer(other);
             for (int i = 0; i < len; i++)
             {
                 if (!value[i].Equals(otherIndexer[i])) return false;

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -149,7 +149,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
             using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
 #elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderArrayPoolIndexer(value);
+            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
 #else
             var valueIndexer = value; // .NET 4.0 - don't care to optimize
 #endif
@@ -908,7 +908,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                         using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
 #elif FEATURE_ARRAYPOOL
-                        using var otherIndexer = new ValueStringBuilderArrayPoolIndexer(other);
+                        using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
 #else
                         var otherIndexer = other; // .NET 4.0 - don't care to optimize
 #endif
@@ -927,7 +927,7 @@ namespace J2N.Text
 #if FEATURE_STRINGBUILDER_GETCHUNKS
                         using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
 #elif FEATURE_ARRAYPOOL
-                        using var otherIndexer = new ValueStringBuilderArrayPoolIndexer(other);
+                        using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
 #else
                         var otherIndexer = other; // .NET 4.0 - don't care to optimize
 #endif

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -146,14 +146,7 @@ namespace J2N.Text
             if (str is null) return (value is null) ? 0 : -1;
             if (value is null) return 1;
 
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-            using var valueIndexer = new ValueStringBuilderChunkIndexer(value);
-#elif FEATURE_ARRAYPOOL
-            using var valueIndexer = new ValueStringBuilderChunkedArrayIndexer(value);
-#else
-            var valueIndexer = value; // .NET 4.0 - don't care to optimize
-#endif
-
+            using var valueIndexer = new ValueStringBuilderIndexer(value);
             int length = Math.Min(str.Length, value.Length);
             int result;
             for (int i = 0; i < length; i++)
@@ -905,13 +898,7 @@ namespace J2N.Text
             {
                 case StringComparison.Ordinal:
                     {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                        using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
-#elif FEATURE_ARRAYPOOL
-                        using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
-#else
-                        var otherIndexer = other; // .NET 4.0 - don't care to optimize
-#endif
+                        using var otherIndexer = new ValueStringBuilderIndexer(other);
                         for (int i = 0; i < length; ++i)
                         {
                             if (text[thisStartIndex + i] != otherIndexer[otherStartIndex + i])
@@ -924,13 +911,7 @@ namespace J2N.Text
 
                 case StringComparison.OrdinalIgnoreCase:
                     {
-#if FEATURE_STRINGBUILDER_GETCHUNKS
-                        using var otherIndexer = new ValueStringBuilderChunkIndexer(other);
-#elif FEATURE_ARRAYPOOL
-                        using var otherIndexer = new ValueStringBuilderChunkedArrayIndexer(other);
-#else
-                        var otherIndexer = other; // .NET 4.0 - don't care to optimize
-#endif
+                        using var otherIndexer = new ValueStringBuilderIndexer(other);
                         int end = thisStartIndex + length;
                         char c1, c2;
                         var textInfo = CultureInfo.InvariantCulture.TextInfo;

--- a/src/J2N/Text/ValueStringBuilderChunkIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderChunkIndexer.cs
@@ -32,7 +32,7 @@ namespace J2N.Text
     /// This type is disposable and the user is responsible for calling <see cref="Dispose()"/> after use.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs have performance issues with readonly fields.")]
-    internal ref struct ValueStringBuilderChunkIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
+    internal ref struct ValueStringBuilderChunkIndexer
     {
         private /*readonly*/ StringBuilder stringBuilder;
         private /*readonly*/ ValueInt32Packer packer;
@@ -230,7 +230,7 @@ namespace J2N.Text
             {
                 if ((uint)index >= (uint)stringBuilder.Length)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
+                    throw new IndexOutOfRangeException();
                 }
 
                 if (index < currentLowerBound || index > currentUpperBound)

--- a/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
@@ -1,6 +1,7 @@
-﻿#if FEATURE_ARRAYPOOL
-using System;
+﻿using System;
+#if FEATURE_ARRAYPOOL
 using System.Buffers;
+#endif
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,8 +13,8 @@ namespace J2N.Text
     /// <summary>
     /// A decorator for <see cref="StringBuilder"/> to track access to the last used chunk so it doesn't have to be looked up
     /// when iterating forward or reverse through the <see cref="StringBuilder"/>. Supports both reads and writes.
-    /// The purpose is to chunk the <see cref="char"/>s from the <see cref="StringBuilder"/> into a pooled array. The
-    /// interface is similar to the <see cref="StringBuilder"/> so
+    /// The purpose is to chunk the <see cref="char"/>s from the <see cref="StringBuilder"/> into an array, which is pooled
+    /// if the platform supports array pooling. The interface is similar to the <see cref="StringBuilder"/> so
     /// business logic doesn't have to be rewritten to iterate a <see cref="StringBuilder"/> via index. The performance of
     /// the <see cref="StringBuilder.this[int]"/> indexer is very poor and this is intended as a direct replacement.
     /// <para/>
@@ -27,14 +28,14 @@ namespace J2N.Text
     /// <para/>
     /// Do not call any operations that mutate the <see cref="StringBuilder"/>, such as <see cref="StringBuilder.Append(string?)"/>,
     /// <see cref="StringBuilder.Insert(int, string?)"/>. If the state of the <see cref="StringBuilder"/> changes, the behavior
-    /// is undefined and you must create a new instance of <see cref="ValueStringBuilderArrayPoolIndexer"/> to read the changes.
+    /// is undefined and you must create a new instance of <see cref="ValueStringBuilderChunkedArrayIndexer"/> to read the changes.
     /// <para/>
     /// This type is disposable and the user is responsible for calling <see cref="Dispose()"/> after use.
     /// <para/>
     /// For .NET Core 3.x and higher, the ValueStringBuilderChunkIndexer should be favored over this approach.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs have performance issues with readonly fields.")]
-    internal ref struct ValueStringBuilderArrayPoolIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
+    internal ref struct ValueStringBuilderChunkedArrayIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
     {
         public const int ChunkLength = 512;
 
@@ -47,7 +48,7 @@ namespace J2N.Text
         private int currentUpperBound;
         private bool iterateForward;
 
-        public ValueStringBuilderArrayPoolIndexer(StringBuilder stringBuilder, bool iterateForward = true)
+        public ValueStringBuilderChunkedArrayIndexer(StringBuilder stringBuilder, bool iterateForward = true)
         {
             this.stringBuilder = stringBuilder ?? throw new ArgumentNullException(nameof(stringBuilder));
             this.iterateForward = iterateForward;
@@ -61,7 +62,11 @@ namespace J2N.Text
 
             int length = stringBuilder.Length;
             int chunkSize = length < ChunkLength ? Math.Max(1, length) : ChunkLength;
+#if FEATURE_ARRAYPOOL
             currentChunk = ArrayPool<char>.Shared.Rent(chunkSize);
+#else
+            currentChunk = new char[chunkSize];
+#endif
             chunkCount = (int)Math.Ceiling((double)length / ChunkLength);
             if (chunkCount > 0)
             {
@@ -76,7 +81,10 @@ namespace J2N.Text
         internal int LastChunkLength => lastChunkLength; // internal for testing
         public void Dispose()
         {
+#if FEATURE_ARRAYPOOL
             ArrayPool<char>.Shared.Return(currentChunk);
+#endif
+            // else no-op
         }
 
         internal void GetBounds(int chunkIndex, out int lowerBound, out int upperBound) // internal for testing
@@ -184,7 +192,9 @@ namespace J2N.Text
 
         public char this[int index]
         {
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
             get
             {
                 if ((uint)index >= (uint)stringBuilder.Length)
@@ -200,7 +210,9 @@ namespace J2N.Text
                 return currentChunk[index - currentLowerBound];
             }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
             set
             {
                 if ((uint)index >= (uint)stringBuilder.Length)
@@ -218,4 +230,3 @@ namespace J2N.Text
         }
     }
 }
-#endif

--- a/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
@@ -35,7 +35,7 @@ namespace J2N.Text
     /// For .NET Core 3.x and higher, the ValueStringBuilderChunkIndexer should be favored over this approach.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Structs have performance issues with readonly fields.")]
-    internal ref struct ValueStringBuilderChunkedArrayIndexer // J2N TODO: Make public? This may be useful in ICU4N and Lucene.NET
+    internal ref struct ValueStringBuilderChunkedArrayIndexer
     {
         public const int ChunkLength = 512;
 
@@ -199,7 +199,7 @@ namespace J2N.Text
             {
                 if ((uint)index >= (uint)stringBuilder.Length)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, SR.ArgumentOutOfRange_Index);
+                    throw new IndexOutOfRangeException();
                 }
 
                 if (index < currentLowerBound || index > currentUpperBound)

--- a/src/J2N/Text/ValueStringBuilderIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderIndexer.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace J2N.Text
+{
+    /// <summary>
+    /// A decorator for <see cref="StringBuilder"/> to track access to the last used chunk so it doesn't have to be looked up
+    /// when iterating forward or reverse through the <see cref="StringBuilder"/>. Supports both reads and writes.
+    /// The purpose is to chunk access to the <see cref="char"/>s from the <see cref="StringBuilder"/> and hold a reference to them
+    /// so iterating is fast. The interface is similar to the <see cref="StringBuilder"/> so
+    /// business logic doesn't have to be rewritten to iterate a <see cref="StringBuilder"/> via index. The performance of
+    /// the <see cref="StringBuilder.this[int]"/> indexer is very poor and this is intended as a direct replacement.
+    /// <para/>
+    /// Usage Note: This works as a drop-in replacement for <see cref="StringBuilder"/> in cases where we are looping either forward
+    /// or backward through the <see cref="char"/>s, without the need to add additional business logic to deal with switching chunks.
+    /// <para/>
+    /// Both sequential and random access are supported, however, sequential access is optimized. If the business logic simultaneously
+    /// iterates both forward and backward, it is recommended to create 2 separate instances (one specifying iterateForward=false)
+    /// to ensure looking up chunks in the <see cref="StringBuilder"/> is a rare operation. Writes are done to the underlying memory of the
+    /// <see cref="StringBuilder"/>, so using multiple instances for tracking both directions will immediately show the changes.
+    /// <para/>
+    /// Do not call any operations that mutate the <see cref="StringBuilder"/>, such as <see cref="StringBuilder.Append(string?)"/>,
+    /// <see cref="StringBuilder.Insert(int, string?)"/>. If the state of the <see cref="StringBuilder"/> changes, the behavior
+    /// is undefined and you must create a new instance of <see cref="ValueStringBuilderIndexer"/> to read the changes.
+    /// <para/>
+    /// This type is disposable and the user is responsible for calling <see cref="Dispose()"/> after use.
+    /// </summary>
+    /// <remarks>
+    /// This implementation uses <c>StringBuilder.GetChunks()</c> when supported to read the chars. If not, it degrades to using
+    /// <see cref="StringBuilder.CopyTo(int, char[], int, int)"/> to move chunks of the string to an array, which is used for
+    /// indexing a specific chunk. When supported, the array is obtained from the <c>ArrayPool&lt;T&gt;</c>; otherwise the array
+    /// is allocated directly on the heap with no reuse. Chunks are switched automatically when iterating before or after the bounds
+    /// of the current chunk.
+    /// </remarks>
+    public ref struct ValueStringBuilderIndexer
+    {
+#if FEATURE_STRINGBUILDER_GETCHUNKS
+        private /*readonly*/ ValueStringBuilderChunkIndexer indexer;
+#else
+        private /*readonly*/ ValueStringBuilderChunkedArrayIndexer indexer;
+#endif
+        private bool disposed;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ValueStringBuilderIndexer"/> with the specified
+        /// <see cref="StringBuilder"/> instance and iteration direction.
+        /// <para/>
+        /// If the <see cref="StringBuilder"/> is edited after construction, the behavior of
+        /// <see cref="ValueStringBuilderIndexer"/> is undefined. If this occurs, a new instance
+        /// of <see cref="ValueStringBuilderIndexer"/> should be created to account for the
+        /// <see cref="StringBuilder"/> edits.
+        /// </summary>
+        /// <param name="stringBuilder">A <see cref="StringBuilder"/> instance containing the text to iterate through.</param>
+        /// <param name="iterateForward"><c>true</c> to optimize iteration for forward order;
+        /// <c>false</c> to optimize iteration for reverse order.</param>
+        public ValueStringBuilderIndexer(StringBuilder stringBuilder, bool iterateForward = true)
+        {
+#if FEATURE_STRINGBUILDER_GETCHUNKS
+            indexer = new ValueStringBuilderChunkIndexer(stringBuilder, iterateForward);
+#else
+            indexer = new ValueStringBuilderChunkedArrayIndexer(stringBuilder, iterateForward);
+#endif
+            disposed = false;
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="ValueStringBuilderIndexer"/>.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                indexer.Dispose();
+                disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this is a forward or reverse instance.
+        /// </summary>
+        public bool IterateForward => indexer.IterateForward;
+
+        /// <summary>
+        /// Gets or sets the character at the specified character position in the <see cref="StringBuilder"/>
+        /// that is passed into the constructor.
+        /// </summary>
+        /// <param name="index">The position of the character.</param>
+        /// <returns>The Unicode character at position <paramref name="index"/>.</returns>
+        /// <exception cref="ObjectDisposedException">The struct has already been disposed.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is outside the bounds of this instance while setting a character.</exception>
+        /// <exception cref="IndexOutOfRangeException"><paramref name="index"/> is outside the bounds of this instance while getting a character.</exception>
+        public char this[int index]
+        {
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get
+            {
+                EnsureOpen();
+                return indexer[index];
+            }
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            set
+            {
+                EnsureOpen();
+                indexer[index] = value;
+            }
+        }
+
+        private void EnsureOpen()
+        {
+            if (disposed)
+                throw new ObjectDisposedException(nameof(ValueStringBuilderIndexer));
+        }
+    }
+}

--- a/tests/J2N.Tests/Text/TestValueStringBuilderChunkIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderChunkIndexer.cs
@@ -22,7 +22,7 @@ namespace J2N.Text
             }
             catch (Exception ex)
             {
-                Assert.IsInstanceOf<ArgumentOutOfRangeException>(ex);
+                Assert.IsInstanceOf<IndexOutOfRangeException>(ex);
             }
 
             try
@@ -32,7 +32,7 @@ namespace J2N.Text
             }
             catch (Exception ex)
             {
-                Assert.IsInstanceOf<ArgumentOutOfRangeException>(ex);
+                Assert.IsInstanceOf<IndexOutOfRangeException>(ex);
             }
         }
 

--- a/tests/J2N.Tests/Text/TestValueStringBuilderChunkedArrayIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderChunkedArrayIndexer.cs
@@ -1,17 +1,16 @@
-﻿#if FEATURE_ARRAYPOOL
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using System;
 using System.Text;
 
 namespace J2N.Text
 {
-    public class TestValueStringBuilderArrayPoolIndexer
+    public class TestValueStringBuilderChunkedArrayIndexer
     {
         [Test]
         public void SequentialAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             for (int i = 0; i < sb.Length; i++)
             {
                 char expected = sb[i];
@@ -24,7 +23,7 @@ namespace J2N.Text
         public void SequentialAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             try
             {
                 for (int i = 0; i < sb.Length; i++)
@@ -44,7 +43,7 @@ namespace J2N.Text
         public void RandomAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             Assert.AreEqual('4', indexer[3]);
             Assert.AreEqual('8', indexer[7]);
         }
@@ -53,7 +52,7 @@ namespace J2N.Text
         public void RandomAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             try
             {
                 indexer[3] = 'X';
@@ -72,7 +71,7 @@ namespace J2N.Text
         public void ResettingIterators_SwitchingDirections_Successful()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             Assert.AreEqual(true, indexer.IterateForward);
 
             // Switching direction from forward to backward
@@ -88,7 +87,7 @@ namespace J2N.Text
         public void InvalidIndex_ThrowsException()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
 
             try
             {
@@ -114,7 +113,7 @@ namespace J2N.Text
         public void GetBounds_SingleChunk_ReturnsCorrectBounds()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             indexer.Reset(iterateForward: true);
             //indexer.IterateForward = true;
 
@@ -129,8 +128,8 @@ namespace J2N.Text
         public void GetBounds_MultipleChunks_ReturnsCorrectBounds()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb, iterateForward: true);
-            int expectedChunkCount = (int)Math.Ceiling((double)sb.Length / ValueStringBuilderArrayPoolIndexer.ChunkLength);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb, iterateForward: true);
+            int expectedChunkCount = (int)Math.Ceiling((double)sb.Length / ValueStringBuilderChunkedArrayIndexer.ChunkLength);
             Assert.AreEqual(expectedChunkCount, indexer.ChunkCount);
 
 
@@ -139,12 +138,12 @@ namespace J2N.Text
                 indexer.GetBounds(i, out int lowerBound, out int upperBound);
                 if (i < expectedChunkCount - 1)
                 {
-                    Assert.AreEqual(ValueStringBuilderArrayPoolIndexer.ChunkLength * i, lowerBound);
-                    Assert.AreEqual((ValueStringBuilderArrayPoolIndexer.ChunkLength * (i + 1)) - 1, upperBound);
+                    Assert.AreEqual(ValueStringBuilderChunkedArrayIndexer.ChunkLength * i, lowerBound);
+                    Assert.AreEqual((ValueStringBuilderChunkedArrayIndexer.ChunkLength * (i + 1)) - 1, upperBound);
                 }
                 else // Last chunk
                 {
-                    Assert.AreEqual(ValueStringBuilderArrayPoolIndexer.ChunkLength * i, lowerBound);
+                    Assert.AreEqual(ValueStringBuilderChunkedArrayIndexer.ChunkLength * i, lowerBound);
                     Assert.AreEqual(sb.Length - 1, upperBound);
                 }
             }
@@ -154,7 +153,7 @@ namespace J2N.Text
         public void IsWithinBounds_SingleChunk_ReturnsTrueForValidIndex()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             indexer.Reset(iterateForward: true);
             //indexer.IterateForward = true;
 
@@ -167,7 +166,7 @@ namespace J2N.Text
         public void IsWithinBounds_SingleChunk_ReturnsFalseForInvalidIndex()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             indexer.Reset(iterateForward: true);
             //indexer.IterateForward = true;
 
@@ -180,9 +179,9 @@ namespace J2N.Text
         public void IsWithinBounds_MultipleChunks_ReturnsTrueForValidIndex()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb, iterateForward: true);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb, iterateForward: true);
             // Multiple chunks scenario
-            bool result = indexer.IsWithinBounds(1, ValueStringBuilderArrayPoolIndexer.ChunkLength * 2 - 10);
+            bool result = indexer.IsWithinBounds(1, ValueStringBuilderChunkedArrayIndexer.ChunkLength * 2 - 10);
             Assert.IsTrue(result);
         }
 
@@ -190,7 +189,7 @@ namespace J2N.Text
         public void IsWithinBounds_MultipleChunks_ReturnsFalseForInvalidIndex()
         {
             StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(sb);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
             indexer.Reset(iterateForward: true);
             //indexer.IterateForward = true;
 
@@ -208,7 +207,7 @@ namespace J2N.Text
             stringBuilder.Append("Beautiful, ").Append(new string('a', 1024));
             stringBuilder.Append("Amazing, ").Append(new string('a', 1024));
             stringBuilder.Append("World!");
-            var indexer = new ValueStringBuilderArrayPoolIndexer(stringBuilder);
+            var indexer = new ValueStringBuilderChunkedArrayIndexer(stringBuilder);
             try
             {
                 // Act
@@ -239,7 +238,7 @@ namespace J2N.Text
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            using var indexer = new ValueStringBuilderArrayPoolIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderChunkedArrayIndexer(stringBuilder);
 
             // Act
             indexer.Reset(iterateForward: false);
@@ -286,4 +285,3 @@ namespace J2N.Text
         }
     }
 }
-#endif

--- a/tests/J2N.Tests/Text/TestValueStringBuilderIndexer.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilderIndexer.cs
@@ -4,13 +4,13 @@ using System.Text;
 
 namespace J2N.Text
 {
-    public class TestValueStringBuilderChunkedArrayIndexer
+    public class TestValueStringBuilderIndexer
     {
         [Test]
         public void SequentialAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
+            using var indexer = new ValueStringBuilderIndexer(sb);
             for (int i = 0; i < sb.Length; i++)
             {
                 char expected = sb[i];
@@ -23,7 +23,7 @@ namespace J2N.Text
         public void SequentialAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
+            var indexer = new ValueStringBuilderIndexer(sb);
             try
             {
                 for (int i = 0; i < sb.Length; i++)
@@ -43,7 +43,7 @@ namespace J2N.Text
         public void RandomAccess_ReadsCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
+            using var indexer = new ValueStringBuilderIndexer(sb);
             Assert.AreEqual('4', indexer[3]);
             Assert.AreEqual('8', indexer[7]);
         }
@@ -52,7 +52,7 @@ namespace J2N.Text
         public void RandomAccess_WritesCorrectly()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
+            var indexer = new ValueStringBuilderIndexer(sb);
             try
             {
                 indexer[3] = 'X';
@@ -68,26 +68,10 @@ namespace J2N.Text
         }
 
         [Test]
-        public void ResettingIterators_SwitchingDirections_Successful()
-        {
-            StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
-            Assert.AreEqual(true, indexer.IterateForward);
-
-            // Switching direction from forward to backward
-            indexer.Reset(false);
-            Assert.AreEqual(false, indexer.IterateForward);
-
-            // Switching direction from backward to forward
-            indexer.Reset(true);
-            Assert.AreEqual(true, indexer.IterateForward);
-        }
-
-        [Test]
         public void InvalidIndex_ThrowsException()
         {
             StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
+            using var indexer = new ValueStringBuilderIndexer(sb);
 
             try
             {
@@ -110,95 +94,6 @@ namespace J2N.Text
         }
 
         [Test]
-        public void GetBounds_SingleChunk_ReturnsCorrectBounds()
-        {
-            StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
-            indexer.Reset(iterateForward: true);
-            //indexer.IterateForward = true;
-
-            // Single chunk scenario
-            indexer.GetBounds(0, out int lowerBound, out int upperBound);
-
-            Assert.AreEqual(0, lowerBound);
-            Assert.AreEqual(sb.Length - 1, upperBound);
-        }
-
-        [Test]
-        public void GetBounds_MultipleChunks_ReturnsCorrectBounds()
-        {
-            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb, iterateForward: true);
-            int expectedChunkCount = (int)Math.Ceiling((double)sb.Length / ValueStringBuilderChunkedArrayIndexer.ChunkLength);
-            Assert.AreEqual(expectedChunkCount, indexer.ChunkCount);
-
-
-            for (int i = 0; i < expectedChunkCount; i++)
-            {
-                indexer.GetBounds(i, out int lowerBound, out int upperBound);
-                if (i < expectedChunkCount - 1)
-                {
-                    Assert.AreEqual(ValueStringBuilderChunkedArrayIndexer.ChunkLength * i, lowerBound);
-                    Assert.AreEqual((ValueStringBuilderChunkedArrayIndexer.ChunkLength * (i + 1)) - 1, upperBound);
-                }
-                else // Last chunk
-                {
-                    Assert.AreEqual(ValueStringBuilderChunkedArrayIndexer.ChunkLength * i, lowerBound);
-                    Assert.AreEqual(sb.Length - 1, upperBound);
-                }
-            }
-        }
-
-        [Test]
-        public void IsWithinBounds_SingleChunk_ReturnsTrueForValidIndex()
-        {
-            StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
-            indexer.Reset(iterateForward: true);
-            //indexer.IterateForward = true;
-
-            // Single chunk scenario
-            bool result = indexer.IsWithinBounds(0, 5);
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void IsWithinBounds_SingleChunk_ReturnsFalseForInvalidIndex()
-        {
-            StringBuilder sb = new StringBuilder("1234567890");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
-            indexer.Reset(iterateForward: true);
-            //indexer.IterateForward = true;
-
-            // Single chunk scenario
-            bool result = indexer.IsWithinBounds(0, sb.Length);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void IsWithinBounds_MultipleChunks_ReturnsTrueForValidIndex()
-        {
-            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb, iterateForward: true);
-            // Multiple chunks scenario
-            bool result = indexer.IsWithinBounds(1, ValueStringBuilderChunkedArrayIndexer.ChunkLength * 2 - 10);
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void IsWithinBounds_MultipleChunks_ReturnsFalseForInvalidIndex()
-        {
-            StringBuilder sb = new StringBuilder("12345678901234567890").Append(new string('a', 1024));
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(sb);
-            indexer.Reset(iterateForward: true);
-            //indexer.IterateForward = true;
-
-            // Multiple chunks scenario
-            bool result = indexer.IsWithinBounds(0, sb.Length);
-            Assert.IsFalse(result);
-        }
-
-        [Test]
         public void ModifyingValuesInMultipleChunks_ChangesValues()
         {
             // Arrange
@@ -207,7 +102,7 @@ namespace J2N.Text
             stringBuilder.Append("Beautiful, ").Append(new string('a', 1024));
             stringBuilder.Append("Amazing, ").Append(new string('a', 1024));
             stringBuilder.Append("World!");
-            var indexer = new ValueStringBuilderChunkedArrayIndexer(stringBuilder);
+            var indexer = new ValueStringBuilderIndexer(stringBuilder);
             try
             {
                 // Act
@@ -238,13 +133,12 @@ namespace J2N.Text
             Assert.AreEqual($"Hello, {new string('a', 1024)}XeautifVl, {new string('a', 1024)}AmAzing, {new string('a', 1024)}Zorld?", stringBuilder.ToString());
         }
 
-
         [Test]
         public void SwitchingToRandomAccessAndBackToSequentialAccess_ReturnsCorrectValues()
         {
             // Arrange
             var stringBuilder = new StringBuilder("Hello").Append(", ").Append("World!");
-            using var indexer = new ValueStringBuilderChunkedArrayIndexer(stringBuilder);
+            using var indexer = new ValueStringBuilderIndexer(stringBuilder);
 
             // Act
             // Assert random access


### PR DESCRIPTION
New API:

```c#
namespace J2N.Text
{
    public ref struct ValueStringBuilderIndexer
    {
        public ValueStringBuilderIndexer(StringBuilder stringBuilder, bool iterateForward = true);
        public void Dispose();
        public bool IterateForward { get; }
        public char this[index] { get; set }
    }
}
```

Indexing through `System.Text.StringBuilder` is painfully slow. The purpose of this type is to wrap `StringBuilder` to allow faster access to the chars via index.

When supported, it uses `StringBuilder.GetChunks()` to access the chars. It keeps track of the bounds of each chunk and will switch to another chunk if an out of bounds index is requested.

If `StringBuilder.GetChunks()` is not supported, it uses an array. If the length of the `StringBuilder` is more than 512 characters, the array is limited to 512 characters max and will be chunked. If array pooling is supported, the array is derived from the array pool, otherwise it is allocated directly on the heap with no reuse. The bounds of each chunk are calculated and it will also switch to another chunk if an out of bounds index is requested (using `StringBuilder.CopyTo()` to move the chars into the array).

Random access is supported, but it is recommended to use the `StringBuilder` directly for random access to a specific index if you are not going to access several more sequential indexes, since it may require switching to a new chunk. This is especially costly if you are on a target framework that doesn't support `StringBuilder.GetChunks()`.

`ValueStringBuilderIndexer` is a ref struct and allocates entirely on the stack unless:

- `StringBuilder.GetChunks()` is not supported
- The number of chunks in the StringBuilder exceeds 32
- The number of characters in the `StringBuilder` exceeds 65535

Arrays that are allocated on the heap are pooled, when supported by the target framework (.NET Framework 4.5+).

This PR also updates all other types to use `ValueStringBuilderIndexer` instead of the `ValueStringBuilderChunkIndexer` and `ValueStringBuilderChunkedArrayIndexer`, which removes a lot of conditional compiler directives from the codebase.