### PR TITLE
PERFORMANCE: Added target for net462

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -19,7 +19,8 @@
       Test Client       | Target Under Test
       net6.0            | net6.0
       net5.0            | netstandard2.1
-      net48             | net45
+      net48             | net462
+      net472            | net45
       net461            | netstandard2.0
       net452            | net40
       MonoAndroid100    | netstandard2.1
@@ -28,7 +29,7 @@
       // The compilations for netstandard2.1 and netstandard2.0 are for loading
       // as dependencies in Xamarin tests to test those exact targets
     -->
-    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net6.0;net5.0;net48;net461;net452;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net6.0;net5.0;net48;net472;net461;net452;netstandard2.1;netstandard2.0</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 
@@ -36,6 +37,7 @@
     <SetTargetFramework></SetTargetFramework>
     <SetTargetFramework Condition=" '$(TargetFramework)' == 'net452' ">TargetFramework=net40</SetTargetFramework>
     <SetTargetFramework Condition=" '$(TargetFramework)' == 'net461' ">TargetFramework=netstandard2.0</SetTargetFramework>
+    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net472' ">TargetFramework=net45</SetTargetFramework>
   </PropertyGroup>
   
 </Project>

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -56,6 +56,16 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
+    framework: 'net472'
+    testProjectName: '${{ parameters.testProjectName }}'
+    osName: '${{ parameters.osName }}'
+    testPlatform: '${{ parameters.testPlatform }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
     framework: 'net461'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net6.0;net5.0;net48;net461;net452'
+  value: 'net6.0;net5.0;net48;net472;net461;net452'
 - name: DotNetSDKVersion
   value: '6.0.101'
 - name: BinaryArtifactName
@@ -258,6 +258,36 @@ stages:
       parameters:
         osName: 'Windows'
         testTargetFrameworks: 'net48'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net472_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    displayName: 'Test net472,x64 on Windows'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: 'Windows'
+        testTargetFrameworks: 'net472'
+        vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net472_x86 # Only run if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
+    displayName: 'Test net472,x86 on Windows'
+    pool:
+      vmImage: 'windows-latest'
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: 'Windows'
+        testTargetFrameworks: 'net472'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build

--- a/src/J2N.TestFramework/J2N.TestFramework.csproj
+++ b/src/J2N.TestFramework/J2N.TestFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
     <RootNamespace>J2N</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
@@ -28,11 +28,11 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net45' ">
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
There are a few performance reasons why this is now a benefit:

-  The `StringBuilder.Append(char*, int)` method (added in `net46`) is a significant performance benefit to legacy ReadOnlySpan<char> support. 
- The `Buffer.MemoryCopy()` method is available, which makes the `float/double` parsing significantly faster.
- The `Array.Empty<T>()` method is available, so we don't have to roll our own solution.

Added test target for `net472`, which will be used to test `net45` (`net48` now tests `net462` instead of `net45`). See: https://github.com/NightOwl888/J2N/blob/89276f7419c9940c4f7795aebdee35c5dcff3750/.build/TestTargetFramework.props#L19-L27

This also changes tests to run on background jobs in parallel to speed up the test runs.