### PR TITLE
J2N.Text.StringExtensions: Added ReadOnlySpan<char> overload to RegionMatches()

### DIFF
--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -337,7 +337,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string? text, ICharSequence? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, ICharSequence? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -359,7 +359,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string? text, char[]? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, char[]? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -381,7 +381,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string? text, StringBuilder? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, StringBuilder? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -403,7 +403,7 @@ namespace J2N.Text
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif 
-        public static bool ContentEquals(this string? text, string? charSequence) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, string? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
         }
@@ -424,7 +424,7 @@ namespace J2N.Text
         /// <param name="charSequence">The character sequence to compare to.</param>
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
-        public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence)
+        public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence == default;
@@ -454,7 +454,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string? text, ICharSequence? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, ICharSequence? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence is null || !charSequence.HasValue;
@@ -489,7 +489,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string? text, char[]? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, char[]? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence is null;
@@ -519,7 +519,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string? text, StringBuilder? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, StringBuilder? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence is null;
@@ -549,7 +549,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string? text, string? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool ContentEquals(this string? text, string? charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence is null;
@@ -581,7 +581,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence, StringComparison comparisonType)
+        public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 return charSequence == default;
@@ -897,7 +897,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="other"/> is <c>null</c></exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool RegionMatches(this string text, int thisStartIndex, ICharSequence other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool RegionMatches(this string text, int thisStartIndex, ICharSequence other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -963,7 +963,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="other"/> is <c>null</c></exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool RegionMatches(this string text, int thisStartIndex, char[] other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool RegionMatches(this string text, int thisStartIndex, char[] other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -1024,7 +1024,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="other"/> is <c>null</c></exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool RegionMatches(this string text, int thisStartIndex, StringBuilder other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool RegionMatches(this string text, int thisStartIndex, StringBuilder other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -1121,7 +1121,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> or <paramref name="other"/> is <c>null</c></exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool RegionMatches(this string text, int thisStartIndex, string other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool RegionMatches(this string text, int thisStartIndex, string other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));
@@ -1183,7 +1183,7 @@ namespace J2N.Text
         /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c></exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
-        public static bool RegionMatches(this string text, int thisStartIndex, ReadOnlySpan<char> other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        public static bool RegionMatches(this string text, int thisStartIndex, ReadOnlySpan<char> other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             if (text is null)
                 throw new ArgumentNullException(nameof(text));

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -1168,7 +1168,39 @@ namespace J2N.Text
             }
         }
 
-        #endregion
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Compares the specified <see cref="ReadOnlySpan{Char}"/> to this string and compares the specified
+        /// range of characters to determine if they are the same.
+        /// </summary>
+        /// <param name="text">This string.</param>
+        /// <param name="thisStartIndex">The starting offset in this string.</param>
+        /// <param name="other">The <see cref="ReadOnlySpan{Char}"/> to compare.</param>
+        /// <param name="otherStartIndex">The starting offset in the specified string.</param>
+        /// <param name="length">The number of characters to compare.</param>
+        /// <param name="comparisonType">One of the enumeration values that specifies the rules for the search.</param>
+        /// <returns><c>true</c> if the ranges of characters are equal, <c>false</c> otherwise.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="text"/> is <c>null</c></exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
+        public static bool RegionMatches(this string text, int thisStartIndex, ReadOnlySpan<char> other, int otherStartIndex, int length, StringComparison comparisonType) // KEEP OVERLOADS FOR ICharSequence, char[], StringBuilder, and string IN SYNC
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text));
+
+            if (other.Length - otherStartIndex < length || otherStartIndex < 0)
+                return false;
+            if (thisStartIndex < 0 || text.Length - thisStartIndex < length)
+                return false;
+            if (length <= 0)
+                return true;
+
+            return text.AsSpan(thisStartIndex, length).Equals(other.Slice(otherStartIndex, length), comparisonType);
+        }
+
+#endif
+
+        #endregion RegionMatches
 
         #region ReverseText
 
@@ -1204,7 +1236,7 @@ namespace J2N.Text
         /// <exception cref="ArgumentNullException"><paramref name="text"/> is
         /// <c>null</c>.</exception>
         /// <seealso cref="StringBuilderExtensions.Reverse(StringBuilder)"/>
-        /// <seealso cref="J2N.Memory.MemoryExtensions.ReverseText(Span{char})"/>
+        /// <seealso cref="J2N.MemoryExtensions.ReverseText(Span{char})"/>
 #else
         /// <summary>
         /// Reverses the character sequence and returns a new string.

--- a/tests/J2N.Tests/Text/TestStringExtensions.cs
+++ b/tests/J2N.Tests/Text/TestStringExtensions.cs
@@ -544,13 +544,10 @@ namespace J2N.Text
             }
             using (var context = new CultureContext("en"))
             {
-                if (!input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
-                    input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
-                    assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
-                        input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
-                }
+                assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
+                input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
+                    input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
             }
         }
 
@@ -605,13 +602,10 @@ namespace J2N.Text
             }
             using (var context = new CultureContext("en"))
             {
-                if (!input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
-                    input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
-                    assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
-                        input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
-                }
+                assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
+                input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
+                    input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
             }
         }
 
@@ -666,13 +660,10 @@ namespace J2N.Text
             }
             using (var context = new CultureContext("en"))
             {
-                if (!input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
-                    input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
-                    assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
-                        input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
-                }
+                assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
+                input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
+                    input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
             }
         }
 
@@ -727,13 +718,10 @@ namespace J2N.Text
             }
             using (var context = new CultureContext("en"))
             {
-                if (!input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase))
-                {
-                    assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
-                    input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
-                    assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
-                        input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
-                }
+                assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
+                input.RegionMatches(10, test, 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
+                    input.RegionMatches(10, test, 0, 3, StringComparison.Ordinal));
             }
         }
 
@@ -758,6 +746,70 @@ namespace J2N.Text
             assertTrue("identical regions failed comparison with different cases",
                     hw1.RegionMatches(2, hw2, 2, 5, StringComparison.Ordinal));
         }
+
+#if FEATURE_SPAN
+
+        /**
+         * @tests java.lang.String#regionMatches(int, java.lang.String, int, int)
+         */
+        [Test]
+        public void Test_RegionMatches_String_Int32_ReadOnlySpan_Int32_Int32_StringComparison()
+        {
+            Assume.That(!PlatformDetection.IsXamarinAndroid, "J2N TODO: Awaits fix: https://github.com/xamarin/xamarin-android/issues/5425");
+
+            // Test for method boolean java.lang.String.regionMatches(int,
+            // java.lang.String, int, int)
+            String bogusString = "xxcedkedkleiorem lvvwr e''' 3r3r 23r";
+
+            assertTrue("identical regions failed comparison", hw1.RegionMatches(2,
+                    hw2.AsSpan(), 2, 5, StringComparison.Ordinal));
+            assertTrue("Different regions returned true", !hw1.RegionMatches(2,
+                    bogusString.AsSpan(), 2, 5, StringComparison.Ordinal));
+
+            var input = "iiiiiiiiiiiıIiii";
+            var test = "İII"; // Turkish capital dotted I test.
+
+            using (var context = new CultureContext("tr"))
+            {
+                assertTrue("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in tr culture",
+                    input.RegionMatches(10, test.AsSpan(), 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in tr culture",
+                    input.RegionMatches(10, test.AsSpan(), 0, 3, StringComparison.Ordinal));
+            }
+            using (var context = new CultureContext("en"))
+            {
+                assertFalse("Turkish captial I test failed using StringComparison.CurrentCultureIgnoreCase in en culture",
+                input.RegionMatches(10, test.AsSpan(), 0, 3, StringComparison.CurrentCultureIgnoreCase));
+                assertFalse("Turkish captial I test failed using StringComparison.Ordinal in en culture",
+                    input.RegionMatches(10, test.AsSpan(), 0, 3, StringComparison.Ordinal));
+            }
+        }
+
+        /**
+         * @tests java.lang.String#regionMatches(boolean, int, java.lang.String,
+         *        int, int)
+         */
+        [Test]
+        public void Test_RegionMatches_String_Int32_ReadOnlySpan_Int32_Int32_StringComparison_OrdinalIgnoreCase()
+        {
+            // Test for method boolean java.lang.String.regionMatches(boolean, int,
+            // java.lang.String, int, int)
+
+            String bogusString = "xxcedkedkleiorem lvvwr e''' 3r3r 23r";
+
+            assertTrue("identical regions failed comparison", hw1.RegionMatches(
+                    2, hw2.AsSpan(), 2, 5, StringComparison.Ordinal));
+            assertTrue("identical regions failed comparison with different cases",
+                    hw1.RegionMatches(2, hw2.AsSpan(), 2, 5, StringComparison.OrdinalIgnoreCase));
+            assertTrue("Different regions returned true", !hw1.RegionMatches(
+                    2, bogusString.AsSpan(), 2, 5, StringComparison.OrdinalIgnoreCase));
+            assertTrue("identical regions failed comparison with different cases",
+                    hw1.RegionMatches(2, hw2.AsSpan(), 2, 5, StringComparison.Ordinal));
+        }
+
+#endif
+
+
 
         /**
         * @tests java.lang.String#startsWith(java.lang.String, int)


### PR DESCRIPTION
New APIs:

```c#
namespace J2N.Text
{
    public static class StringExtensions
    {
        public static bool RegionMatches(this string text, int thisStartIndex, ReadOnlySpan<char> other, int otherStartIndex, int length, StringComparison comparisonType);
    }
}
```

This method has extra logic to ensure it will return a result if the bounds are out of range, but if it is not needed, slicing the span and using `System.MemoryExtensions.Equals(ReadOnlySpan<char>)` is a better option. Therefore, this method is intended primarily as a transition mechanism during porting.