### PR TITLE
J2N.Text.StringExtensions, J2N.Memory.MemoryExtensions: Added optimized ReverseText() methods

### DIFF
--- a/src/J2N/Memory/MemoryExtensions.cs
+++ b/src/J2N/Memory/MemoryExtensions.cs
@@ -1,0 +1,132 @@
+﻿using System;
+
+namespace J2N.Memory
+{
+    /// <summary>
+    /// Extensions to System.Memory types.
+    /// </summary>
+    public static class MemoryExtensions
+    {
+        #region Reverse
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Causes this character sequence to be replaced by the reverse of
+        /// the sequence. If there are any surrogate pairs included in the
+        /// sequence, these are treated as single characters for the
+        /// reverse operation. Thus, the order of the high-low surrogates
+        /// is never reversed.
+        /// <para/>
+        /// This operation is done in-place.
+        /// <para/>
+        /// Let <c>n</c> be the character length of this character sequence
+        /// (not the length in <see cref="char"/> values) just prior to
+        /// execution of the <see cref="ReverseText(Span{char})"/> method. Then the
+        /// character at index <c>k</c> in the new character sequence is
+        /// equal to the character at index <c>n-k-1</c> in the old
+        /// character sequence.
+        /// <para/>
+        /// Note that the reverse operation may result in producing
+        /// surrogate pairs that were unpaired low-surrogates and
+        /// high-surrogates before the operation. For example, reversing
+        /// "&#92;uDC00&#92;uD800" produces "&#92;uD800&#92;uDC00" which is
+        /// a valid surrogate pair.
+        /// <para/>
+        /// Usage Note: This is the same operation as
+        /// <see cref="J2N.Text.StringBuilderExtensions.Reverse(System.Text.StringBuilder)"/>
+        /// (derived from Java's StringBuilder.reverse() method) but is more
+        /// efficient because it doesn't allocate a new <see cref="System.Text.StringBuilder"/>
+        /// instance.
+        /// </summary>
+        /// <param name="text">this <see cref="Span{Char}"/></param>
+        /// <seealso cref="J2N.Text.StringBuilderExtensions.Reverse(System.Text.StringBuilder)"/>
+        /// <seealso cref="J2N.Text.StringExtensions.ReverseText(string)"/>
+        public unsafe static void ReverseText(this Span<char> text)
+        {
+            int count = text.Length;
+            if (count == 0) return;
+            fixed (char* textPtr = text)
+            {
+                ReverseText(textPtr, count);
+            }
+        }
+
+#endif
+
+        internal unsafe static void ReverseText(char* text, int count)
+        {
+            if (count == 0) return;
+            int start = 0;
+            int end = count - 1;
+            char startHigh = text[0];
+            char endLow = text[end];
+            bool allowStartSurrogate = true, allowEndSurrogate = true;
+            while (start < end)
+            {
+                char startLow = text[start + 1];
+                char endHigh = text[end - 1];
+                bool surrogateAtStart = allowStartSurrogate && startLow >= 0xdc00
+                        && startLow <= 0xdfff && startHigh >= 0xd800
+                        && startHigh <= 0xdbff;
+                if (surrogateAtStart && (count < 3))
+                {
+                    return;
+                }
+                bool surrogateAtEnd = allowEndSurrogate && endHigh >= 0xd800
+                        && endHigh <= 0xdbff && endLow >= 0xdc00
+                        && endLow <= 0xdfff;
+                allowStartSurrogate = allowEndSurrogate = true;
+                if (surrogateAtStart == surrogateAtEnd)
+                {
+                    if (surrogateAtStart)
+                    {
+                        // both surrogates
+                        text[end] = startLow;
+                        text[end - 1] = startHigh;
+                        text[start] = endHigh;
+                        text[start + 1] = endLow;
+                        startHigh = text[start + 2];
+                        endLow = text[end - 2];
+                        start++;
+                        end--;
+                    }
+                    else
+                    {
+                        // neither surrogates
+                        text[end] = startHigh;
+                        text[start] = endLow;
+                        startHigh = startLow;
+                        endLow = endHigh;
+                    }
+                }
+                else
+                {
+                    if (surrogateAtStart)
+                    {
+                        // surrogate only at the front
+                        text[end] = startLow;
+                        text[start] = endLow;
+                        endLow = endHigh;
+                        allowStartSurrogate = false;
+                    }
+                    else
+                    {
+                        // surrogate only at the end
+                        text[end] = startHigh;
+                        text[start] = endHigh;
+                        startHigh = startLow;
+                        allowEndSurrogate = false;
+                    }
+                }
+                start++;
+                end--;
+            }
+            if ((count & 1) == 1 && (!allowStartSurrogate || !allowEndSurrogate))
+            {
+                text[end] = allowStartSurrogate ? endLow : startHigh;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -1766,10 +1766,17 @@ namespace J2N.Text
         /// high-surrogates before the operation. For example, reversing
         /// "&#92;uDC00&#92;uD800" produces "&#92;uD800&#92;uDC00" which is
         /// a valid surrogate pair.
+        /// <para/>
+        /// Usage Note: This is the same operation as Java's StringBuilder.reverse()
+        /// method. However, J2N also provides <see cref="J2N.Text.StringExtensions.ReverseText(string)"/>
+        /// and <see cref="J2N.Memory.MemoryExtensions.ReverseText(Span{char})"/> which
+        /// don't require a <see cref="StringBuilder"/> instance.
         /// </summary>
         /// <param name="text">this <see cref="StringBuilder"/></param>
         /// <returns>A reference to this <see cref="StringBuilder"/>, for chaining.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is <c>null</c>.</exception>
+        /// <seealso cref="J2N.Text.StringExtensions.ReverseText(string)"/>
+        /// <seealso cref="J2N.Memory.MemoryExtensions.ReverseText(Span{char})"/>
         public static StringBuilder Reverse(this StringBuilder text)
         {
             if (text is null)

--- a/tests/J2N.Tests/Memory/TestMemoryExtensions.cs
+++ b/tests/J2N.Tests/Memory/TestMemoryExtensions.cs
@@ -1,0 +1,131 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace J2N.Memory
+{
+    public class TestMemoryExtensions : TestCase
+    {
+#if FEATURE_SPAN
+        private void reverseTest(string org, string rev, string back)
+        {
+            {
+                Span<char> sb = stackalloc char[org.Length];
+                org.AsSpan().CopyTo(sb);
+                sb.ReverseText();
+                string reversed = sb.ToString();
+                assertEquals(rev, reversed);
+
+                Span<char> sb2 = stackalloc char[reversed.Length];
+                reversed.AsSpan().CopyTo(sb);
+                sb.ReverseText();
+                reversed = sb.ToString();
+                assertEquals(back, reversed);
+            }
+        }
+
+        [Test]
+        public void Test_ReverseText_Span()
+        {
+            {
+                string fixture = "0123456789";
+                Span<char> sb = stackalloc char[fixture.Length];
+                fixture.AsSpan().CopyTo(sb);
+                sb.ReverseText();
+                assertEquals("9876543210", sb.ToString());
+            }
+
+            {
+                string fixture = "012345678";
+                Span<char> sb = stackalloc char[fixture.Length];
+                fixture.AsSpan().CopyTo(sb);
+                sb.ReverseText();
+                assertEquals("876543210", sb.ToString());
+            }
+
+            {
+                string fixture = "8";
+                Span<char> sb = stackalloc char[fixture.Length];
+                fixture.AsSpan().CopyTo(sb);
+                sb.ReverseText();
+                assertEquals("8", sb.ToString());
+            }
+
+            {
+                string fixture = "";
+                Span<char> sb = stackalloc char[1];
+                fixture.AsSpan().CopyTo(sb);
+                sb.Slice(0, 0).ReverseText();
+                assertEquals("", sb.Slice(0, 0).ToString());
+            }
+
+
+            string str;
+            str = "a";
+            reverseTest(str, str, str);
+
+            str = "ab";
+            reverseTest(str, "ba", str);
+
+            str = "abcdef";
+            reverseTest(str, "fedcba", str);
+
+            str = "abcdefg";
+            reverseTest(str, "gfedcba", str);
+
+            str = "\ud800\udc00";
+            reverseTest(str, str, str);
+
+            str = "\udc00\ud800";
+            reverseTest(str, "\ud800\udc00", "\ud800\udc00");
+
+            str = "a\ud800\udc00";
+            reverseTest(str, "\ud800\udc00a", str);
+
+            str = "ab\ud800\udc00";
+            reverseTest(str, "\ud800\udc00ba", str);
+
+            str = "abc\ud800\udc00";
+            reverseTest(str, "\ud800\udc00cba", str);
+
+            str = "\ud800\udc00\udc01\ud801\ud802\udc02";
+            reverseTest(str, "\ud802\udc02\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01\ud802\udc02");
+
+            str = "\ud800\udc00\ud801\udc01\ud802\udc02";
+            reverseTest(str, "\ud802\udc02\ud801\udc01\ud800\udc00", str);
+
+            str = "\ud800\udc00\udc01\ud801a";
+            reverseTest(str, "a\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01a");
+
+            str = "a\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00a", str);
+
+            str = "\ud800\udc00\udc01\ud801ab";
+            reverseTest(str, "ba\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01ab");
+
+            str = "ab\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00ba", str);
+
+            str = "\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00", str);
+
+            str = "a\ud800\udc00z\ud801\udc01";
+            reverseTest(str, "\ud801\udc01z\ud800\udc00a", str);
+
+            str = "a\ud800\udc00bz\ud801\udc01";
+            reverseTest(str, "\ud801\udc01zb\ud800\udc00a", str);
+
+            str = "abc\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02cba", str);
+
+            str = "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba", str);
+
+            str = new string('z', 1000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00" + new string('p', 3000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('p', 3000) + "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('z', 1000), str);
+        }
+#endif
+    }
+}

--- a/tests/J2N.Tests/Text/TestStringExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using J2N.Globalization;
 using NUnit.Framework;
 using System;
-using System.Globalization;
 using System.Text;
 
 namespace J2N.Text
@@ -740,6 +739,126 @@ namespace J2N.Text
 
             assertNotNull(result);
             assertEquals(typeof(StringCharSequence), result.GetType());
+        }
+
+        private void reverseTest(string org, string rev, string back)
+        {
+            {
+                string reversed = org.ReverseText();
+                assertEquals(rev, reversed);
+
+                reversed = reversed.ReverseText();
+                assertEquals(back, reversed);
+            }
+
+            {
+                var sb = new StringBuilder(org);
+                string copy = sb.ToString();
+                assertEquals(org, copy);
+                string reversed = copy.ReverseText();
+                assertEquals(rev, reversed);
+                sb = new StringBuilder(reversed);
+                copy = sb.ToString();
+                assertEquals(rev, copy);
+                reversed = copy.ReverseText();
+                assertEquals(back, reversed);
+            }
+        }
+
+        [Test]
+        public void TestReverseText()
+        {
+            {
+                string fixture = "0123456789";
+                string actual = fixture.ReverseText();
+                assertEquals("9876543210", actual);
+            }
+
+            {
+                string fixture = "012345678";
+                string actual = fixture.ReverseText();
+                assertEquals("876543210", actual);
+            }
+
+            {
+                string fixture = "8";
+                string actual = fixture.ReverseText();
+                assertEquals("8", actual);
+            }
+
+            {
+                string fixture = "";
+                string actual = fixture.ReverseText();
+                assertEquals("", actual);
+            }
+
+
+            string str;
+            str = "a";
+            reverseTest(str, str, str);
+
+            str = "ab";
+            reverseTest(str, "ba", str);
+
+            str = "abcdef";
+            reverseTest(str, "fedcba", str);
+
+            str = "abcdefg";
+            reverseTest(str, "gfedcba", str);
+
+            str = "\ud800\udc00";
+            reverseTest(str, str, str);
+
+            str = "\udc00\ud800";
+            reverseTest(str, "\ud800\udc00", "\ud800\udc00");
+
+            str = "a\ud800\udc00";
+            reverseTest(str, "\ud800\udc00a", str);
+
+            str = "ab\ud800\udc00";
+            reverseTest(str, "\ud800\udc00ba", str);
+
+            str = "abc\ud800\udc00";
+            reverseTest(str, "\ud800\udc00cba", str);
+
+            str = "\ud800\udc00\udc01\ud801\ud802\udc02";
+            reverseTest(str, "\ud802\udc02\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01\ud802\udc02");
+
+            str = "\ud800\udc00\ud801\udc01\ud802\udc02";
+            reverseTest(str, "\ud802\udc02\ud801\udc01\ud800\udc00", str);
+
+            str = "\ud800\udc00\udc01\ud801a";
+            reverseTest(str, "a\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01a");
+
+            str = "a\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00a", str);
+
+            str = "\ud800\udc00\udc01\ud801ab";
+            reverseTest(str, "ba\ud801\udc01\ud800\udc00",
+                    "\ud800\udc00\ud801\udc01ab");
+
+            str = "ab\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00ba", str);
+
+            str = "\ud800\udc00\ud801\udc01";
+            reverseTest(str, "\ud801\udc01\ud800\udc00", str);
+
+            str = "a\ud800\udc00z\ud801\udc01";
+            reverseTest(str, "\ud801\udc01z\ud800\udc00a", str);
+
+            str = "a\ud800\udc00bz\ud801\udc01";
+            reverseTest(str, "\ud801\udc01zb\ud800\udc00a", str);
+
+            str = "abc\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02cba", str);
+
+            str = "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba", str);
+
+            str = new string('z', 1000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00" + new string('p', 3000) + "abcd\ud802\udc02\ud801\udc01\ud800\udc00";
+            reverseTest(str, "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('p', 3000) + "\ud800\udc00\ud801\udc01\ud802\udc02dcba" + new string('z', 1000), str);
         }
     }
 }


### PR DESCRIPTION
Added optimized `ReverseText()` methods to reverse strings while respecting the correct order of surrogate pairs, just like the `StringBuilderExtensions.Reverse()` method.

These are the same operation as Java's `StringBuilder.reverse()` method, except they don't require an instance of `StringBuilder` to function.