### PR TITLE
J2N.Text (CharArrayExtensions + StringBuilderExtensions + StringExtensions): Added ReadOnlySpan<char> overload of CompareToOrdinal()

### DIFF
--- a/tests/J2N.Tests/Text/TestCharArrayExtensions.cs
+++ b/tests/J2N.Tests/Text/TestCharArrayExtensions.cs
@@ -46,6 +46,9 @@ namespace J2N.Text
             char[] target = null;
             string compareTo = "Alpine";
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -55,6 +58,9 @@ namespace J2N.Text
 
             target = "Alpha".ToCharArray();
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -64,6 +70,9 @@ namespace J2N.Text
 
             compareTo = "Alpha";
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo));
@@ -73,6 +82,9 @@ namespace J2N.Text
 
             compareTo = "Alp";
 
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Less(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Less(0, target.CompareToOrdinal(compareTo));
@@ -80,7 +92,9 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new StringBuilderCharSequence(new StringBuilder(compareTo))));
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(compareTo)));
 
-
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.Less(0, target.CompareToOrdinal((char[])null));
             Assert.Less(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.Less(0, target.CompareToOrdinal((string)null));
@@ -90,6 +104,9 @@ namespace J2N.Text
 
             target = null;
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
             Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.AreEqual(0, target.CompareToOrdinal((string)null));

--- a/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -143,6 +143,9 @@ namespace J2N.Text
             StringBuilder target = null;
             string compareTo = "Alpine";
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -152,6 +155,9 @@ namespace J2N.Text
 
             target = new StringBuilder("Alpha");
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -161,6 +167,9 @@ namespace J2N.Text
 
             compareTo = "Alpha";
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo));
@@ -170,6 +179,9 @@ namespace J2N.Text
 
             compareTo = "Alp";
 
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Less(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Less(0, target.CompareToOrdinal(compareTo));
@@ -178,6 +190,9 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(compareTo)));
 
 
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.Less(0, target.CompareToOrdinal((char[])null));
             Assert.Less(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.Less(0, target.CompareToOrdinal((string)null));
@@ -187,6 +202,9 @@ namespace J2N.Text
 
             target = null;
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
             Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.AreEqual(0, target.CompareToOrdinal((string)null));

--- a/tests/J2N.Tests/Text/TestStringExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringExtensions.cs
@@ -19,6 +19,9 @@ namespace J2N.Text
             string target = null;
             string compareTo = "Alpine";
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -28,6 +31,9 @@ namespace J2N.Text
 
             target = "Alpha";
 
+#if FEATURE_SPAN
+            Assert.Greater(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Greater(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Greater(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Greater(0, target.CompareToOrdinal(compareTo));
@@ -37,6 +43,9 @@ namespace J2N.Text
 
             compareTo = "Alpha";
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.AreEqual(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.AreEqual(0, target.CompareToOrdinal(compareTo));
@@ -46,6 +55,9 @@ namespace J2N.Text
 
             compareTo = "Alp";
 
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal(compareTo.AsSpan()));
+#endif
             Assert.Less(0, target.CompareToOrdinal(compareTo.ToCharArray()));
             Assert.Less(0, target.CompareToOrdinal(new StringBuilder(compareTo)));
             Assert.Less(0, target.CompareToOrdinal(compareTo));
@@ -53,7 +65,9 @@ namespace J2N.Text
             Assert.Less(0, target.CompareToOrdinal(new StringBuilderCharSequence(new StringBuilder(compareTo))));
             Assert.Less(0, target.CompareToOrdinal(new StringCharSequence(compareTo)));
 
-
+#if FEATURE_SPAN
+            Assert.Less(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.Less(0, target.CompareToOrdinal((char[])null));
             Assert.Less(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.Less(0, target.CompareToOrdinal((string)null));
@@ -63,6 +77,9 @@ namespace J2N.Text
 
             target = null;
 
+#if FEATURE_SPAN
+            Assert.AreEqual(0, target.CompareToOrdinal((ReadOnlySpan<char>)null));
+#endif
             Assert.AreEqual(0, target.CompareToOrdinal((char[])null));
             Assert.AreEqual(0, target.CompareToOrdinal((StringBuilder)null));
             Assert.AreEqual(0, target.CompareToOrdinal((string)null));


### PR DESCRIPTION
New APIs:

```c#
namespace J2N.Text
{
    public static class CharArrayExtensions
    {
        public static int CompareToOrdinal(this char[]? str, ReadOnlySpan<char> value);
    }
    public static class StringBuilderExtensions
    {
        public static int CompareToOrdinal(this StringBuilder? text, ReadOnlySpan<char> value);
    }
    public static class StringExtensions
    {
        public static int CompareToOrdinal(this string? str, ReadOnlySpan<char> value);
    }
}
```

Null comparison checks are performed against `ReadOnlySpan<char>.Empty`.