### PR TITLE
J2N.Collections: Added AsReadOnly() method to each dictionary and set

### DIFF
--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 #endregion
+
 using J2N.Collections.Generic;
+using J2N.Collections.ObjectModel;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -762,6 +764,24 @@ namespace J2N.Collections.Concurrent
                 });
             }
         }
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlyDictionary{TKey, TValue}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="LurchTable{TKey, TValue}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="LurchTable{TKey, TValue}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlyDictionary{TKey, TValue}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="LurchTable{TKey, TValue}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlyDictionary<TKey, TValue> AsReadOnly()
+            => new ReadOnlyDictionary<TKey, TValue>(this);
+
+        #endregion AsReadOnly
 
         #region IDictionary Members
 

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -16,6 +16,7 @@
  */
 #endregion
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -393,6 +394,24 @@ namespace J2N.Collections.Generic
         }
 
 #endif
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlyDictionary{TKey, TValue}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="Dictionary{TKey, TValue}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="Dictionary{TKey, TValue}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlyDictionary{TKey, TValue}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="Dictionary{TKey, TValue}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlyDictionary<TKey, TValue> AsReadOnly()
+            => new ReadOnlyDictionary<TKey, TValue>(this);
+
+        #endregion AsReadOnly
 
         #region SCG.Dictionary<TKey, TValue> Members
 

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -298,6 +299,24 @@ namespace J2N.Collections.Generic
 #endif
 
         #endregion
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlySet{T}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="HashSet{T}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="HashSet{T}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlySet{T}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="HashSet{T}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlySet<T> AsReadOnly()
+            => new ReadOnlySet<T>(this);
+
+        #endregion AsReadOnly
 
         #region ICollection<T> methods
 

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -24,6 +24,7 @@ THE SOFTWARE.
 */
 #endregion
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -208,6 +209,24 @@ namespace J2N.Collections.Generic
 #endif
 
         #endregion
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlyDictionary{TKey, TValue}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="LinkedDictionary{TKey, TValue}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="LinkedDictionary{TKey, TValue}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlyDictionary{TKey, TValue}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="LinkedDictionary{TKey, TValue}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlyDictionary<TKey, TValue> AsReadOnly()
+            => new ReadOnlyDictionary<TKey, TValue>(this);
+
+        #endregion AsReadOnly
 
         #region SCG.Dictionary<TKey, TValue> Members
 

--- a/src/J2N/Collections/Generic/LinkedHashSet.cs
+++ b/src/J2N/Collections/Generic/LinkedHashSet.cs
@@ -16,6 +16,7 @@
  */
 #endregion
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -180,6 +181,24 @@ namespace J2N.Collections.Generic
 #endif
 
         #endregion
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlySet{T}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="LinkedHashSet{T}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="LinkedHashSet{T}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlySet{T}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="LinkedHashSet{T}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlySet<T> AsReadOnly()
+            => new ReadOnlySet<T>(this);
+
+        #endregion AsReadOnly
 
         #region Nested Class: HashSetWrapper
 

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -182,6 +183,24 @@ namespace J2N.Collections.Generic
         }
 
         #endregion
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlyDictionary{TKey, TValue}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="SortedDictionary{TKey, TValue}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="SortedDictionary{TKey, TValue}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlyDictionary{TKey, TValue}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="SortedDictionary{TKey, TValue}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlyDictionary<TKey, TValue> AsReadOnly()
+            => new ReadOnlyDictionary<TKey, TValue>(this);
+
+        #endregion AsReadOnly
 
         #region SCG.SortedDictionary<TKey, TValue> Members
 

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using J2N.Collections.ObjectModel;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -417,6 +418,24 @@ namespace J2N.Collections.Generic
         internal virtual bool IsWithinRange(T item) => true;
 
         #endregion
+
+        #region AsReadOnly
+
+        /// <summary>
+        /// Returns a read-only <see cref="ReadOnlySet{T}"/> wrapper for the current collection.
+        /// </summary>
+        /// <returns>An object that acts as a read-only wrapper around the current <see cref="SortedSet{T}"/>.</returns>
+        /// <remarks>
+        /// To prevent any modifications to the <see cref="SortedSet{T}"/> object, expose it only through this wrapper.
+        /// A <see cref="ReadOnlySet{T}"/> object does not expose methods that modify the collection. However,
+        /// if changes are made to the underlying <see cref="SortedSet{T}"/> object, the read-only collection reflects those changes.
+        /// <para/>
+        /// This method is an O(1) operation.
+        /// </remarks>
+        public ReadOnlySet<T> AsReadOnly()
+            => new ReadOnlySet<T>(this);
+
+        #endregion AsReadOnly
 
         #region Java TreeSet-like Members
 


### PR DESCRIPTION
J2N.Collections: Added `AsReadOnly()` method to each dictionary and set to ensure it is unaffected by Micorsoft's extension methods of the same name in net core. This ensures read-only collections of the built-in types will always respect structural equality and structural formatting.

There will still be collisions using `.AsReadOnly()` if declaring `using J2N.Collections.Generic.Extensions;` and `using System.Collections.Generic;`. In those cases, the user must call the static method that they prefer explicitly.

Our extension method existed prior to Microsoft's. We followed a best practice of putting it into a separate namespace than `J2N.Collections.Generic` so users would have an option to not import the `J2N.Collections.Generic.Extensions` if there were a conflict with another library. It was assumed that Microsoft would declare `AsReadOnly()` on each collection (as it is on `List<T>`) rather than using an extension method so there would be no conflict. Or at least that they would follow the best practice of not including it directly in the `System.Collections.Generic` namespace. Unfortunately, they did neither of those things.