### PR TITLE
Added support for Span<T>/ReadOnlySpan<T> in net40

### DIFF
--- a/.build/TestReferences.Common.targets
+++ b/.build/TestReferences.Common.targets
@@ -12,5 +12,6 @@
 
   <ItemGroup Label="Test Project Common References">
     <PackageReference Include="NUnit" Version="$(NUnitPackageReferenceVersion)" />
+    <PackageReference Include="RandomizedTesting.Generators" Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
   </ItemGroup>
 </Project>

--- a/.build/TestReferences.Common.targets
+++ b/.build/TestReferences.Common.targets
@@ -12,6 +12,5 @@
 
   <ItemGroup Label="Test Project Common References">
     <PackageReference Include="NUnit" Version="$(NUnitPackageReferenceVersion)" />
-    <PackageReference Include="RandomizedTesting.Generators" Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
   </ItemGroup>
 </Project>

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -4,13 +4,12 @@
     <!-- Changing this setting will allow testing on all target frameworks within Visual Studio 2017.
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
-    <TargetFramework>net452</TargetFramework>
+    <!--<TargetFramework>net452</TargetFramework>-->
     <!--<TargetFramework>net461</TargetFramework>-->
-    <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->
-    <!--<TestAllTargetFrameworks>true</TestAllTargetFrameworks>-->
+    <TestAllTargetFrameworks>true</TestAllTargetFrameworks>
 
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting. 
@@ -31,7 +30,6 @@
       // as dependencies in Xamarin tests to test those exact targets
     -->
     <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net6.0;net5.0;net48;net472;net461;net452;netstandard2.1;netstandard2.0</TargetFrameworks>
-    <!--<TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net452</TargetFrameworks>-->
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -4,12 +4,13 @@
     <!-- Changing this setting will allow testing on all target frameworks within Visual Studio 2017.
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
-    <!--<TargetFramework>net452</TargetFramework>-->
+    <TargetFramework>net452</TargetFramework>
     <!--<TargetFramework>net461</TargetFramework>-->
+    <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->
-    <TestAllTargetFrameworks>true</TestAllTargetFrameworks>
+    <!--<TestAllTargetFrameworks>true</TestAllTargetFrameworks>-->
 
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting. 
@@ -30,6 +31,7 @@
       // as dependencies in Xamarin tests to test those exact targets
     -->
     <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net6.0;net5.0;net48;net472;net461;net452;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <!--<TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net452</TargetFrameworks>-->
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -6,6 +6,7 @@
     this setting only affects the test projects. -->
     <!--<TargetFramework>net452</TargetFramework>-->
     <!--<TargetFramework>net461</TargetFramework>-->
+    <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->

--- a/.build/azure-templates/install-android-sdk.yml
+++ b/.build/azure-templates/install-android-sdk.yml
@@ -1,0 +1,42 @@
+﻿# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Installs the Android SDK
+
+parameters:
+  sdkVersion: '' # The Android SDK version to install
+
+steps:
+- pwsh: |
+    function EnsureNotNullOrEmpty([string]$param, [string]$nameOfParam) {
+        if ([string]::IsNullOrEmpty($param)) {
+            Write-Host "##vso[task.logissue type=error;]Missing template parameter \"$nameOfParam\""
+            Write-Host "##vso[task.complete result=Failed;]"
+        }
+    }
+    EnsureNotNullOrEmpty('${{ parameters.sdkVersion }}', 'sdkVersion')
+  displayName: 'Validate Template Parameters'
+
+- pwsh: |
+    $sdkPath = 'C:\Program Files (x86)\Android\android-sdk'
+    $sdkVersion = '${{ parameters.sdkVersion }}'
+    $platformDir = "$sdkPath\platforms\android-$sdkVersion"
+    if (-not (Test-Path $platformDir)) {
+        Write-Host "Android SDK platform $sdkVersion not found. Installing..."
+        sdkmanager "platforms;android-$sdkVersion" > $null
+    }
+  displayName: 'Install Android SDK Platform ${{ parameters.sdkVersion }}'

--- a/.build/azure-templates/install-android-sdk.yml
+++ b/.build/azure-templates/install-android-sdk.yml
@@ -37,6 +37,6 @@ steps:
     $platformDir = "$sdkPath/platforms/android-$sdkVersion"
     if (-not (Test-Path $platformDir)) {
         Write-Host "Android SDK platform $sdkVersion not found. Installing..."
-        & "$sdkPath/tools/bin/sdkmanager" "platforms;android-$sdkVersion" > $null
+        & "$sdkPath/tools/bin/sdkmanager.bat" "platforms;android-$sdkVersion" > $null
     }
   displayName: 'Install Android SDK Platform ${{ parameters.sdkVersion }}'

--- a/.build/azure-templates/install-android-sdk.yml
+++ b/.build/azure-templates/install-android-sdk.yml
@@ -32,11 +32,11 @@ steps:
   displayName: 'Validate Template Parameters'
 
 - pwsh: |
-    $sdkPath = 'C:\Program Files (x86)\Android\android-sdk'
+    $sdkPath = "$env:ANDROID_HOME"
     $sdkVersion = '${{ parameters.sdkVersion }}'
-    $platformDir = "$sdkPath\platforms\android-$sdkVersion"
+    $platformDir = "$sdkPath/platforms/android-$sdkVersion"
     if (-not (Test-Path $platformDir)) {
         Write-Host "Android SDK platform $sdkVersion not found. Installing..."
-        & "$sdkPath\tools\bin\sdkmanager" "platforms;android-$sdkVersion" > $null
+        & "$sdkPath/tools/bin/sdkmanager" "platforms;android-$sdkVersion" > $null
     }
   displayName: 'Install Android SDK Platform ${{ parameters.sdkVersion }}'

--- a/.build/azure-templates/install-android-sdk.yml
+++ b/.build/azure-templates/install-android-sdk.yml
@@ -37,6 +37,6 @@ steps:
     $platformDir = "$sdkPath\platforms\android-$sdkVersion"
     if (-not (Test-Path $platformDir)) {
         Write-Host "Android SDK platform $sdkVersion not found. Installing..."
-        sdkmanager "platforms;android-$sdkVersion" > $null
+        & "$sdkPath\tools\bin\sdkmanager" "platforms;android-$sdkVersion" > $null
     }
   displayName: 'Install Android SDK Platform ${{ parameters.sdkVersion }}'

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -75,7 +75,7 @@ steps:
     testResultsFileName: '${{ parameters.testResultsFileName }}'
 
 # Special Case: Using lowest supported version of .NET Framework (4.5.2) in xUnit to test .NET Framework 4.0.
-# This only works because we are using the AdditionalProperties attribute to set the target framework of the project reference.
+# This only works because we are using the SetTargetFramework attribute to set the target framework of the project reference.
 - template: publish-test-results.yml
   parameters:
     framework: 'net452'

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -7,14 +7,12 @@
     <MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>1.1.1</MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
-    <NetFxSystemMemoryPackageReferenceVersion>4.0.0-alpha-0016</NetFxSystemMemoryPackageReferenceVersion>
-    <NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>$(NetFxSystemMemoryPackageReferenceVersion)</NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
-    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8.1-alpha-0009-gfd548c1e41</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8-beta-0001</RandomizedTestingGeneratorsPackageReferenceVersion>
     <SystemMemoryPackageReferenceVersion>4.5.4</SystemMemoryPackageReferenceVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.5.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemTextEncodingCodePagesPackageReferenceVersion>4.3.0</SystemTextEncodingCodePagesPackageReferenceVersion>
     <XunitPackageReferenceVersion>2.4.1</XunitPackageReferenceVersion>
     <XunitRunnerVisualStudioPackageReferenceVersion>$(XunitPackageReferenceVersion)</XunitRunnerVisualStudioPackageReferenceVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -7,12 +7,15 @@
     <MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>1.1.1</MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
+    <NetFxSystemMemoryPackageReferenceVersion>4.0.0-alpha-0016</NetFxSystemMemoryPackageReferenceVersion>
+    <NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>$(NetFxSystemMemoryPackageReferenceVersion)</NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
-    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8-beta-0001</RandomizedTestingGeneratorsPackageReferenceVersion>
-    <SystemMemoryPackageReferenceVersion>4.5.4</SystemMemoryPackageReferenceVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.5.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8.1-alpha-0009-gfd548c1e41</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <SystemMemoryPackageReferenceVersion>4.5.5</SystemMemoryPackageReferenceVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion Condition=" '$(TargetFramework)' == 'net45' ">4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemTextEncodingCodePagesPackageReferenceVersion>4.3.0</SystemTextEncodingCodePagesPackageReferenceVersion>
     <XunitPackageReferenceVersion>2.4.1</XunitPackageReferenceVersion>
     <XunitRunnerVisualStudioPackageReferenceVersion>$(XunitPackageReferenceVersion)</XunitRunnerVisualStudioPackageReferenceVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -7,12 +7,14 @@
     <MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>1.1.1</MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
+    <NetFxSystemMemoryPackageReferenceVersion>4.0.0-alpha-0016</NetFxSystemMemoryPackageReferenceVersion>
+    <NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>$(NetFxSystemMemoryPackageReferenceVersion)</NetFxSystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
-    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8-beta-0001</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8.1-alpha-0009-gfd548c1e41</RandomizedTestingGeneratorsPackageReferenceVersion>
     <SystemMemoryPackageReferenceVersion>4.5.4</SystemMemoryPackageReferenceVersion>
-    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.5.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemTextEncodingCodePagesPackageReferenceVersion>4.3.0</SystemTextEncodingCodePagesPackageReferenceVersion>
     <XunitPackageReferenceVersion>2.4.1</XunitPackageReferenceVersion>
     <XunitRunnerVisualStudioPackageReferenceVersion>$(XunitPackageReferenceVersion)</XunitRunnerVisualStudioPackageReferenceVersion>

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -12,7 +12,8 @@
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
-    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8.1-alpha-0009-gfd548c1e41</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8</RandomizedTestingGeneratorsPackageReferenceVersion>
+    <SystemBuffersPackageReferenceVersion>4.5.1</SystemBuffersPackageReferenceVersion>
     <SystemMemoryPackageReferenceVersion>4.5.5</SystemMemoryPackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion Condition=" '$(TargetFramework)' == 'net45' ">4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -135,21 +135,15 @@
   <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
 
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
-    <!-- Due to dependency conflicts we are disabling ICU4N comparison tests, for now -->
-    <!--<DefineConstants>$(DefineConstants);FEATURE_ICU4N</DefineConstants>-->
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>
 
-  </PropertyGroup>
-
-  <!-- Features that apply everywhere (to be removed) -->
-  <PropertyGroup>
-    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -185,7 +179,7 @@
 
   <!-- Global PackageReferences -->
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+  <ItemGroup>
     <!-- This is to allow the .NET Framework references to be machine-indepenedent so builds can happen without installing prerequisites -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion)" PrivateAssets="All" />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -135,15 +135,21 @@
   <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
 
-    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
+    <!-- Due to dependency conflicts we are disabling ICU4N comparison tests, for now -->
+    <!--<DefineConstants>$(DefineConstants);FEATURE_ICU4N</DefineConstants>-->
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>
 
+  </PropertyGroup>
+
+  <!-- Features that apply everywhere (to be removed) -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -179,7 +185,7 @@
 
   <!-- Global PackageReferences -->
 
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <!-- This is to allow the .NET Framework references to be machine-indepenedent so builds can happen without installing prerequisites -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion)" PrivateAssets="All" />
   </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -135,15 +135,19 @@
   <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
 
-    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>
 
+  </PropertyGroup>
+
+  <!-- Features that apply everywhere (to be removed) -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAYPOOL</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYMEMORY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SPAN</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -179,7 +183,7 @@
 
   <!-- Global PackageReferences -->
 
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <!-- This is to allow the .NET Framework references to be machine-indepenedent so builds can happen without installing prerequisites -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="$(MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion)" PrivateAssets="All" />
   </ItemGroup>
@@ -193,8 +197,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageReferenceVersion)" PrivateAssets="All"/>
   </ItemGroup>
 
-  <!-- J2N will always use semantic versioning, there is no need for a 4 component version number so we don't always have to skip this on Azure DevOps -->
-  <ItemGroup Condition=" '$(SkipGitVersioning.ToLower())' != 'true' ">
+  <ItemGroup Condition=" '$(SkipGitVersioning.ToLower())' != 'true' And '$(TF_BUILD.ToLower())' != 'true' ">
     <PackageReference Include="Nerdbank.GitVersioning" Version="$(NerdBankGitVersioningPackageReferenceVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/J2N.sln
+++ b/J2N.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34525.116
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9F28FE5B-BE86-4A38-8534-A6555C7C53A4}"
 	ProjectSection(SolutionItems) = preProject
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azure-templates", "azure-te
 	ProjectSection(SolutionItems) = preProject
 		.build\azure-templates\build-pack-and-publish-libraries.yml = .build\azure-templates\build-pack-and-publish-libraries.yml
 		.build\azure-templates\gitversioning-increment-and-persist-versions.yml = .build\azure-templates\gitversioning-increment-and-persist-versions.yml
+		.build\azure-templates\install-android-sdk.yml = .build\azure-templates\install-android-sdk.yml
+		.build\azure-templates\install-dotnet-sdk.yml = .build\azure-templates\install-dotnet-sdk.yml
 		.build\azure-templates\publish-nuget-packages.yml = .build\azure-templates\publish-nuget-packages.yml
 		.build\azure-templates\publish-test-results-for-target-frameworks.yml = .build\azure-templates\publish-test-results-for-target-frameworks.yml
 		.build\azure-templates\publish-test-results-for-test-projects.yml = .build\azure-templates\publish-test-results-for-test-projects.yml

--- a/NuGet.config
+++ b/NuGet.config
@@ -21,8 +21,10 @@ under the License.
 
 <configuration>
   <packageSources>
+    <clear/>
     <add key="NuGet.Xamarin.Android MyGet feed" value="https://www.myget.org/F/nunit-xamarin-android/api/v3/index.json" />
+    <add key="Randomized Testing Preview feed" value="https://www.myget.org/F/randomizedtesting-preview/api/v3/index.json" />
     <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
-	<add key="Nerdbank.GitVersioning CI Feed" value="https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/nuget/v3/index.json" />
+    <add key="Nerdbank.GitVersioning CI Feed" value="https://pkgs.dev.azure.com/andrewarnott/OSS/_packaging/PublicCI/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,8 @@ stages:
       vmImage: 'windows-latest'
 
     steps:
+    - template: '.build/azure-templates/show-all-files.yml' # for debugging
+
     - pwsh: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
         Write-Host "##vso[task.setvariable variable=BuildConfiguration;]$configuration"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,10 +48,11 @@ stages:
 
   - job: Build
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2019'
 
     steps:
-    - template: '.build/azure-templates/show-all-files.yml' # for debugging
+    #- template: '.build/azure-templates/show-all-files.yml' # for debugging
+    - pwsh: C:;cd $env:ANDROID_HOME;dir -r  | Where-Object {$_.PsIsContainer -eq $false} | % { $_.FullName }
 
     - pwsh: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
@@ -96,13 +97,13 @@ stages:
         nugetArtifactName: '$(NuGetArtifactName)'
         binaryArtifactName: '$(BinaryArtifactName)'
 
-    - template: '.build/azure-templates/install-android-sdk.yml'
-      parameters:
-        sdkVersion: '28'
+    #- template: '.build/azure-templates/install-android-sdk.yml'
+    #  parameters:
+    #    sdkVersion: '28'
 
-    - template: '.build/azure-templates/install-android-sdk.yml'
-      parameters:
-        sdkVersion: '29'
+    #- template: '.build/azure-templates/install-android-sdk.yml'
+    #  parameters:
+    #    sdkVersion: '29'
 
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
 
     steps:
     #- template: '.build/azure-templates/show-all-files.yml' # for debugging
-    - pwsh: C:;cd $env:ANDROID_HOME;dir -r  | Where-Object {$_.PsIsContainer -eq $false} | % { $_.FullName }
+    #- pwsh: C:;cd $env:ANDROID_HOME;dir -r  | Where-Object {$_.PsIsContainer -eq $false} | % { $_.FullName }
 
     - pwsh: |
         $configuration = if ($env:BUILDCONFIGURATION) { $env:BUILDCONFIGURATION } else { "Release" }
@@ -97,13 +97,13 @@ stages:
         nugetArtifactName: '$(NuGetArtifactName)'
         binaryArtifactName: '$(BinaryArtifactName)'
 
-    #- template: '.build/azure-templates/install-android-sdk.yml'
-    #  parameters:
-    #    sdkVersion: '28'
+    - template: '.build/azure-templates/install-android-sdk.yml'
+      parameters:
+        sdkVersion: '28'
 
-    #- template: '.build/azure-templates/install-android-sdk.yml'
-    #  parameters:
-    #    sdkVersion: '29'
+    - template: '.build/azure-templates/install-android-sdk.yml'
+      parameters:
+        sdkVersion: '29'
 
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,6 +94,18 @@ stages:
         nugetArtifactName: '$(NuGetArtifactName)'
         binaryArtifactName: '$(BinaryArtifactName)'
 
+    - task: AndroidSdkInstaller@0
+      inputs:
+        sdkPath: 'C:\Program Files (x86)\Android\android-sdk'
+        sdkVersion: '28'
+      displayName: 'Install Android SDK Platform 28'
+
+    - task: AndroidSdkInstaller@0
+      inputs:
+        sdkPath: 'C:\Program Files (x86)\Android\android-sdk'
+        sdkVersion: '29'
+      displayName: 'Install Android SDK Platform 29'
+
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,17 +94,13 @@ stages:
         nugetArtifactName: '$(NuGetArtifactName)'
         binaryArtifactName: '$(BinaryArtifactName)'
 
-    - task: AndroidSdkInstaller@0
-      inputs:
-        sdkPath: 'C:\Program Files (x86)\Android\android-sdk'
+    - template: '.build/azure-templates/install-android-sdk.yml'
+      parameters:
         sdkVersion: '28'
-      displayName: 'Install Android SDK Platform 28'
 
-    - task: AndroidSdkInstaller@0
-      inputs:
-        sdkPath: 'C:\Program Files (x86)\Android\android-sdk'
+    - template: '.build/azure-templates/install-android-sdk.yml'
+      parameters:
         sdkVersion: '29'
-      displayName: 'Install Android SDK Platform 29'
 
     - task: NuGetToolInstaller@1
       displayName: 'Install NuGet'

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -957,7 +957,7 @@ namespace J2N.Collections.Concurrent
         public bool ContainsKey(TKey key)
         {
             if (_entries == null) throw new ObjectDisposedException(nameof(LurchTable<TKey, TValue>));
-            return TryGetValue(key, out TValue _);
+            return TryGetValue(key, out _);
         }
 
         /// <summary>

--- a/src/J2N/Collections/Generic/ArraySortHelper.cs
+++ b/src/J2N/Collections/Generic/ArraySortHelper.cs
@@ -55,7 +55,9 @@ namespace J2N.Collections.Generic
             }
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         private static void Swap(Span<T> a, int i, int j)
         {
             Debug.Assert(i != j);
@@ -115,7 +117,8 @@ namespace J2N.Collections.Generic
                 int p = PickPivotAndPartition(keys.Slice(0, partitionSize), comparer!);
 
                 // Note we've already partitioned around the pivot and do not have to move the pivot again.
-                IntroSort(keys[(p + 1)..partitionSize], depthLimit, comparer!);
+                //IntroSort(keys[(p + 1)..partitionSize], depthLimit, comparer!);
+                IntroSort(keys.Slice(p + 1, partitionSize - (p + 1)), depthLimit, comparer!); // J2N: Removed index/range so we can compile on .NET Framework
                 partitionSize = p;
             }
         }

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -828,7 +828,7 @@ namespace J2N.Collections.Generic
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
         {
-            return TryGetNode(item.Key, item.Value, out LinkedListNode<KeyValuePair<TKey, TValue>> _);
+            return TryGetNode(item.Key, item.Value, out _);
         }
 
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -32,10 +32,6 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="NetFx.System.Memory" Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -32,6 +32,10 @@
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="NetFx.System.Memory" Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net40' ">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -25,7 +25,9 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int IndexOf(this ReadOnlySpan<char> text, char value)
             => System.MemoryExtensions.IndexOf(text, value);
 
@@ -41,7 +43,9 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int IndexOf(this Span<char> text, char value)
             => System.MemoryExtensions.IndexOf(text, value);
 
@@ -177,7 +181,9 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int LastIndexOf(this ReadOnlySpan<char> text, char value)
             => System.MemoryExtensions.LastIndexOf(text, value);
 
@@ -193,7 +199,9 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public static int LastIndexOf(this Span<char> text, char value)
             => System.MemoryExtensions.LastIndexOf(text, value);
 

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -3211,7 +3211,9 @@ namespace J2N.Numerics
     {
 #if FEATURE_SPAN
         // From MemoryExtensions class in .NET Runtime
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         internal static bool EqualsOrdinalIgnoreCase(this ReadOnlySpan<char> span, ReadOnlySpan<char> value)
         {
             if (span.Length != value.Length)

--- a/src/J2N/Text/ValueStringBuilder.cs
+++ b/src/J2N/Text/ValueStringBuilder.cs
@@ -169,7 +169,9 @@ namespace J2N.Text
             _pos += count;
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public void Append(char c)
         {
             int pos = _pos;
@@ -184,7 +186,9 @@ namespace J2N.Text
             }
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public void Append(string? s)
         {
             if (s == null)
@@ -263,7 +267,9 @@ namespace J2N.Text
             _pos += value.Length;
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public Span<char> AppendSpan(int length)
         {
             int origPos = _pos;
@@ -310,7 +316,9 @@ namespace J2N.Text
             }
         }
 
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
         public void Dispose()
         {
             char[]? toReturn = _arrayToReturnToPool;

--- a/tests/J2N.Tests/IO/TestByteBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestByteBuffer2.cs
@@ -275,7 +275,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestCharBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestCharBuffer2.cs
@@ -172,7 +172,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestDoubleBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestDoubleBuffer2.cs
@@ -163,7 +163,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestInt16Buffer2.cs
+++ b/tests/J2N.Tests/IO/TestInt16Buffer2.cs
@@ -158,7 +158,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestInt32Buffer2.cs
+++ b/tests/J2N.Tests/IO/TestInt32Buffer2.cs
@@ -162,7 +162,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestInt64Buffer2.cs
+++ b/tests/J2N.Tests/IO/TestInt64Buffer2.cs
@@ -161,7 +161,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/IO/TestSingleBuffer2.cs
+++ b/tests/J2N.Tests/IO/TestSingleBuffer2.cs
@@ -165,7 +165,7 @@ namespace J2N.IO
             }
             catch (Exception x)
             {
-                if (ex.GetTypeInfo().IsAssignableFrom(x.GetType()))
+                if (ex.IsAssignableFrom(x.GetType()))
                 {
                     caught = true;
                 }

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(SolutionDir)/.build/TestTargetFramework.props" />
-
-  <PropertyGroup>
-    <TargetFramework Condition=" '$(TargetFramework)' == 'net452' ">net40</TargetFramework>
-  </PropertyGroup>
-  
   <Import Project="$(SolutionDir)/.build/TestReferences.Common.targets" />
   
   <PropertyGroup>
@@ -22,33 +17,12 @@
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
-  <!-- We cannot test this on net452 (target net40) because this will load System.Memory, which conflicts with NetFx.System.Memory. -->
-  <!-- Due to dependency conflicts we are disabling ICU4N comparison tests, for now -->
-  <!--<ItemGroup Condition=" '$(TargetFramework)' != 'net452' ">
+  <ItemGroup>
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageReferenceVersion)" />
-  </ItemGroup>-->
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net452' And '$(TargetFramework)' != 'net40' And '$(TargetFramework)' != '' ">
-    <PackageReference Include="RandomizedTesting.Generators"
-                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="RandomizedTesting.Generators"
-                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
-    <!--<PackageReference Include="RandomizedTesting.Generators"
-                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)"
-                      ExcludeAssets="Compile"/>
-    <Reference Include="RandomizedTesting.Generators">
-      <HintPath>F:\Users\shad\.nuget\packages\randomizedtesting.generators\$(RandomizedTestingGeneratorsPackageReferenceVersion)\lib\net40\RandomizedTesting.Generators.dll</HintPath>
-    </Reference>-->
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="NetFx.System.Memory" Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -78,25 +52,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\J2N.TestFramework\J2N.TestFramework.csproj">
-      <SetTargetFramework>TargetFramework=net40</SetTargetFramework>
-      <!--<ReferenceOutputAssembly>false</ReferenceOutputAssembly>-->
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\..\src\J2N\J2N.csproj">
-      <SetTargetFramework>TargetFramework=net40</SetTargetFramework>
-      <!--<ReferenceOutputAssembly>false</ReferenceOutputAssembly>-->
+      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
     </ProjectReference>
   </ItemGroup>
-
-  <!--<ItemGroup>
-    <Reference Include="RandomizedTesting.Generators">
-      <HintPath>F:\Users\shad\.nuget\packages\randomizedtesting.generators\$(RandomizedTestingGeneratorsPackageReferenceVersion)\lib\net45\RandomizedTesting.Generators.dll</HintPath>
-    </Reference>
-    <Reference Include="J2N">
-      <HintPath>..\..\src\J2N\bin\Debug\net40\J2N.dll</HintPath>
-    </Reference>
-    <Reference Include="J2N.TestFramework">
-      <HintPath>..\..\src\J2N.TestFramework\bin\Debug\net40\J2N.TestFramework.dll</HintPath>
-    </Reference>
-  </ItemGroup>-->
 
 </Project>

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -21,12 +21,6 @@
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageReferenceVersion)" />
     <PackageReference Include="RandomizedTesting.Generators" Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
   </ItemGroup>
-
-  <!-- Override the asset target fallback for net452, since we are testing net40 here and need those specific dependencies.
-      We favor net40 and fallback to net451 or net45, if available. -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' And ('$(PackageReference)' == 'ICU4N' Or '$(PackageReference)' == 'RandomizedTesting.Generators') ">
-    <AssetTargetFallback>net40;net451;net45</AssetTargetFallback>
-  </PropertyGroup>
   
   <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -22,17 +22,25 @@
     <PackageReference Include="RandomizedTesting.Generators" Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
   </ItemGroup>
 
-  <!-- Override the asset target fallback for net452, since we are testing net40 here and need those specific dependencies -->
+  <!-- Override the asset target fallback for net452, since we are testing net40 here and need those specific dependencies.
+      We favor net40 and fallback to net451 or net45, if available. -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' And ('$(PackageReference)' == 'ICU4N' Or '$(PackageReference)' == 'RandomizedTesting.Generators') ">
-    <AssetTargetFallback>net40</AssetTargetFallback>
+    <AssetTargetFallback>net40;net451;net45</AssetTargetFallback>
   </PropertyGroup>
   
   <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
-    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL as follows. The IDE view is wrong, this ref doesn't actually exist. -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
+        ExcludeAssets=compile removes the dependency from being referenced. ExcludeAssets=runtime removes the dependency from the build output. -->
+    <PackageReference Include="System.Buffers"
+                      Version="$(SystemBuffersPackageReferenceVersion)"
+                      ExcludeAssets="compile;runtime" />
     <PackageReference Include="System.Memory"
                       Version="$(SystemMemoryPackageReferenceVersion)"
-                      ExcludeAssets="compile" />
+                      ExcludeAssets="compile;runtime" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe"
+                      Version="$(SystemRuntimeCompilerServicesUnsafePackageReferenceVersion)"
+                      ExcludeAssets="compile;runtime" />
     <PackageReference Include="NetFx.System.Memory"
                       Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="$(SolutionDir)/.build/TestTargetFramework.props" />
+
+  <PropertyGroup>
+    <TargetFramework Condition=" '$(TargetFramework)' == 'net452' ">net40</TargetFramework>
+  </PropertyGroup>
+  
   <Import Project="$(SolutionDir)/.build/TestReferences.Common.targets" />
   
   <PropertyGroup>
@@ -17,12 +22,33 @@
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- We cannot test this on net452 (target net40) because this will load System.Memory, which conflicts with NetFx.System.Memory. -->
+  <!-- Due to dependency conflicts we are disabling ICU4N comparison tests, for now -->
+  <!--<ItemGroup Condition=" '$(TargetFramework)' != 'net452' ">
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageReferenceVersion)" />
+  </ItemGroup>-->
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net452' And '$(TargetFramework)' != 'net40' And '$(TargetFramework)' != '' ">
+    <PackageReference Include="RandomizedTesting.Generators"
+                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="RandomizedTesting.Generators"
+                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
+    <!--<PackageReference Include="RandomizedTesting.Generators"
+                      Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)"
+                      ExcludeAssets="Compile"/>
+    <Reference Include="RandomizedTesting.Generators">
+      <HintPath>F:\Users\shad\.nuget\packages\randomizedtesting.generators\$(RandomizedTestingGeneratorsPackageReferenceVersion)\lib\net40\RandomizedTesting.Generators.dll</HintPath>
+    </Reference>-->
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="NetFx.System.Memory" Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
@@ -52,11 +78,25 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\J2N.TestFramework\J2N.TestFramework.csproj">
-      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net40</SetTargetFramework>
+      <!--<ReferenceOutputAssembly>false</ReferenceOutputAssembly>-->
     </ProjectReference>
     <ProjectReference Include="..\..\src\J2N\J2N.csproj">
-      <SetTargetFramework>$(SetTargetFramework)</SetTargetFramework>
+      <SetTargetFramework>TargetFramework=net40</SetTargetFramework>
+      <!--<ReferenceOutputAssembly>false</ReferenceOutputAssembly>-->
     </ProjectReference>
   </ItemGroup>
+
+  <!--<ItemGroup>
+    <Reference Include="RandomizedTesting.Generators">
+      <HintPath>F:\Users\shad\.nuget\packages\randomizedtesting.generators\$(RandomizedTestingGeneratorsPackageReferenceVersion)\lib\net45\RandomizedTesting.Generators.dll</HintPath>
+    </Reference>
+    <Reference Include="J2N">
+      <HintPath>..\..\src\J2N\bin\Debug\net40\J2N.dll</HintPath>
+    </Reference>
+    <Reference Include="J2N.TestFramework">
+      <HintPath>..\..\src\J2N.TestFramework\bin\Debug\net40\J2N.TestFramework.dll</HintPath>
+    </Reference>
+  </ItemGroup>-->
 
 </Project>

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -5,7 +5,7 @@
   
   <PropertyGroup>
     <RootNamespace>J2N</RootNamespace>
-    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,6 +19,22 @@
 
   <ItemGroup>
     <PackageReference Include="ICU4N" Version="$(ICU4NPackageReferenceVersion)" />
+    <PackageReference Include="RandomizedTesting.Generators" Version="$(RandomizedTestingGeneratorsPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <!-- Override the asset target fallback for net452, since we are testing net40 here and need those specific dependencies -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' And ('$(PackageReference)' == 'ICU4N' Or '$(PackageReference)' == 'RandomizedTesting.Generators') ">
+    <AssetTargetFallback>net40</AssetTargetFallback>
+  </PropertyGroup>
+  
+  <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net40' ">
+    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL as follows. The IDE view is wrong, this ref doesn't actually exist. -->
+    <PackageReference Include="System.Memory"
+                      Version="$(SystemMemoryPackageReferenceVersion)"
+                      ExcludeAssets="compile" />
+    <PackageReference Include="NetFx.System.Memory"
+                      Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">

--- a/tests/J2N.Tests/TestAssemblyExtensions.cs
+++ b/tests/J2N.Tests/TestAssemblyExtensions.cs
@@ -16,7 +16,7 @@ namespace J2N
         public void Test_getResourceLjava_lang_String()
         {
             string name = "test_resource.txt";
-            string res = GetType().GetTypeInfo().Assembly.FindResource(GetType(), name);
+            string res = GetType().Assembly.FindResource(GetType(), name);
             assertNotNull(res);
         }
 
@@ -27,11 +27,11 @@ namespace J2N
         public void Test_getResourceAsStreamLjava_lang_String()
         {
             string name = "test_resource.txt";
-            using (Stream stream = GetType().GetTypeInfo().Assembly.FindAndGetManifestResourceStream(GetType(), name))
+            using (Stream stream = GetType().Assembly.FindAndGetManifestResourceStream(GetType(), name))
                 assertNotNull("the file " + name + " can not be found in this directory", stream);
 
             String nameBadURI = "org/apache/harmony/luni/tests/test_resource.txt";
-            using (Stream stream2 = GetType().GetTypeInfo().Assembly.FindAndGetManifestResourceStream(GetType(), nameBadURI))
+            using (Stream stream2 = GetType().Assembly.FindAndGetManifestResourceStream(GetType(), nameBadURI))
                 assertNull("the file " + nameBadURI + " should not be found in this directory", stream2);
 
             //Stream str = Object.class.getResourceAsStream("Class.class");
@@ -41,7 +41,7 @@ namespace J2N
             //assertEquals("Cannot read multiple bytes", 5, str.read(new byte[5]));
             //str.close();
 
-            using (Stream str2 = GetType().GetTypeInfo().Assembly.FindAndGetManifestResourceStream(GetType(), "test_resource.txt"))
+            using (Stream str2 = GetType().Assembly.FindAndGetManifestResourceStream(GetType(), "test_resource.txt"))
             {
                 assertNotNull("Can't find resource", str2);
                 assertTrue("Cannot read single byte", str2.ReadByte() != -1);

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1,8 +1,6 @@
-﻿#if FEATURE_ICU4N
-using ICU4N;
+﻿using ICU4N;
 using ICU4N.Globalization;
 using ICU4N.Text;
-#endif
 using J2N.Collections;
 using J2N.Text;
 using NUnit.Framework;
@@ -1721,7 +1719,6 @@ namespace J2N
             assertEquals("Returned incorrect digit", 1, Character.Digit('๑', 10));
         }
 
-#if FEATURE_ICU4N
         [Test]
         public void Test_DigitCI_Against_ICU4N()
         {
@@ -1739,7 +1736,6 @@ namespace J2N
                 }
             }
         }
-#endif
 
         /**
          * @tests java.lang.Character#digit(int, int)
@@ -1759,7 +1755,6 @@ namespace J2N
             assertEquals(-1, Character.Digit(0x110000, 20));
         }
 
-#if FEATURE_ICU4N
         [Test]
         //[Ignore("Run Manually - ICU4N's Digit method is slow with surrogates")]
         public void Test_Digit_II_Against_ICU4N()
@@ -1788,7 +1783,6 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match for radix {radix}.", expected, actual);
         }
-#endif
 
         /////**
         //// * @tests java.lang.Character#equals(java.lang.Object)
@@ -1848,7 +1842,6 @@ namespace J2N
                     .GetNumericValue('\uff12'));
         }
 
-#if FEATURE_ICU4N
         [Test]
         public void Test_GetNumericValueC_Against_ICU4N()
         {
@@ -1875,7 +1868,6 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
         }
-#endif
 
         /**
          * @tests java.lang.Character#getNumericValue(int)
@@ -1913,7 +1905,6 @@ namespace J2N
             assertEquals(35, Character.GetNumericValue(0xFF5A));
         }
 
-#if FEATURE_ICU4N
         [Test]
         public void Test_GetNumericValue_I_Against_ICU4N()
         {
@@ -1937,7 +1928,6 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
         }
-#endif
 
         /**
          * @tests java.lang.Character#getType(char)
@@ -2813,12 +2803,10 @@ namespace J2N
                 assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
             }
 
-#if FEATURE_ICU4N
             for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
             {
                 assertEquals($"0x{c:X4}", UChar.IsWhiteSpace((char)c), Character.IsWhiteSpace((char)c));
             }
-#endif
 
             //assertTrue("space returned false", Character.IsWhiteSpace('\n'));
             //assertTrue("non-space returned true", !Character.IsWhiteSpace('T'));
@@ -2886,12 +2874,10 @@ namespace J2N
                 assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
             }
 
-#if FEATURE_ICU4N
             for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
             {
                 assertEquals($"0x{c:X4}", UChar.IsWhiteSpace(c), Character.IsWhiteSpace(c));
             }
-#endif
 
             //assertTrue(Character.IsWhiteSpace((int)'\n'));
             //assertFalse(Character.IsWhiteSpace((int)'T'));

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1,6 +1,8 @@
-﻿using ICU4N;
+﻿#if FEATURE_ICU4N
+using ICU4N;
 using ICU4N.Globalization;
 using ICU4N.Text;
+#endif
 using J2N.Collections;
 using J2N.Text;
 using NUnit.Framework;
@@ -1719,6 +1721,7 @@ namespace J2N
             assertEquals("Returned incorrect digit", 1, Character.Digit('๑', 10));
         }
 
+#if FEATURE_ICU4N
         [Test]
         public void Test_DigitCI_Against_ICU4N()
         {
@@ -1736,6 +1739,7 @@ namespace J2N
                 }
             }
         }
+#endif
 
         /**
          * @tests java.lang.Character#digit(int, int)
@@ -1755,6 +1759,7 @@ namespace J2N
             assertEquals(-1, Character.Digit(0x110000, 20));
         }
 
+#if FEATURE_ICU4N
         [Test]
         //[Ignore("Run Manually - ICU4N's Digit method is slow with surrogates")]
         public void Test_Digit_II_Against_ICU4N()
@@ -1783,6 +1788,7 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match for radix {radix}.", expected, actual);
         }
+#endif
 
         /////**
         //// * @tests java.lang.Character#equals(java.lang.Object)
@@ -1842,6 +1848,7 @@ namespace J2N
                     .GetNumericValue('\uff12'));
         }
 
+#if FEATURE_ICU4N
         [Test]
         public void Test_GetNumericValueC_Against_ICU4N()
         {
@@ -1868,6 +1875,7 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
         }
+#endif
 
         /**
          * @tests java.lang.Character#getNumericValue(int)
@@ -1905,6 +1913,7 @@ namespace J2N
             assertEquals(35, Character.GetNumericValue(0xFF5A));
         }
 
+#if FEATURE_ICU4N
         [Test]
         public void Test_GetNumericValue_I_Against_ICU4N()
         {
@@ -1928,6 +1937,7 @@ namespace J2N
 
             assertEquals($"{c} (Hex 0x{c.ToHexString()}) failed to match.", expected, actual);
         }
+#endif
 
         /**
          * @tests java.lang.Character#getType(char)
@@ -2803,10 +2813,12 @@ namespace J2N
                 assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
             }
 
+#if FEATURE_ICU4N
             for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
             {
                 assertEquals($"0x{c:X4}", UChar.IsWhiteSpace((char)c), Character.IsWhiteSpace((char)c));
             }
+#endif
 
             //assertTrue("space returned false", Character.IsWhiteSpace('\n'));
             //assertTrue("non-space returned true", !Character.IsWhiteSpace('T'));
@@ -2874,10 +2886,12 @@ namespace J2N
                 assertFalse($"0x{c:X4}", Character.IsWhiteSpace(c));
             }
 
+#if FEATURE_ICU4N
             for (int c = Character.MinCodePoint; c <= Character.MaxCodePoint; c++)
             {
                 assertEquals($"0x{c:X4}", UChar.IsWhiteSpace(c), Character.IsWhiteSpace(c));
             }
+#endif
 
             //assertTrue(Character.IsWhiteSpace((int)'\n'));
             //assertFalse(Character.IsWhiteSpace((int)'T'));

--- a/tests/J2N.Tests/Text/TestValueStringBuilder.cs
+++ b/tests/J2N.Tests/Text/TestValueStringBuilder.cs
@@ -107,6 +107,7 @@ namespace J2N.Text
             Assert.AreEqual(sb.ToString(), vsb.ToString());
         }
 
+#if FEATURE_STRINGBUILDER_APPEND_CHARPTR
         [Test]
         public unsafe void Append_PtrInt_MatchesStringBuilder()
         {
@@ -125,6 +126,7 @@ namespace J2N.Text
             Assert.AreEqual(sb.Length, vsb.Length);
             Assert.AreEqual(sb.ToString(), vsb.ToString());
         }
+#endif
 
         [Test]
         public void AppendSpan_DataAppendedCorrectly()

--- a/tests/J2N.Tests/Threading/TestThreadJob.cs
+++ b/tests/J2N.Tests/Threading/TestThreadJob.cs
@@ -1286,7 +1286,9 @@ namespace J2N.Threading
         {
             // Test for method void java.lang.Thread.sleep(long, int)
 
+#if FEATURE_RUNTIMEINFORMATION
             Assume.That(!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !PlatformDetection.IsXamarinAndroid, "J2N TODO: This test currently fails on macOS and Xamarin.Android.");
+#endif
 
             // TODO : Test needs revisiting.
             long stime = 0, ftime = 0;
@@ -1311,7 +1313,9 @@ namespace J2N.Threading
         [Test]
         public void Test_start()
         {
+#if FEATURE_RUNTIMEINFORMATION
             Assume.That(!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !PlatformDetection.IsXamarinAndroid, "J2N TODO: This test currently fails on macOS and hangs on Xamarin.Android.");
+#endif
 
             // Test for method void java.lang.Thread.start()
             try


### PR DESCRIPTION
This fixes the net40 target so it supports key features in

- System.Memory
- System.Buffers
- System.Runtime.CompilerServices.Unsafe

which can significantly reduce allocations when used. All of the features in these libraries can now be utilized without conditionally compiling. It also means that the ref struct `ValueStringBuilder` can now be utilized on net40 as well, further reducing conditional compilation.

This PR does not (yet) remove the conditional compilation. This will take a bit more work because there is quite a bit of duplicate code for the `string` vs `ReadOnlySpan<char>` overloads. We will now be able to cascade all of the `string` overload calls to the `ReadOnlySpan<char>` internal methods.

This PR includes an update to get Xamarin.Android tests running again, since the SDKs we use are no longer installed by default on Azure Pipelines agents.