### PR TITLE
J2N.MemoryExtensions: Added IndexOf(codePoint) and LastIndexOf(codePoint) extension methods

### DIFF
--- a/src/J2N/Memory/MemoryExtensions.cs
+++ b/src/J2N/Memory/MemoryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace J2N.Memory
@@ -8,6 +9,443 @@ namespace J2N.Memory
     /// </summary>
     public static class MemoryExtensions
     {
+
+        #region IndexOf
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Returns the index within this string of the first occurrence of
+        /// the specified character. If a character with value
+        /// <paramref name="codePoint"/> occurs in the character sequence represented by
+        /// this <see cref="ReadOnlySpan{Char}"/> object, then the index (in Unicode
+        /// code units) of the first such occurrence is returned. For
+        /// values of <paramref name="codePoint"/> in the range from 0 to 0xFFFF
+        /// (inclusive), this is the smallest value <i>k</i> such that:
+        /// <code>
+        ///     this[(<i>k</i>] == <paramref name="codePoint"/>
+        /// </code>
+        /// is true. For other values of <paramref name="codePoint"/>, it is the
+        /// smallest value <i>k</i> such that:
+        /// <code>
+        ///     this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>
+        /// </code>
+        /// is true. In either case, if no such character occurs in this
+        /// string, then <c>-1</c> is returned.
+        /// </summary>
+        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <returns>The index of the first occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int IndexOf(this ReadOnlySpan<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.IndexOf()
+        {
+            return IndexOf(text, codePoint, 0);
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the first occurrence of the
+        /// specified character, starting the search at the specified index.
+        /// </summary>
+        /// <remarks>
+        /// If a character with value <paramref name="codePoint"/> occurs in the
+        /// character sequence represented by this <see cref="ReadOnlySpan{Char}"/>
+        /// object at an index no smaller than <paramref name="startIndex"/>, then
+        /// the index of the first such occurrence is returned. For values
+        /// of <paramref name="codePoint"/> in the range from 0 to 0xFFFF (inclusive),
+        /// this is the smallest value <i>k</i> such that:
+        /// <code>
+        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is true. For other values of <code>ch</code>, it is the
+        /// smallest value <i>k</i> such that:
+        /// <code>
+        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is true. In either case, if no such character occurs in this
+        /// string at or after position <paramref name="startIndex"/>, then
+        /// <c>-1</c> is returned.
+        /// <para/>
+        /// There is no restriction on the value of <paramref name="startIndex"/>. If it
+        /// is negative, it has the same effect as if it were zero: this entire
+        /// string may be searched. If it is greater than the length of this
+        /// string, it has the same effect as if it were equal to the length of
+        /// this string: <c>-1</c> is returned.
+        /// <para/>
+        /// All indices are specified in <c>char</c> values
+        /// (Unicode code units).
+        /// </remarks>
+        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <param name="startIndex">The index to start the search from.</param>
+        /// <returns>The index of the first occurrence of the character in the
+        /// character sequence represented by this object that is greater
+        /// than or equal to <paramref name="startIndex"/>, or <c>-1</c>
+        /// if the character does not occur.
+        /// </returns>
+        public static int IndexOf(this ReadOnlySpan<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOf()
+        {
+            int textLength = text.Length;
+            if (startIndex < 0)
+            {
+                startIndex = 0;
+            }
+            else if (startIndex >= textLength)
+            {
+                // Note: fromIndex might be near -1>>>1.
+                return -1;
+            }
+
+            if (codePoint < Character.MinSupplementaryCodePoint)
+            {
+                // handle most cases here (ch is a BMP code point or a
+                // negative value (invalid code point))
+                if (codePoint >= Character.MinCodePoint)
+                    return System.MemoryExtensions.IndexOf(text.Slice(startIndex), (char)codePoint) + startIndex;
+
+                return -1;
+            }
+            else
+            {
+                unsafe
+                {
+                    fixed (char* textPtr = &MemoryMarshal.GetReference(text))
+                    return IndexOfSupplementary(textPtr, textLength, codePoint, startIndex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the first occurrence of
+        /// the specified character. If a character with value
+        /// <paramref name="codePoint"/> occurs in the character sequence represented by
+        /// this <see cref="Span{Char}"/> object, then the index (in Unicode
+        /// code units) of the first such occurrence is returned. For
+        /// values of <paramref name="codePoint"/> in the range from 0 to 0xFFFF
+        /// (inclusive), this is the smallest value <i>k</i> such that:
+        /// <code>
+        ///     this[(<i>k</i>] == <paramref name="codePoint"/>
+        /// </code>
+        /// is true. For other values of <paramref name="codePoint"/>, it is the
+        /// smallest value <i>k</i> such that:
+        /// <code>
+        ///     this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>
+        /// </code>
+        /// is true. In either case, if no such character occurs in this
+        /// string, then <c>-1</c> is returned.
+        /// </summary>
+        /// <param name="text">This <see cref="Span{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <returns>The index of the first occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int IndexOf(this Span<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.IndexOf()
+        {
+            return IndexOf(text, codePoint, 0);
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the first occurrence of the
+        /// specified character, starting the search at the specified index.
+        /// </summary>
+        /// <remarks>
+        /// If a character with value <paramref name="codePoint"/> occurs in the
+        /// character sequence represented by this <see cref="Span{Char}"/>
+        /// object at an index no smaller than <paramref name="startIndex"/>, then
+        /// the index of the first such occurrence is returned. For values
+        /// of <paramref name="codePoint"/> in the range from 0 to 0xFFFF (inclusive),
+        /// this is the smallest value <i>k</i> such that:
+        /// <code>
+        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is true. For other values of <code>ch</code>, it is the
+        /// smallest value <i>k</i> such that:
+        /// <code>
+        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is true. In either case, if no such character occurs in this
+        /// string at or after position <paramref name="startIndex"/>, then
+        /// <c>-1</c> is returned.
+        /// <para/>
+        /// There is no restriction on the value of <paramref name="startIndex"/>. If it
+        /// is negative, it has the same effect as if it were zero: this entire
+        /// string may be searched. If it is greater than the length of this
+        /// string, it has the same effect as if it were equal to the length of
+        /// this string: <c>-1</c> is returned.
+        /// <para/>
+        /// All indices are specified in <c>char</c> values
+        /// (Unicode code units).
+        /// </remarks>
+        /// <param name="text">This <see cref="Span{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <param name="startIndex">The index to start the search from.</param>
+        /// <returns>The index of the first occurrence of the character in the
+        /// character sequence represented by this object that is greater
+        /// than or equal to <paramref name="startIndex"/>, or <c>-1</c>
+        /// if the character does not occur.
+        /// </returns>
+        public static int IndexOf(this Span<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOf()
+        {
+            int textLength = text.Length;
+            if (startIndex < 0)
+            {
+                startIndex = 0;
+            }
+            else if (startIndex >= textLength)
+            {
+                // Note: fromIndex might be near -1>>>1.
+                return -1;
+            }
+
+            if (codePoint < Character.MinSupplementaryCodePoint)
+            {
+                // handle most cases here (ch is a BMP code point or a
+                // negative value (invalid code point))
+                if (codePoint >= Character.MinCodePoint)
+                    return System.MemoryExtensions.IndexOf(text.Slice(startIndex), (char)codePoint) + startIndex;
+
+                return -1;
+            }
+            else
+            {
+                unsafe
+                {
+                    fixed (char* textPtr = &MemoryMarshal.GetReference(text))
+                        return IndexOfSupplementary(textPtr, textLength, codePoint, startIndex);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles (rare) calls of indexOf with a supplementary character.
+        /// </summary>
+        private unsafe static int IndexOfSupplementary(char* text, int textLength, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOfSupplementary()
+        {
+            if (Character.IsValidCodePoint(codePoint))
+            {
+                Character.ToChars(codePoint, out char hi, out char lo); // J2N: Eliminated array allocation
+                int max = textLength - 1;
+                for (int i = startIndex; i < max; i++)
+                {
+                    if (text[i] == hi && text[i + 1] == lo)
+                    {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+#endif
+
+        #endregion IndexOf
+
+        #region LastIndexOf
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Returns the index within this string of the last occurrence of
+        /// the specified character. For values of <paramref name="codePoint"/> in the
+        /// range from 0 to 0xFFFF (inclusive), the index (in Unicode code
+        /// units) returned is the largest value <i>k</i> such that:
+        /// <code>
+        ///     this[<i>k</i>] == <paramref name="codePoint"/>
+        /// </code>
+        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
+        /// largest value in <i>k</i> such that:
+        /// <code>
+        ///     this.CodePointAt(<i>k</i>) = <paramref name="codePoint"/>
+        /// </code>
+        /// is <c>true</c>. In either case, if no such character occurs in this
+        /// string, then <c>-1</c> is returned.  The
+        /// <paramref name="text"/> is searched backwards starting at the last character.
+        /// </summary>
+        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <returns>
+        /// The index of the last occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int LastIndexOf(this ReadOnlySpan<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
+        {
+            return LastIndexOf(text, codePoint, text.Length - 1);
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the last occurrence of
+        /// the specified character, searching backward starting at the
+        /// specified index. For values of <paramref name="codePoint"/> in the range
+        /// from 0 to 0xFFFF (inclusive), the index returned is the largest
+        /// value <i>k</i> such that:
+        /// <code>
+        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
+        /// largest value <i>k</i> such that:
+        /// <code>
+        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is <c>true</c>. In either case, if no such character occurs in this
+        /// string at or before position <paramref name="startIndex"/>, then
+        /// <c>-1</c> is returned.
+        /// <para/>
+        /// All indices are specified in <see cref="char"/> values
+        /// (Unicode code units).
+        /// </summary>
+        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <param name="startIndex">
+        /// The index to start the search from. There is no
+        /// restriction on the value of <paramref name="startIndex"/>. If it is
+        /// greater than or equal to the length of this string, it has
+        /// the same effect as if it were equal to one less than the
+        /// length of this string: this entire string may be searched.
+        /// If it is negative, it has the same effect as if it were <c>-1</c>:
+        /// </param>
+        /// <returns>
+        /// The index of the last occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int LastIndexOf(this ReadOnlySpan<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
+        {
+            if (codePoint < Character.MinSupplementaryCodePoint)
+            {
+                // handle most cases here (ch is a BMP code point or a
+                // negative value (invalid code point))
+                if (codePoint >= Character.MinCodePoint)
+                    return System.MemoryExtensions.LastIndexOf(text.Slice(0, Math.Min(startIndex + 1, text.Length)), (char)codePoint);
+
+                return -1;
+            }
+            else
+            {
+                unsafe
+                {
+                    fixed (char* textPtr = &MemoryMarshal.GetReference(text))
+                    {
+                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint, startIndex);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the last occurrence of
+        /// the specified character. For values of <paramref name="codePoint"/> in the
+        /// range from 0 to 0xFFFF (inclusive), the index (in Unicode code
+        /// units) returned is the largest value <i>k</i> such that:
+        /// <code>
+        ///     this[<i>k</i>] == <paramref name="codePoint"/>
+        /// </code>
+        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
+        /// largest value in <i>k</i> such that:
+        /// <code>
+        ///     this.CodePointAt(<i>k</i>) = <paramref name="codePoint"/>
+        /// </code>
+        /// is <c>true</c>. In either case, if no such character occurs in this
+        /// string, then <c>-1</c> is returned.  The
+        /// <paramref name="text"/> is searched backwards starting at the last character.
+        /// </summary>
+        /// <param name="text">This <see cref="Span{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <returns>
+        /// The index of the last occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int LastIndexOf(this Span<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
+        {
+            return LastIndexOf(text, codePoint, text.Length - 1);
+        }
+
+        /// <summary>
+        /// Returns the index within this string of the last occurrence of
+        /// the specified character, searching backward starting at the
+        /// specified index. For values of <paramref name="codePoint"/> in the range
+        /// from 0 to 0xFFFF (inclusive), the index returned is the largest
+        /// value <i>k</i> such that:
+        /// <code>
+        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
+        /// largest value <i>k</i> such that:
+        /// <code>
+        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
+        /// </code>
+        /// is <c>true</c>. In either case, if no such character occurs in this
+        /// string at or before position <paramref name="startIndex"/>, then
+        /// <c>-1</c> is returned.
+        /// <para/>
+        /// All indices are specified in <see cref="char"/> values
+        /// (Unicode code units).
+        /// </summary>
+        /// <param name="text">This <see cref="Span{Char}"/>.</param>
+        /// <param name="codePoint">A character (Unicode code point).</param>
+        /// <param name="startIndex">
+        /// The index to start the search from. There is no
+        /// restriction on the value of <paramref name="startIndex"/>. If it is
+        /// greater than or equal to the length of this string, it has
+        /// the same effect as if it were equal to one less than the
+        /// length of this string: this entire string may be searched.
+        /// If it is negative, it has the same effect as if it were <c>-1</c>:
+        /// </param>
+        /// <returns>
+        /// The index of the last occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
+        public static int LastIndexOf(this Span<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
+        {
+            if (codePoint < Character.MinSupplementaryCodePoint)
+            {
+                // handle most cases here (ch is a BMP code point or a
+                // negative value (invalid code point))
+                if (codePoint >= Character.MinCodePoint)
+                    return System.MemoryExtensions.LastIndexOf(text.Slice(0, Math.Min(startIndex + 1, text.Length)), (char)codePoint);
+
+                return -1;
+            }
+            else
+            {
+                unsafe
+                {
+                    fixed (char* textPtr = &MemoryMarshal.GetReference(text))
+                    {
+                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint, startIndex);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles (rare) calls of lastIndexOf with a supplementary character.
+        /// </summary>
+        private unsafe static int LastIndexOfSupplementary(char* text, int textLength, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOfSupplementary()
+        {
+            if (Character.IsValidCodePoint(codePoint))
+            {
+                Character.ToChars(codePoint, out char hi, out char lo); // J2N: Eliminated array allocation
+                int i = Math.Min(startIndex, textLength - 2);
+                for (; i >= 0; i--)
+                {
+                    if (text[i] == hi && text[i + 1] == lo)
+                    {
+                        return i;
+                    }
+                }
+            }
+            return -1;
+        }
+
+#endif
+
+        #endregion LastIndexOf
+
         #region Reverse
 
 #if FEATURE_SPAN

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -40,68 +40,12 @@ namespace J2N
         /// </returns>
         public static int IndexOf(this ReadOnlySpan<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.IndexOf()
         {
-            return IndexOf(text, codePoint, 0);
-        }
-
-        /// <summary>
-        /// Returns the index within this string of the first occurrence of the
-        /// specified character, starting the search at the specified index.
-        /// </summary>
-        /// <remarks>
-        /// If a character with value <paramref name="codePoint"/> occurs in the
-        /// character sequence represented by this <see cref="ReadOnlySpan{Char}"/>
-        /// object at an index no smaller than <paramref name="startIndex"/>, then
-        /// the index of the first such occurrence is returned. For values
-        /// of <paramref name="codePoint"/> in the range from 0 to 0xFFFF (inclusive),
-        /// this is the smallest value <i>k</i> such that:
-        /// <code>
-        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is true. For other values of <code>ch</code>, it is the
-        /// smallest value <i>k</i> such that:
-        /// <code>
-        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is true. In either case, if no such character occurs in this
-        /// string at or after position <paramref name="startIndex"/>, then
-        /// <c>-1</c> is returned.
-        /// <para/>
-        /// There is no restriction on the value of <paramref name="startIndex"/>. If it
-        /// is negative, it has the same effect as if it were zero: this entire
-        /// string may be searched. If it is greater than the length of this
-        /// string, it has the same effect as if it were equal to the length of
-        /// this string: <c>-1</c> is returned.
-        /// <para/>
-        /// All indices are specified in <c>char</c> values
-        /// (Unicode code units).
-        /// </remarks>
-        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
-        /// <param name="codePoint">A character (Unicode code point).</param>
-        /// <param name="startIndex">The index to start the search from.</param>
-        /// <returns>The index of the first occurrence of the character in the
-        /// character sequence represented by this object that is greater
-        /// than or equal to <paramref name="startIndex"/>, or <c>-1</c>
-        /// if the character does not occur.
-        /// </returns>
-        public static int IndexOf(this ReadOnlySpan<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOf()
-        {
-            int textLength = text.Length;
-            if (startIndex < 0)
-            {
-                startIndex = 0;
-            }
-            else if (startIndex >= textLength)
-            {
-                // Note: fromIndex might be near -1>>>1.
-                return -1;
-            }
-
             if (codePoint < Character.MinSupplementaryCodePoint)
             {
                 // handle most cases here (ch is a BMP code point or a
                 // negative value (invalid code point))
                 if (codePoint >= Character.MinCodePoint)
-                    return System.MemoryExtensions.IndexOf(text.Slice(startIndex), (char)codePoint) + startIndex;
+                    return System.MemoryExtensions.IndexOf(text, (char)codePoint);
 
                 return -1;
             }
@@ -110,7 +54,9 @@ namespace J2N
                 unsafe
                 {
                     fixed (char* textPtr = &MemoryMarshal.GetReference(text))
-                    return IndexOfSupplementary(textPtr, textLength, codePoint, startIndex);
+                    {
+                        return IndexOfSupplementary(textPtr, text.Length, codePoint);
+                    }
                 }
             }
         }
@@ -142,68 +88,12 @@ namespace J2N
         /// </returns>
         public static int IndexOf(this Span<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.IndexOf()
         {
-            return IndexOf(text, codePoint, 0);
-        }
-
-        /// <summary>
-        /// Returns the index within this string of the first occurrence of the
-        /// specified character, starting the search at the specified index.
-        /// </summary>
-        /// <remarks>
-        /// If a character with value <paramref name="codePoint"/> occurs in the
-        /// character sequence represented by this <see cref="Span{Char}"/>
-        /// object at an index no smaller than <paramref name="startIndex"/>, then
-        /// the index of the first such occurrence is returned. For values
-        /// of <paramref name="codePoint"/> in the range from 0 to 0xFFFF (inclusive),
-        /// this is the smallest value <i>k</i> such that:
-        /// <code>
-        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is true. For other values of <code>ch</code>, it is the
-        /// smallest value <i>k</i> such that:
-        /// <code>
-        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &gt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is true. In either case, if no such character occurs in this
-        /// string at or after position <paramref name="startIndex"/>, then
-        /// <c>-1</c> is returned.
-        /// <para/>
-        /// There is no restriction on the value of <paramref name="startIndex"/>. If it
-        /// is negative, it has the same effect as if it were zero: this entire
-        /// string may be searched. If it is greater than the length of this
-        /// string, it has the same effect as if it were equal to the length of
-        /// this string: <c>-1</c> is returned.
-        /// <para/>
-        /// All indices are specified in <c>char</c> values
-        /// (Unicode code units).
-        /// </remarks>
-        /// <param name="text">This <see cref="Span{Char}"/>.</param>
-        /// <param name="codePoint">A character (Unicode code point).</param>
-        /// <param name="startIndex">The index to start the search from.</param>
-        /// <returns>The index of the first occurrence of the character in the
-        /// character sequence represented by this object that is greater
-        /// than or equal to <paramref name="startIndex"/>, or <c>-1</c>
-        /// if the character does not occur.
-        /// </returns>
-        public static int IndexOf(this Span<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOf()
-        {
-            int textLength = text.Length;
-            if (startIndex < 0)
-            {
-                startIndex = 0;
-            }
-            else if (startIndex >= textLength)
-            {
-                // Note: fromIndex might be near -1>>>1.
-                return -1;
-            }
-
             if (codePoint < Character.MinSupplementaryCodePoint)
             {
                 // handle most cases here (ch is a BMP code point or a
                 // negative value (invalid code point))
                 if (codePoint >= Character.MinCodePoint)
-                    return System.MemoryExtensions.IndexOf(text.Slice(startIndex), (char)codePoint) + startIndex;
+                    return System.MemoryExtensions.IndexOf(text, (char)codePoint);
 
                 return -1;
             }
@@ -212,7 +102,9 @@ namespace J2N
                 unsafe
                 {
                     fixed (char* textPtr = &MemoryMarshal.GetReference(text))
-                        return IndexOfSupplementary(textPtr, textLength, codePoint, startIndex);
+                    {
+                        return IndexOfSupplementary(textPtr, text.Length, codePoint);
+                    }
                 }
             }
         }
@@ -220,13 +112,13 @@ namespace J2N
         /// <summary>
         /// Handles (rare) calls of indexOf with a supplementary character.
         /// </summary>
-        private unsafe static int IndexOfSupplementary(char* text, int textLength, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.IndexOfSupplementary()
+        private unsafe static int IndexOfSupplementary(char* text, int textLength, int codePoint) // KEEP IN SYNC WITH StringExtensions.IndexOfSupplementary()
         {
             if (Character.IsValidCodePoint(codePoint))
             {
                 Character.ToChars(codePoint, out char hi, out char lo); // J2N: Eliminated array allocation
                 int max = textLength - 1;
-                for (int i = startIndex; i < max; i++)
+                for (int i = 0; i < max; i++)
                 {
                     if (text[i] == hi && text[i + 1] == lo)
                     {
@@ -271,53 +163,12 @@ namespace J2N
         /// </returns>
         public static int LastIndexOf(this ReadOnlySpan<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
         {
-            return LastIndexOf(text, codePoint, text.Length - 1);
-        }
-
-        /// <summary>
-        /// Returns the index within this string of the last occurrence of
-        /// the specified character, searching backward starting at the
-        /// specified index. For values of <paramref name="codePoint"/> in the range
-        /// from 0 to 0xFFFF (inclusive), the index returned is the largest
-        /// value <i>k</i> such that:
-        /// <code>
-        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
-        /// largest value <i>k</i> such that:
-        /// <code>
-        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is <c>true</c>. In either case, if no such character occurs in this
-        /// string at or before position <paramref name="startIndex"/>, then
-        /// <c>-1</c> is returned.
-        /// <para/>
-        /// All indices are specified in <see cref="char"/> values
-        /// (Unicode code units).
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{Char}"/>.</param>
-        /// <param name="codePoint">A character (Unicode code point).</param>
-        /// <param name="startIndex">
-        /// The index to start the search from. There is no
-        /// restriction on the value of <paramref name="startIndex"/>. If it is
-        /// greater than or equal to the length of this string, it has
-        /// the same effect as if it were equal to one less than the
-        /// length of this string: this entire string may be searched.
-        /// If it is negative, it has the same effect as if it were <c>-1</c>:
-        /// </param>
-        /// <returns>
-        /// The index of the last occurrence of the character in the
-        /// character sequence represented by this object, or
-        /// <c>-1</c> if the character does not occur.
-        /// </returns>
-        public static int LastIndexOf(this ReadOnlySpan<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
-        {
             if (codePoint < Character.MinSupplementaryCodePoint)
             {
                 // handle most cases here (ch is a BMP code point or a
                 // negative value (invalid code point))
                 if (codePoint >= Character.MinCodePoint)
-                    return System.MemoryExtensions.LastIndexOf(text.Slice(0, Math.Min(startIndex + 1, text.Length)), (char)codePoint);
+                    return System.MemoryExtensions.LastIndexOf(text, (char)codePoint);
 
                 return -1;
             }
@@ -327,7 +178,7 @@ namespace J2N
                 {
                     fixed (char* textPtr = &MemoryMarshal.GetReference(text))
                     {
-                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint, startIndex);
+                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint);
                     }
                 }
             }
@@ -359,53 +210,12 @@ namespace J2N
         /// </returns>
         public static int LastIndexOf(this Span<char> text, int codePoint) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
         {
-            return LastIndexOf(text, codePoint, text.Length - 1);
-        }
-
-        /// <summary>
-        /// Returns the index within this string of the last occurrence of
-        /// the specified character, searching backward starting at the
-        /// specified index. For values of <paramref name="codePoint"/> in the range
-        /// from 0 to 0xFFFF (inclusive), the index returned is the largest
-        /// value <i>k</i> such that:
-        /// <code>
-        ///     (this[<i>k</i>] == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is <c>true</c>. For other values of <paramref name="codePoint"/>, it is the
-        /// largest value <i>k</i> such that:
-        /// <code>
-        ///     (this.CodePointAt(<i>k</i>) == <paramref name="codePoint"/>) &amp;&amp; (<i>k</i> &lt;= <paramref name="startIndex"/>)
-        /// </code>
-        /// is <c>true</c>. In either case, if no such character occurs in this
-        /// string at or before position <paramref name="startIndex"/>, then
-        /// <c>-1</c> is returned.
-        /// <para/>
-        /// All indices are specified in <see cref="char"/> values
-        /// (Unicode code units).
-        /// </summary>
-        /// <param name="text">This <see cref="Span{Char}"/>.</param>
-        /// <param name="codePoint">A character (Unicode code point).</param>
-        /// <param name="startIndex">
-        /// The index to start the search from. There is no
-        /// restriction on the value of <paramref name="startIndex"/>. If it is
-        /// greater than or equal to the length of this string, it has
-        /// the same effect as if it were equal to one less than the
-        /// length of this string: this entire string may be searched.
-        /// If it is negative, it has the same effect as if it were <c>-1</c>:
-        /// </param>
-        /// <returns>
-        /// The index of the last occurrence of the character in the
-        /// character sequence represented by this object, or
-        /// <c>-1</c> if the character does not occur.
-        /// </returns>
-        public static int LastIndexOf(this Span<char> text, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOf()
-        {
             if (codePoint < Character.MinSupplementaryCodePoint)
             {
                 // handle most cases here (ch is a BMP code point or a
                 // negative value (invalid code point))
                 if (codePoint >= Character.MinCodePoint)
-                    return System.MemoryExtensions.LastIndexOf(text.Slice(0, Math.Min(startIndex + 1, text.Length)), (char)codePoint);
+                    return System.MemoryExtensions.LastIndexOf(text, (char)codePoint);
 
                 return -1;
             }
@@ -415,7 +225,7 @@ namespace J2N
                 {
                     fixed (char* textPtr = &MemoryMarshal.GetReference(text))
                     {
-                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint, startIndex);
+                        return LastIndexOfSupplementary(textPtr, text.Length, codePoint);
                     }
                 }
             }
@@ -424,13 +234,12 @@ namespace J2N
         /// <summary>
         /// Handles (rare) calls of lastIndexOf with a supplementary character.
         /// </summary>
-        private unsafe static int LastIndexOfSupplementary(char* text, int textLength, int codePoint, int startIndex) // KEEP IN SYNC WITH StringExtensions.LastIndexOfSupplementary()
+        private unsafe static int LastIndexOfSupplementary(char* text, int textLength, int codePoint) // KEEP IN SYNC WITH StringExtensions.LastIndexOfSupplementary()
         {
             if (Character.IsValidCodePoint(codePoint))
             {
                 Character.ToChars(codePoint, out char hi, out char lo); // J2N: Eliminated array allocation
-                int i = Math.Min(startIndex, textLength - 2);
-                for (; i >= 0; i--)
+                for (int i = textLength - 2; i >= 0; i--)
                 {
                     if (text[i] == hi && text[i + 1] == lo)
                     {

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace J2N.Memory
+namespace J2N
 {
     /// <summary>
     /// Extensions to System.Memory types.

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace J2N
 {
     /// <summary>
-    /// Extensions to System.Memory types.
+    /// Extensions to <see cref="Span{T}"/> and <see cref="ReadOnlySpan{T}"/>.
     /// </summary>
     public static class MemoryExtensions
     {

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace J2N
@@ -12,6 +13,38 @@ namespace J2N
         #region IndexOf
 
 #if FEATURE_SPAN
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence.
+        /// <para/>
+        /// This method simply cascades the call to <see cref="System.MemoryExtensions.IndexOf{T}(ReadOnlySpan{T}, T)"/>.
+        /// Its purpose is to avoid the overhead of casting to an <see cref="int"/> and back to <see cref="char"/> when
+        /// calling <see cref="IndexOf(ReadOnlySpan{char}, int)"/> with a <see cref="char"/>. If this method did not exist,
+        /// the compiler would always choose <see cref="IndexOf(ReadOnlySpan{char}, int)"/> instead of
+        /// <see cref="System.MemoryExtensions.IndexOf{T}(ReadOnlySpan{T}, T)"/> when the type of <c>T</c> is <see cref="char"/>.
+        /// </summary>
+        /// <param name="text">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<char> text, char value)
+            => System.MemoryExtensions.IndexOf(text, value);
+
+        /// <summary>
+        /// Searches for the specified sequence and returns the index of its first occurrence.
+        /// <para/>
+        /// This method simply cascades the call to <see cref="System.MemoryExtensions.IndexOf{T}(Span{T}, T)"/>.
+        /// Its purpose is to avoid the overhead of casting to an <see cref="int"/> and back to <see cref="char"/> when
+        /// calling <see cref="IndexOf(Span{char}, int)"/> with a <see cref="char"/>. If this method did not exist,
+        /// the compiler would always choose <see cref="IndexOf(Span{char}, int)"/> instead of
+        /// <see cref="System.MemoryExtensions.IndexOf{T}(Span{T}, T)"/> when the type of <c>T</c> is <see cref="char"/>.
+        /// </summary>
+        /// <param name="text">The span to search.</param>
+        /// <param name="value">The value to search for.</param>
+        /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<char> text, char value)
+            => System.MemoryExtensions.IndexOf(text, value);
 
         /// <summary>
         /// Returns the index within this string of the first occurrence of
@@ -136,6 +169,38 @@ namespace J2N
         #region LastIndexOf
 
 #if FEATURE_SPAN
+
+        ///// <summary>
+        ///// Searches for the specified value and returns the index of its last occurrence.
+        ///// <para/>
+        ///// This method simply cascades the call to <see cref="System.MemoryExtensions.LastIndexOf{T}(ReadOnlySpan{T}, T)"/>.
+        ///// Its purpose is to avoid the overhead of casting to an <see cref="int"/> and back to <see cref="char"/> when
+        ///// calling <see cref="LastIndexOf(ReadOnlySpan{char}, int)"/> with a <see cref="char"/>. If this method did not exist,
+        ///// the compiler would always choose <see cref="LastIndexOf(ReadOnlySpan{char}, int)"/> instead of
+        ///// <see cref="System.MemoryExtensions.LastIndexOf{T}(ReadOnlySpan{T}, T)"/> when the type of <c>T</c> is <see cref="char"/>.
+        ///// </summary>
+        ///// <param name="text">The span to search.</param>
+        ///// <param name="value">The value to search for.</param>
+        ///// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //public static int LastIndexOf(this ReadOnlySpan<char> text, char value)
+        //    => System.MemoryExtensions.LastIndexOf(text, value);
+
+        ///// <summary>
+        ///// Searches for the specified value and returns the index of its last occurrence.
+        ///// <para/>
+        ///// This method simply cascades the call to <see cref="System.MemoryExtensions.LastIndexOf{T}(Span{T}, T)"/>.
+        ///// Its purpose is to avoid the overhead of casting to an <see cref="int"/> and back to <see cref="char"/> when
+        ///// calling <see cref="LastIndexOf(Span{char}, int)"/> with a <see cref="char"/>. If this method did not exist,
+        ///// the compiler would always choose <see cref="LastIndexOf(Span{char}, int)"/> instead of
+        ///// <see cref="System.MemoryExtensions.LastIndexOf{T}(Span{T}, T)"/> when the type of <c>T</c> is <see cref="char"/>.
+        ///// </summary>
+        ///// <param name="text">The span to search.</param>
+        ///// <param name="value">The value to search for.</param>
+        ///// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //public static int LastIndexOf(this Span<char> text, char value)
+        //    => System.MemoryExtensions.LastIndexOf(text, value);
 
         /// <summary>
         /// Returns the index within this string of the last occurrence of

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -537,7 +537,7 @@ namespace J2N.Text
         /// <c>-1</c> if the character does not occur.
         /// </returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static int IndexOf(this string text, int codePoint)
+        public static int IndexOf(this string text, int codePoint) // KEEP IN SYNC WITH MemoryExtensions.IndexOf()
         {
             return IndexOf(text, codePoint, 0);
         }
@@ -583,7 +583,7 @@ namespace J2N.Text
         /// if the character does not occur.
         /// </returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static int IndexOf(this string text, int codePoint, int startIndex)
+        public static int IndexOf(this string text, int codePoint, int startIndex) // KEEP IN SYNC WITH MemoryExtensions.IndexOf()
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -616,10 +616,7 @@ namespace J2N.Text
         /// <summary>
         /// Handles (rare) calls of indexOf with a supplementary character.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
-        private static int IndexOfSupplementary(this string text, int codePoint, int startIndex)
+        private static int IndexOfSupplementary(this string text, int codePoint, int startIndex) // KEEP IN SYNC WITH MemoryExtensions.IndexOfSupplementary()
         {
             if (Character.IsValidCodePoint(codePoint))
             {
@@ -686,7 +683,7 @@ namespace J2N.Text
         /// <c>-1</c> if the character does not occur.
         /// </returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static int LastIndexOf(this string text, int codePoint)
+        public static int LastIndexOf(this string text, int codePoint) // KEEP IN SYNC WITH MemoryExtensions.LastIndexOf()
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -725,9 +722,13 @@ namespace J2N.Text
         /// length of this string: this entire string may be searched.
         /// If it is negative, it has the same effect as if it were <c>-1</c>:
         /// </param>
-        /// <returns></returns>
+        /// <returns>
+        /// The index of the last occurrence of the character in the
+        /// character sequence represented by this object, or
+        /// <c>-1</c> if the character does not occur.
+        /// </returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c>.</exception>
-        public static int LastIndexOf(this string text, int codePoint, int startIndex)
+        public static int LastIndexOf(this string text, int codePoint, int startIndex) // KEEP IN SYNC WITH MemoryExtensions.LastIndexOf()
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -750,10 +751,7 @@ namespace J2N.Text
         /// <summary>
         /// Handles (rare) calls of lastIndexOf with a supplementary character.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
-        private static int LastIndexOfSupplementary(this string text, int codePoint, int startIndex)
+        private static int LastIndexOfSupplementary(this string text, int codePoint, int startIndex) // KEEP IN SYNC WITH MemoryExtensions.LastIndexOfSupplementary()
         {
             if (Character.IsValidCodePoint(codePoint))
             {

--- a/tests/J2N.Tests/Memory/TestMemoryExtensions.cs
+++ b/tests/J2N.Tests/Memory/TestMemoryExtensions.cs
@@ -5,7 +5,119 @@ namespace J2N.Memory
 {
     public class TestMemoryExtensions : TestCase
     {
+        private const string hw1 = "HelloWorld";
+        private const string TestStringSupplementary = "李红：不，那不是杂志。那是字典。𠳕";
+
 #if FEATURE_SPAN
+
+        /**
+         * @tests java.lang.String#indexOf(int)
+         */
+        [Test]
+        public void Test_IndexOf_ReadOnlySpan_Int32()
+        {
+            // Test for method int java.lang.String.indexOf(int)
+            assertEquals("Invalid index returned", 1, hw1.AsSpan().IndexOf((int)'e'));
+            assertEquals("Invalid index returned", 1, "a\ud800\udc00".AsSpan().IndexOf(0x10000));
+
+            MemoryExtensions.IndexOf(TestStringSupplementary.AsSpan(), "𠳕".CodePointAt(0));
+        }
+
+        /**
+         * @tests java.lang.String#indexOf(int, int)
+         */
+        [Test]
+        public void Test_IndexOf_ReadOnlySpan_Int32_Int32()
+        {
+            // Test for method int java.lang.String.indexOf(int, int)
+            assertEquals("Invalid character index returned", 5, hw1.AsSpan().IndexOf((int)'W', 2));
+            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".AsSpan().IndexOf(0x10000, 1));
+        }
+
+        /**
+         * @tests java.lang.String#lastIndexOf(int)
+         */
+        [Test]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32()
+        {
+            // Test for method int java.lang.String.lastIndexOf(int)
+            assertEquals("Failed to return correct index", 5, hw1.AsSpan().LastIndexOf((int)'W'));
+            assertEquals("Returned index for non-existent char", -1, hw1.AsSpan()
+                    .LastIndexOf((int)'Z'));
+            assertEquals("Failed to return correct index", 1, "a\ud800\udc00".AsSpan()
+                    .LastIndexOf(0x10000));
+        }
+
+        /**
+         * @tests java.lang.String#lastIndexOf(int, int)
+         */
+        [Test]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32_Int32()
+        {
+            // Test for method int java.lang.String.lastIndexOf(int, int)
+            assertEquals("Failed to return correct index", 5, hw1.AsSpan().LastIndexOf((int)'W',
+                    6));
+            assertEquals("Returned index for char out of specified range", -1, hw1.AsSpan()
+                    .LastIndexOf((int)'W', 4));
+            assertEquals("Returned index for non-existent char", -1, hw1.AsSpan()
+                    .LastIndexOf((int)'Z', 9));
+        }
+
+
+        /**
+         * @tests java.lang.String#indexOf(int)
+         */
+        [Test]
+        public void Test_IndexOf_Span_Int32()
+        {
+            // Test for method int java.lang.String.indexOf(int)
+            assertEquals("Invalid index returned", 1, hw1.ToCharArray().AsSpan().IndexOf((int)'e'));
+            assertEquals("Invalid index returned", 1, "a\ud800\udc00".ToCharArray().AsSpan().IndexOf(0x10000));
+
+            MemoryExtensions.IndexOf(TestStringSupplementary.ToCharArray().AsSpan(), "𠳕".CodePointAt(0));
+        }
+
+        /**
+         * @tests java.lang.String#indexOf(int, int)
+         */
+        [Test]
+        public void Test_IndexOf_Span_Int32_Int32()
+        {
+            // Test for method int java.lang.String.indexOf(int, int)
+            assertEquals("Invalid character index returned", 5, hw1.ToCharArray().AsSpan().IndexOf((int)'W', 2));
+            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".ToCharArray().AsSpan().IndexOf(0x10000, 1));
+        }
+
+        /**
+         * @tests java.lang.String#lastIndexOf(int)
+         */
+        [Test]
+        public void Test_LastIndexOf_Span_Int32()
+        {
+            // Test for method int java.lang.String.lastIndexOf(int)
+            assertEquals("Failed to return correct index", 5, hw1.ToCharArray().AsSpan().LastIndexOf((int)'W'));
+            assertEquals("Returned index for non-existent char", -1, hw1.ToCharArray().AsSpan()
+                    .LastIndexOf((int)'Z'));
+            assertEquals("Failed to return correct index", 1, "a\ud800\udc00".ToCharArray().AsSpan()
+                    .LastIndexOf(0x10000));
+        }
+
+        /**
+         * @tests java.lang.String#lastIndexOf(int, int)
+         */
+        [Test]
+        public void Test_LastIndexOf_Span_Int32_Int32()
+        {
+            // Test for method int java.lang.String.lastIndexOf(int, int)
+            assertEquals("Failed to return correct index", 5, hw1.ToCharArray().AsSpan().LastIndexOf((int)'W',
+                    6));
+            assertEquals("Returned index for char out of specified range", -1, hw1.ToCharArray().AsSpan()
+                    .LastIndexOf((int)'W', 4));
+            assertEquals("Returned index for non-existent char", -1, hw1.ToCharArray().AsSpan()
+                    .LastIndexOf((int)'Z', 9));
+        }
+
+
         private void reverseTest(string org, string rev, string back)
         {
             {

--- a/tests/J2N.Tests/TestMemoryExtensions.cs
+++ b/tests/J2N.Tests/TestMemoryExtensions.cs
@@ -26,12 +26,12 @@ namespace J2N
         /**
          * @tests java.lang.String#indexOf(int, int)
          */
-        [Test]
+        [Test] // J2N: Verify we can use "startIndex" by slicing the Span
         public void Test_IndexOf_ReadOnlySpan_Int32_Int32()
         {
             // Test for method int java.lang.String.indexOf(int, int)
-            assertEquals("Invalid character index returned", 5, hw1.AsSpan().IndexOf((int)'W', 2));
-            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".AsSpan().IndexOf(0x10000, 1));
+            assertEquals("Invalid character index returned", 5, hw1.AsSpan(2).IndexOf((int)'W') + 2);
+            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".AsSpan(1).IndexOf(0x10000) + 1);
         }
 
         /**
@@ -51,16 +51,15 @@ namespace J2N
         /**
          * @tests java.lang.String#lastIndexOf(int, int)
          */
-        [Test]
+        [Test] // J2N: Verify we can use "startIndex" by slicing the Span
         public void Test_LastIndexOf_ReadOnlySpan_Int32_Int32()
         {
             // Test for method int java.lang.String.lastIndexOf(int, int)
-            assertEquals("Failed to return correct index", 5, hw1.AsSpan().LastIndexOf((int)'W',
-                    6));
-            assertEquals("Returned index for char out of specified range", -1, hw1.AsSpan()
-                    .LastIndexOf((int)'W', 4));
-            assertEquals("Returned index for non-existent char", -1, hw1.AsSpan()
-                    .LastIndexOf((int)'Z', 9));
+            assertEquals("Failed to return correct index", 5, hw1.AsSpan(0, 6 + 1).LastIndexOf((int)'W'));
+            assertEquals("Returned index for char out of specified range", -1, hw1.AsSpan(0, 4 + 1)
+                    .LastIndexOf((int)'W'));
+            assertEquals("Returned index for non-existent char", -1, hw1.AsSpan(0, 9 + 1)
+                    .LastIndexOf((int)'Z'));
         }
 
 
@@ -80,12 +79,12 @@ namespace J2N
         /**
          * @tests java.lang.String#indexOf(int, int)
          */
-        [Test]
+        [Test] // J2N: Verify we can use "startIndex" by slicing the Span
         public void Test_IndexOf_Span_Int32_Int32()
         {
             // Test for method int java.lang.String.indexOf(int, int)
-            assertEquals("Invalid character index returned", 5, hw1.ToCharArray().AsSpan().IndexOf((int)'W', 2));
-            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".ToCharArray().AsSpan().IndexOf(0x10000, 1));
+            assertEquals("Invalid character index returned", 5, hw1.ToCharArray().AsSpan(2).IndexOf((int)'W') + 2);
+            assertEquals("Invalid index returned", 2, "ab\ud800\udc00".ToCharArray().AsSpan(1).IndexOf(0x10000) + 1);
         }
 
         /**
@@ -105,16 +104,15 @@ namespace J2N
         /**
          * @tests java.lang.String#lastIndexOf(int, int)
          */
-        [Test]
+        [Test] // J2N: Verify we can use "startIndex" by slicing the Span
         public void Test_LastIndexOf_Span_Int32_Int32()
         {
             // Test for method int java.lang.String.lastIndexOf(int, int)
-            assertEquals("Failed to return correct index", 5, hw1.ToCharArray().AsSpan().LastIndexOf((int)'W',
-                    6));
-            assertEquals("Returned index for char out of specified range", -1, hw1.ToCharArray().AsSpan()
-                    .LastIndexOf((int)'W', 4));
-            assertEquals("Returned index for non-existent char", -1, hw1.ToCharArray().AsSpan()
-                    .LastIndexOf((int)'Z', 9));
+            assertEquals("Failed to return correct index", 5, hw1.ToCharArray().AsSpan(0, 6 + 1).LastIndexOf((int)'W'));
+            assertEquals("Returned index for char out of specified range", -1, hw1.ToCharArray().AsSpan(0, 4 + 1)
+                    .LastIndexOf((int)'W'));
+            assertEquals("Returned index for non-existent char", -1, hw1.ToCharArray().AsSpan(0, 9 + 1)
+                    .LastIndexOf((int)'Z'));
         }
 
 

--- a/tests/J2N.Tests/TestMemoryExtensions.cs
+++ b/tests/J2N.Tests/TestMemoryExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 
-namespace J2N.Memory
+namespace J2N
 {
     public class TestMemoryExtensions : TestCase
     {


### PR DESCRIPTION
This moves `MemoryExtensions` from the J2N.Memory namespace (unreleased) to the J2N namespace.

New APIs:

```c#
namespace J2N
{
    public static class MemoryExtensions
    {
        public static int IndexOf(this ReadOnlySpan<char> text, char value);
        public static int IndexOf(this Span<char> text, char value);
        public static int IndexOf(this ReadOnlySpan<char> text, int codePoint);
        public static int IndexOf(this Span<char> text, int codePoint);
        public static int LastIndexOf(this ReadOnlySpan<char> text, char value);
        public static int LastIndexOf(this Span<char> text, char value);
        public static int LastIndexOf(this ReadOnlySpan<char> text, int codePoint);
        public static int LastIndexOf(this Span<char> text, int codePoint);
    }
}
```

The `char` overloads are only provided to cascade the call to [`System.MemoryExtensions.IndexOf<T>(Span<T>, T)`](https://learn.microsoft.com/en-us/dotnet/api/system.memoryextensions.indexof?view=net-8.0#system-memoryextensions-indexof-1(system-span((-0))-0)), since the compiler otherwise prefers the `int` overload if you pass a `char`.