### PR TITLE
J2N.Runtime.InteropServices: Added CollectionMarshal class

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <GitHubOrganization>NightOwl888</GitHubOrganization>
     <GitHubProject>J2N</GitHubProject>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -38,6 +38,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_PREDEFINEDONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HASHSET_MODIFY_CONTINUEENUMERATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ICU</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_MEMORYMARSHAL_GETARRAYDATAREFERENCE</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -8,7 +8,7 @@
     <WarningsAsErrors Label="Force all public members to have XML doc comments.">NU1605;1591</WarningsAsErrors>
 
     <Nullable>enable</Nullable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package Settings">

--- a/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
+++ b/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
@@ -58,7 +58,7 @@ namespace J2N.Runtime.InteropServices
         /// <param name="list">The list to set the count of.</param>
         /// <param name="count">The value to set the list's count to.</param>
         /// <typeparam name="T">The type of the elements in the list.</typeparam>
-        /// <exception cref="NullReferenceException">
+        /// <exception cref="ArgumentNullException">
         /// <paramref name="list"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="ArgumentOutOfRangeException">
@@ -69,6 +69,9 @@ namespace J2N.Runtime.InteropServices
         /// </remarks>
         public static void SetCount<T>(List<T> list, int count)
         {
+            if (list is null)
+                throw new ArgumentNullException(nameof(list));
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);

--- a/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
+++ b/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.Collections.Generic;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace J2N.Runtime.InteropServices
+{
+    using SR = J2N.Resources.Strings;
+
+    /// <summary>
+    /// An unsafe class that provides a set of methods to access the underlying data representations of collections.
+    /// </summary>
+    public static class CollectionMarshal
+    {
+        /// <summary>
+        /// Get a <see cref="Span{T}"/> view over a <see cref="List{T}"/>'s data.
+        /// Items should not be added or removed from the <see cref="List{T}"/> while the <see cref="Span{T}"/> is in use.
+        /// </summary>
+        /// <param name="list">The list to get the data view over.</param>
+        /// <typeparam name="T">The type of the elements in the list.</typeparam>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static Span<T> AsSpan<T>(List<T>? list)
+        {
+            Span<T> span = default;
+            if (list is not null)
+            {
+                int size = list._size;
+                T[] items = list._items;
+                Debug.Assert(items is not null, "Implementation depends on List<T> always having an array.");
+
+                if ((uint)size > (uint)items!.Length)
+                {
+                    // List<T> was erroneously mutated concurrently with this call, leading to a count larger than its array.
+                    throw new InvalidOperationException(SR.InvalidOperation_ConcurrentOperationsNotSupported);
+                }
+
+                Debug.Assert(typeof(T[]) == list._items.GetType(), "Implementation depends on List<T> always using a T[] and not U[] where U : T.");
+#if FEATURE_MEMORYMARSHAL_GETARRAYDATAREFERENCE
+                // Per the comments, this is the equivalent of the Span<T>(ref T reference, int length) constructor.
+                span = MemoryMarshal.CreateSpan<T>(ref MemoryMarshal.GetArrayDataReference(items), size);
+#else
+                span = items.AsSpan(0, size);
+#endif
+            }
+
+            return span;
+        }
+
+        /// <summary>
+        /// Sets the count of the <see cref="List{T}"/> to the specified value.
+        /// </summary>
+        /// <param name="list">The list to set the count of.</param>
+        /// <param name="count">The value to set the list's count to.</param>
+        /// <typeparam name="T">The type of the elements in the list.</typeparam>
+        /// <exception cref="NullReferenceException">
+        /// <paramref name="list"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="count"/> is negative.
+        /// </exception>
+        /// <remarks>
+        /// When increasing the count, uninitialized data is being exposed.
+        /// </remarks>
+        public static void SetCount<T>(List<T> list, int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            list._version++;
+
+            if (count > list.Capacity)
+            {
+                list.Grow(count);
+            }
+#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
+            else if (count < list._size && RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+#else
+            else if (count < list._size && List<T>.TIsNullableType)
+#endif
+            {
+                Array.Clear(list._items, count, list._size - count);
+            }
+
+            list._size = count;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
+++ b/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
@@ -4,6 +4,7 @@
 
   <PropertyGroup>
     <RootNamespace>J2N</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <NoWarn Label="Use Length/Count property instead of Enumerable.Count method">$(NoWarn);CA1829</NoWarn>
     <NoWarn Label="Do not use equality check to check for collection size.">$(NoWarn);xUnit2013</NoWarn>
@@ -14,6 +15,23 @@
 
   <ItemGroup>
     <PackageReference Include="xunit" Version="$(XunitPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
+        ExcludeAssets=compile removes the dependency from being referenced. ExcludeAssets=runtime removes the dependency from the build output. -->
+    <PackageReference Include="System.Buffers"
+                      Version="$(SystemBuffersPackageReferenceVersion)"
+                      ExcludeAssets="compile;runtime" />
+    <PackageReference Include="System.Memory"
+                      Version="$(SystemMemoryPackageReferenceVersion)"
+                      ExcludeAssets="compile;runtime" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe"
+                      Version="$(SystemRuntimeCompilerServicesUnsafePackageReferenceVersion)"
+                      ExcludeAssets="compile;runtime" />
+    <PackageReference Include="NetFx.System.Memory"
+                      Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Label="Test Project Common References" Condition=" !$(TargetFramework.StartsWith('netstandard')) ">

--- a/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
+++ b/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
@@ -513,9 +513,11 @@ namespace J2N.Runtime.InteropServices.Tests
         public void ListSetCount()
         {
             List<int> list = null;
-            Assert.Throws<NullReferenceException>(() => CollectionMarshal.SetCount(list, 3));
+            // J2N: Changed API to throw ArgumentNullException instead of NullReferenceException.
+            // To match other APIs, the null check is done first.
+            Assert.Throws<ArgumentNullException>(() => CollectionMarshal.SetCount(list, 3));
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => CollectionMarshal.SetCount(list, -1));
+            //Assert.Throws<ArgumentOutOfRangeException>(() => CollectionMarshal.SetCount(list, -1));
 
             list = new List<int>();
             Assert.Throws<ArgumentOutOfRangeException>(() => CollectionMarshal.SetCount(list, -1));

--- a/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
+++ b/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
@@ -1,0 +1,562 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using J2N.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+
+namespace J2N.Runtime.InteropServices.Tests
+{
+    public class CollectionMarshalTests
+    {
+        [Fact]
+        public unsafe void NullListAsSpanValueType()
+        {
+            List<int> list = null;
+            Span<int> span = CollectionMarshal.AsSpan(list);
+
+            Assert.Equal(0, span.Length);
+
+            fixed (int* pSpan = span)
+            {
+                Assert.True(pSpan == null);
+            }
+        }
+
+        [Fact]
+        public unsafe void NullListAsSpanClass()
+        {
+            List<object> list = null;
+            Span<object> span = CollectionMarshal.AsSpan(list);
+
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public void ListAsSpanValueType()
+        {
+            var list = new List<int>();
+            foreach (int length in Enumerable.Range(0, 36))
+            {
+                list.Clear();
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                for (int i = 0; i < length; i++)
+                {
+                    list.Add(i);
+                }
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                list.TrimExcess();
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                list.Add(length + 1);
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+            }
+
+            static void ValidateContentEquality(List<int> list, Span<int> span)
+            {
+                Assert.Equal(list.Count, span.Length);
+
+                for (int i = 0; i < span.Length; i++)
+                {
+                    Assert.Equal(list[i], span[i]);
+                }
+            }
+        }
+
+        [Fact]
+        public void ListAsSpanClass()
+        {
+            var list = new List<IntAsObject>();
+            foreach (int length in Enumerable.Range(0, 36))
+            {
+                list.Clear();
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                for (var i = 0; i < length; i++)
+                {
+                    list.Add(new IntAsObject { Value = i });
+                }
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                list.TrimExcess();
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+
+                list.Add(new IntAsObject { Value = length + 1 });
+                ValidateContentEquality(list, CollectionMarshal.AsSpan(list));
+            }
+
+            static void ValidateContentEquality(List<IntAsObject> list, Span<IntAsObject> span)
+            {
+                Assert.Equal(list.Count, span.Length);
+
+                for (int i = 0; i < span.Length; i++)
+                {
+                    Assert.Equal(list[i].Value, span[i].Value);
+                }
+            }
+        }
+
+        [Fact]
+        public void ListAsSpanLinkBreaksOnResize()
+        {
+            var list = new List<int>(capacity: 10);
+
+            for (int i = 0; i < 10; i++)
+            {
+                list.Add(i);
+            }
+            list.TrimExcess();
+            Span<int> span = CollectionMarshal.AsSpan(list);
+
+            int startCapacity = list.Capacity;
+            int startCount = list.Count;
+            Assert.Equal(startCount, startCapacity);
+            Assert.Equal(startCount, span.Length);
+
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i]++;
+                Assert.Equal(list[i], span[i]);
+
+                list[i]++;
+                Assert.Equal(list[i], span[i]);
+            }
+
+            // Resize to break link between Span and List
+            list.Add(11);
+
+            Assert.NotEqual(startCapacity, list.Capacity);
+            Assert.NotEqual(startCount, list.Count);
+            Assert.Equal(startCount, span.Length);
+
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] += 2;
+                Assert.NotEqual(list[i], span[i]);
+
+                list[i] += 3;
+                Assert.NotEqual(list[i], span[i]);
+            }
+        }
+
+        //[Fact]
+        //public void GetValueRefOrNullRefValueType()
+        //{
+        //    var dict = new Dictionary<int, Struct>
+        //    {
+        //        {  1, default },
+        //        {  2, default }
+        //    };
+
+        //    Assert.Equal(2, dict.Count);
+
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    Struct itemVal = dict[1];
+        //    itemVal.Value = 1;
+        //    itemVal.Property = 2;
+
+        //    // Does not change values in dictionary
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
+        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
+
+        //    Assert.Equal(3, dict[1].Value);
+        //    Assert.Equal(4, dict[1].Property);
+
+        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
+
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 5;
+        //    itemRef.Property = 6;
+
+        //    Assert.Equal(5, itemRef.Value);
+        //    Assert.Equal(6, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    itemRef = new Struct() { Value = 7, Property = 8 };
+
+        //    Assert.Equal(7, itemRef.Value);
+        //    Assert.Equal(8, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    // Check for null refs
+
+        //    Assert.True(Unsafe.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
+        //    Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
+
+        //    Assert.Equal(2, dict.Count);
+        //}
+
+        //[Fact]
+        //public void GetValueRefOrNullRefClass()
+        //{
+        //    var dict = new Dictionary<int, IntAsObject>
+        //    {
+        //        {  1, new IntAsObject() },
+        //        {  2, new IntAsObject() }
+        //    };
+
+        //    Assert.Equal(2, dict.Count);
+
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    IntAsObject itemVal = dict[1];
+        //    itemVal.Value = 1;
+        //    itemVal.Property = 2;
+
+        //    // Does change values in dictionary
+        //    Assert.Equal(1, dict[1].Value);
+        //    Assert.Equal(2, dict[1].Property);
+
+        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
+        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
+
+        //    Assert.Equal(3, dict[1].Value);
+        //    Assert.Equal(4, dict[1].Property);
+
+        //    ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
+
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 5;
+        //    itemRef.Property = 6;
+
+        //    Assert.Equal(5, itemRef.Value);
+        //    Assert.Equal(6, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    itemRef = new IntAsObject() { Value = 7, Property = 8 };
+
+        //    Assert.Equal(7, itemRef.Value);
+        //    Assert.Equal(8, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    // Check for null refs
+
+        //    Assert.True(Unsafe.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
+        //    Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
+
+        //    Assert.Equal(2, dict.Count);
+        //}
+
+        //[Fact]
+        //public void GetValueRefOrNullRefLinkBreaksOnResize()
+        //{
+        //    var dict = new Dictionary<int, Struct>
+        //    {
+        //        {  1, new Struct() }
+        //    };
+
+        //    Assert.Equal(1, dict.Count);
+
+        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 1);
+
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 1;
+        //    itemRef.Property = 2;
+
+        //    Assert.Equal(1, itemRef.Value);
+        //    Assert.Equal(2, itemRef.Property);
+        //    Assert.Equal(dict[1].Value, itemRef.Value);
+        //    Assert.Equal(dict[1].Property, itemRef.Property);
+
+        //    // Resize
+        //    dict.EnsureCapacity(100);
+        //    for (int i = 2; i <= 50; i++)
+        //    {
+        //        dict.Add(i, new Struct());
+        //    }
+
+        //    itemRef.Value = 3;
+        //    itemRef.Property = 4;
+
+        //    Assert.Equal(3, itemRef.Value);
+        //    Assert.Equal(4, itemRef.Property);
+
+        //    // Check connection broken
+        //    Assert.NotEqual(dict[1].Value, itemRef.Value);
+        //    Assert.NotEqual(dict[1].Property, itemRef.Property);
+
+        //    Assert.Equal(50, dict.Count);
+        //}
+
+        //[Fact]
+        //public void GetValueRefOrAddDefaultValueType()
+        //{
+        //    // This test is the same as the one for GetValueRefOrNullRef, but it uses
+        //    // GetValueRefOrAddDefault instead, and also checks for incorrect additions.
+        //    // The two APIs should behave the same when values already exist.
+        //    var dict = new Dictionary<int, Struct>
+        //    {
+        //        {  1, default },
+        //        {  2, default }
+        //    };
+
+        //    Assert.Equal(2, dict.Count);
+
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    Struct itemVal = dict[1];
+        //    itemVal.Value = 1;
+        //    itemVal.Property = 2;
+
+        //    // Does not change values in dictionary
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+
+        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+        //    Assert.Equal(3, dict[1].Value);
+        //    Assert.Equal(4, dict[1].Property);
+
+        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 5;
+        //    itemRef.Property = 6;
+
+        //    Assert.Equal(5, itemRef.Value);
+        //    Assert.Equal(6, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    itemRef = new Struct() { Value = 7, Property = 8 };
+
+        //    Assert.Equal(7, itemRef.Value);
+        //    Assert.Equal(8, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    // Check for correct additions
+
+        //    ref Struct entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+
+        //    Assert.False(exists);
+        //    Assert.Equal(3, dict.Count);
+        //    Assert.False(Unsafe.IsNullRef(ref entry3Ref));
+        //    Assert.True(EqualityComparer<Struct>.Default.Equals(entry3Ref, default));
+
+        //    entry3Ref.Property = 42;
+        //    entry3Ref.Value = 12345;
+
+        //    Struct value3 = dict[3];
+
+        //    Assert.Equal(42, value3.Property);
+        //    Assert.Equal(12345, value3.Value);
+        //}
+
+        //[Fact]
+        //public void GetValueRefOrAddDefaultClass()
+        //{
+        //    var dict = new Dictionary<int, IntAsObject>
+        //    {
+        //        {  1, new IntAsObject() },
+        //        {  2, new IntAsObject() }
+        //    };
+
+        //    Assert.Equal(2, dict.Count);
+
+        //    Assert.Equal(0, dict[1].Value);
+        //    Assert.Equal(0, dict[1].Property);
+
+        //    IntAsObject itemVal = dict[1];
+        //    itemVal.Value = 1;
+        //    itemVal.Property = 2;
+
+        //    // Does change values in dictionary
+        //    Assert.Equal(1, dict[1].Value);
+        //    Assert.Equal(2, dict[1].Property);
+
+        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+
+        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+        //    Assert.Equal(3, dict[1].Value);
+        //    Assert.Equal(4, dict[1].Property);
+
+        //    ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+
+        //    Assert.True(exists);
+        //    Assert.Equal(2, dict.Count);
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 5;
+        //    itemRef.Property = 6;
+
+        //    Assert.Equal(5, itemRef.Value);
+        //    Assert.Equal(6, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    itemRef = new IntAsObject() { Value = 7, Property = 8 };
+
+        //    Assert.Equal(7, itemRef.Value);
+        //    Assert.Equal(8, itemRef.Property);
+        //    Assert.Equal(dict[2].Value, itemRef.Value);
+        //    Assert.Equal(dict[2].Property, itemRef.Property);
+
+        //    // Check for correct additions
+
+        //    ref IntAsObject entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+
+        //    Assert.False(exists);
+        //    Assert.Equal(3, dict.Count);
+        //    Assert.False(Unsafe.IsNullRef(ref entry3Ref));
+        //    Assert.Null(entry3Ref);
+
+        //    entry3Ref = new IntAsObject() { Value = 12345, Property = 42 };
+
+        //    IntAsObject value3 = dict[3];
+
+        //    Assert.Equal(42, value3.Property);
+        //    Assert.Equal(12345, value3.Value);
+        //}
+
+        //[Fact]
+        //public void GetValueRefOrAddDefaultLinkBreaksOnResize()
+        //{
+        //    var dict = new Dictionary<int, Struct>
+        //    {
+        //        {  1, new Struct() }
+        //    };
+
+        //    Assert.Equal(1, dict.Count);
+
+        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists);
+
+        //    Assert.True(exists);
+        //    Assert.Equal(1, dict.Count);
+        //    Assert.Equal(0, itemRef.Value);
+        //    Assert.Equal(0, itemRef.Property);
+
+        //    itemRef.Value = 1;
+        //    itemRef.Property = 2;
+
+        //    Assert.Equal(1, itemRef.Value);
+        //    Assert.Equal(2, itemRef.Property);
+        //    Assert.Equal(dict[1].Value, itemRef.Value);
+        //    Assert.Equal(dict[1].Property, itemRef.Property);
+
+        //    // Resize
+        //    dict.EnsureCapacity(100);
+        //    for (int i = 2; i <= 50; i++)
+        //    {
+        //        dict.Add(i, new Struct());
+        //    }
+
+        //    itemRef.Value = 3;
+        //    itemRef.Property = 4;
+
+        //    Assert.Equal(3, itemRef.Value);
+        //    Assert.Equal(4, itemRef.Property);
+
+        //    // Check connection broken
+        //    Assert.NotEqual(dict[1].Value, itemRef.Value);
+        //    Assert.NotEqual(dict[1].Property, itemRef.Property);
+
+        //    Assert.Equal(50, dict.Count);
+        //}
+
+        private struct Struct
+        {
+            public int Value;
+            public int Property { get; set; }
+        }
+
+        private class IntAsObject
+        {
+            public int Value;
+            public int Property { get; set; }
+        }
+
+        [Fact]
+        public void ListSetCount()
+        {
+            List<int> list = null;
+            Assert.Throws<NullReferenceException>(() => CollectionMarshal.SetCount(list, 3));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => CollectionMarshal.SetCount(list, -1));
+
+            list = new List<int>();
+            Assert.Throws<ArgumentOutOfRangeException>(() => CollectionMarshal.SetCount(list, -1));
+
+            CollectionMarshal.SetCount(list, 5);
+            Assert.Equal(5, list.Count);
+
+            list = new List<int>() { 1, 2, 3, 4, 5 };
+            ref int intRef = ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(list));
+
+            // make sure that size decrease preserves content
+            CollectionMarshal.SetCount(list, 3);
+            Assert.Equal(3, list.Count);
+            Assert.Throws<ArgumentOutOfRangeException>(() => list[3]);
+            AssertExtensions.SequenceEqual(CollectionMarshal.AsSpan(list), new int[] { 1, 2, 3 });
+            Assert.True(Unsafe.AreSame(ref intRef, ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(list))));
+
+            // make sure that size increase preserves content and doesn't clear
+            CollectionMarshal.SetCount(list, 5);
+            AssertExtensions.SequenceEqual(CollectionMarshal.AsSpan(list), new int[] { 1, 2, 3, 4, 5 });
+            Assert.True(Unsafe.AreSame(ref intRef, ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(list))));
+
+            // make sure that reallocations preserve content
+            int newCount = list.Capacity * 2;
+            CollectionMarshal.SetCount(list, newCount);
+            Assert.Equal(newCount, list.Count);
+            AssertExtensions.SequenceEqual(CollectionMarshal.AsSpan(list).Slice(0, 3) /*[..3]*/, new int[] { 1, 2, 3 });
+            Assert.True(!Unsafe.AreSame(ref intRef, ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(list))));
+
+            List<string> listReference = new List<string>() { "a", "b", "c", "d", "e" };
+            ref string stringRef = ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(listReference));
+            CollectionMarshal.SetCount(listReference, 3);
+
+            // verify that reference types aren't cleared
+            AssertExtensions.SequenceEqual(CollectionMarshal.AsSpan(listReference), new string[] { "a", "b", "c" });
+            Assert.True(Unsafe.AreSame(ref stringRef, ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(listReference))));
+            CollectionMarshal.SetCount(listReference, 5);
+
+            // verify that removed reference types are cleared
+            AssertExtensions.SequenceEqual(CollectionMarshal.AsSpan(listReference), new string[] { "a", "b", "c", null, null });
+            Assert.True(Unsafe.AreSame(ref stringRef, ref MemoryMarshal.GetReference(CollectionMarshal.AsSpan(listReference))));
+        }
+    }
+}

--- a/tests/J2N.Tests/Collections/Generic/TestList.cs
+++ b/tests/J2N.Tests/Collections/Generic/TestList.cs
@@ -1114,7 +1114,7 @@ namespace J2N.Collections.Generic
 
                 List<String> list = new List<String>(1);
                 list.Add("hello");
-                list.EnsureCapacity(int.MinValue);
+                list.EnsureCapacity(/*int.MinValue*/ 0); // J2N: int.MinValue throws ArgumentOutOfRangeException, but this is nonsensical, anyway.
             }
 
             /**


### PR DESCRIPTION
J2N.Runtime.InteropServices: Added `CollectionMarshal` class to provide access to the underlying memory of a `List<T>`. This also adds a public `List<T>.EnsureCapacity(int)` method.

New APIs:

```c#
namespace J2N.Runtime.InteropServices
{
    public static class CollectionMarshal
    {
        public static Span<T> AsSpan<T>(List<T>? list)
        public static void SetCount<T>(List<T> list, int count);   
    }
}

namespace J2N.Collections.Generic
{
    public class List<T>
    {
        public int EnsureCapacity(int capacity);
    }
}
```