### PR TITLE
J2N.Character: Added overloads of CodePointAt() and CodePointBefore()

### DIFF
--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -581,7 +581,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null || !seq.HasValue)
                 throw new ArgumentNullException(nameof(seq));
@@ -624,7 +624,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -648,6 +648,11 @@ namespace J2N
         /// <c><paramref name="index"/> + 1</c> is a low-surrogate unit, then the supplementary code
         /// point represented by the pair is returned; otherwise the <see cref="char"/>
         /// value at <paramref name="index"/> is returned.
+        /// <para/>
+        /// <strong>Usage Note:</strong> Using this overload for getting a single code point is fine. However,
+        /// if you are calling this method in a loop, it is highly recommended to use the
+        /// <see cref="CodePointAt(ref ValueStringBuilderIndexer, int)"/> overload
+        /// after wrapping the <see cref="StringBuilder"/> in a <see cref="ValueStringBuilderIndexer"/>.
         /// </summary>
         /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
         /// <param name="index">the position in <paramref name="seq"/> from which to retrieve the code
@@ -662,7 +667,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -687,6 +692,45 @@ namespace J2N
         /// <c><paramref name="index"/> + 1</c> is a low-surrogate unit, then the supplementary code
         /// point represented by the pair is returned; otherwise the <see cref="char"/>
         /// value at <paramref name="index"/> is returned.
+        /// <para/>
+        /// <strong>Usage Note:</strong> Prefer this overload instead of <see cref="CodePointAt(StringBuilder, int)"/>
+        /// for optimal performance. Simply wrap the <see cref="StringBuilder"/> in a <see cref="ValueStringBuilderIndexer"/>
+        /// to make repeated calls to this method.
+        /// </summary>
+        /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
+        /// <param name="index">the position in <paramref name="seq"/> from which to retrieve the code
+        /// point.</param>
+        /// <returns>the Unicode code point or <see cref="char"/> value at <paramref name="index"/> in
+        /// <paramref name="seq"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is greater than or equal to the length of <paramref name="seq"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="index"/> is less than zero.
+        /// </exception>
+        public static int CodePointAt(this ref ValueStringBuilderIndexer seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
+        {
+            int len = seq.Length;
+            if (index < 0 || index >= len)
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_Index);
+
+            char high = seq[index++];
+            if (index >= len)
+                return high;
+            char low = seq[index];
+            if (char.IsSurrogatePair(high, low))
+                return ToCodePoint(high, low);
+            return high;
+        }
+
+        /// <summary>
+        /// Returns the code point at <paramref name="index"/> in the specified sequence of
+        /// character units. If the unit at <paramref name="index"/> is a high-surrogate unit,
+        /// <c><paramref name="index"/> + 1</c> is less than the length of the sequence and the unit at
+        /// <c><paramref name="index"/> + 1</c> is a low-surrogate unit, then the supplementary code
+        /// point represented by the pair is returned; otherwise the <see cref="char"/>
+        /// value at <paramref name="index"/> is returned.
         /// </summary>
         /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
         /// <param name="index">the position in <paramref name="seq"/> from which to retrieve the code
@@ -701,7 +745,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -739,7 +783,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="index"/> is less than zero.
         /// </exception>
-        public static int CodePointAt(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             int len = seq.Length;
             if (index < 0 || index >= len)
@@ -777,7 +821,7 @@ namespace J2N
         /// <para/>
         /// <paramref name="limit"/> is less than zero or greater than the length of <paramref name="seq"/>.
         /// </exception>
-        public static int CodePointAt(this char[] seq, int index, int limit) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointAt(this char[] seq, int index, int limit) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -811,7 +855,7 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this ICharSequence seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null || !seq.HasValue)
                 throw new ArgumentNullException(nameof(seq));
@@ -851,7 +895,7 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this char[] seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -877,6 +921,11 @@ namespace J2N
         /// <c><paramref name="index"/> - 2</c> is a high-surrogate unit, then the supplementary code
         /// point represented by the pair is returned; otherwise the <see cref="char"/>
         /// value at <c><paramref name="index"/> - 1</c> is returned.
+        /// <para/>
+        /// <strong>Usage Note:</strong> Using this overload for getting a single code point is fine. However,
+        /// if you are calling this method in a loop, it is highly recommended to use the
+        /// <see cref="CodePointBefore(ref ValueStringBuilderIndexer, int)"/> overload
+        /// after wrapping the <see cref="StringBuilder"/> in a <see cref="ValueStringBuilderIndexer"/>.
         /// </summary>
         /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
         /// <param name="index">The position in <paramref name="seq"/> following the code
@@ -886,7 +935,7 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this StringBuilder seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -913,6 +962,43 @@ namespace J2N
         /// <c><paramref name="index"/> - 2</c> is a high-surrogate unit, then the supplementary code
         /// point represented by the pair is returned; otherwise the <see cref="char"/>
         /// value at <c><paramref name="index"/> - 1</c> is returned.
+        /// <para/>
+        /// <strong>Usage Note:</strong> Prefer this overload instead of <see cref="CodePointBefore(StringBuilder, int)"/>
+        /// for optimal performance. Simply wrap the <see cref="StringBuilder"/> in a <see cref="ValueStringBuilderIndexer"/>
+        /// to make repeated calls to this method. Generally, you should instantiate <see cref="ValueStringBuilderIndexer"/>
+        /// with <c>iterateForward: false</c> when using this method.
+        /// </summary>
+        /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
+        /// <param name="index">The position in <paramref name="seq"/> following the code
+        /// point that should be returned.</param>
+        /// <returns>The Unicode code point or <see cref="char"/> value before <paramref name="index"/>
+        /// in <paramref name="seq"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
+        /// the length of <paramref name="seq"/>.</exception>
+        public static int CodePointBefore(this ref ValueStringBuilderIndexer seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
+        {
+            int len = seq.Length;
+            if (index < 1 || index > len)
+                throw new ArgumentOutOfRangeException(nameof(index), SR2.ArgumentOutOfRange_IndexBefore);
+
+            char low = seq[--index];
+            if (--index < 0)
+                return low;
+            char high = seq[index];
+            if (char.IsSurrogatePair(high, low))
+            {
+                return ToCodePoint(high, low);
+            }
+            return low;
+        }
+
+        /// <summary>
+        /// Returns the code point that precedes <paramref name="index"/> in the specified
+        /// sequence of character units. If the unit at <c><paramref name="index"/> - 1</c> is a
+        /// low-surrogate unit, <c><paramref name="index"/> - 2</c> is not negative and the unit at
+        /// <c><paramref name="index"/> - 2</c> is a high-surrogate unit, then the supplementary code
+        /// point represented by the pair is returned; otherwise the <see cref="char"/>
+        /// value at <c><paramref name="index"/> - 1</c> is returned.
         /// </summary>
         /// <param name="seq">The source sequence of <see cref="char"/> units.</param>
         /// <param name="index">The position in <paramref name="seq"/> following the code
@@ -922,7 +1008,7 @@ namespace J2N
         /// <exception cref="ArgumentNullException">If <paramref name="seq"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this string seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             if (seq is null)
                 throw new ArgumentNullException(nameof(seq));
@@ -957,7 +1043,7 @@ namespace J2N
         /// in <paramref name="seq"/>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If the <paramref name="index"/> is less than 1 or greater than
         /// the length of <paramref name="seq"/>.</exception>
-        public static int CodePointBefore(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static int CodePointBefore(this ReadOnlySpan<char> seq, int index) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, ValueStringBuilderIndexer, and string IN SYNC
         {
             int len = seq.Length;
             if (index < 1 || index > len)

--- a/src/J2N/Text/ValueStringBuilderChunkIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderChunkIndexer.cs
@@ -223,6 +223,8 @@ namespace J2N.Text
 
         public bool IterateForward => iterateForward;
 
+        public int Length => stringBuilder.Length;
+
         public char this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderChunkedArrayIndexer.cs
@@ -190,6 +190,8 @@ namespace J2N.Text
 
         public bool IterateForward => iterateForward;
 
+        public int Length => stringBuilder.Length;
+
         public char this[int index]
         {
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING

--- a/src/J2N/Text/ValueStringBuilderIndexer.cs
+++ b/src/J2N/Text/ValueStringBuilderIndexer.cs
@@ -82,6 +82,11 @@ namespace J2N.Text
         public bool IterateForward => indexer.IterateForward;
 
         /// <summary>
+        /// Gets the length of the <see cref="StringBuilder"/>.
+        /// </summary>
+        public int Length => indexer.Length;
+
+        /// <summary>
         /// Gets or sets the character at the specified character position in the <see cref="StringBuilder"/>
         /// that is passed into the constructor.
         /// </summary>

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -256,6 +256,51 @@ namespace J2N
         }
 
         [Test]
+        public void Test_codePointAt_ValueStringBuilderIndexerI()
+        {
+            var i1 = new ValueStringBuilderIndexer(new StringBuilder("abc"));
+            assertEquals('a', Character.CodePointAt(ref i1, 0));
+            assertEquals('a', i1.CodePointAt(0));
+            assertEquals('b', Character.CodePointAt(ref i1, 1));
+            assertEquals('b', i1.CodePointAt(1));
+            assertEquals('c', Character.CodePointAt(ref i1, 2));
+            assertEquals('c', i1.CodePointAt(2));
+
+            var i2 = new ValueStringBuilderIndexer(new StringBuilder("\uD800\uDC00"));
+            assertEquals(0x10000, Character.CodePointAt(ref i2, 0));
+            assertEquals(0x10000, i2.CodePointAt(0));
+            assertEquals('\uDC00', Character.CodePointAt(ref i2, 1));
+            assertEquals('\uDC00', i2.CodePointAt(1));
+
+            //try
+            //{
+            //    Character.CodePointAt((StringBuilder)null, 0);
+            //    fail("No NPE.");
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //}
+
+            try
+            {
+                Character.CodePointAt(ref i1, -1);
+                fail("No IOOBE, negative index.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.CodePointAt(ref i1, 4);
+                fail("No IOOBE, index too large.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+        }
+
+        [Test]
         public void Test_codePointAt_StringI()
         {
 
@@ -543,6 +588,52 @@ namespace J2N
             try
             {
                 Character.CodePointBefore((StringBuilder)new StringBuilder("abc"), 4);
+                fail("No IOOBE, index too large.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+        }
+
+        [Test]
+        public void Test_codePointBefore_ValueStringBuilderIndexerI()
+        {
+            var i1 = new ValueStringBuilderIndexer(new StringBuilder("abc"));
+            assertEquals('a', Character.CodePointBefore(ref i1, 1));
+            assertEquals('a', i1.CodePointBefore(1));
+            assertEquals('b', Character.CodePointBefore(ref i1, 2));
+            assertEquals('b', i1.CodePointBefore(2));
+            assertEquals('c', Character.CodePointBefore(ref i1, 3));
+            assertEquals('c', i1.CodePointBefore(3));
+
+            var i2 = new ValueStringBuilderIndexer(new StringBuilder("\uD800\uDC00"));
+            assertEquals(0x10000, Character.CodePointBefore(ref i2, 2));
+            assertEquals(0x10000, i2.CodePointBefore(2));
+            assertEquals('\uD800', Character.CodePointBefore(ref i2, 1));
+            assertEquals('\uD800', i2.CodePointBefore(1));
+
+
+            //try
+            //{
+            //    Character.CodePointBefore((StringBuilder)null, 0);
+            //    fail("No NPE.");
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //}
+
+            try
+            {
+                Character.CodePointBefore(ref i1, 0);
+                fail("No IOOBE, index below one.");
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+            }
+
+            try
+            {
+                Character.CodePointBefore(ref i1, 4);
                 fail("No IOOBE, index too large.");
             }
             catch (ArgumentOutOfRangeException e)


### PR DESCRIPTION
Added overloads of `CodePointAt()` and `CodePointBefore()` for use with `ValueStringBuilderIndexer`, since these methods are designed to be called inside of a loop.