### PR TITLE
Upgraded Dictionary<TKey, TValue> to use a low level (rather than a wrapped) implementation

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -62,10 +62,6 @@
     <!--<DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>-->
 
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_ENSURECAPACITY</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_OUTVALUE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRIMEXCESS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRYADD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMBER_TRYFORMAT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_CURRENTCULTURE_SETTER</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ENCODINGPROVIDERS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_GETBYTES_OFFSET_COUNT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEINFORMATION</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_CHARPTR</DefineConstants>
 
@@ -25,6 +26,7 @@
   <!-- Features in .NET 6.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) ">
 
+    <DefineConstants>$(DefineConstants);FEATURE_ARRAY_CLEAR_ARRAY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTSINGLE</DefineConstants>
     <!-- J2N NOTE: This is technically supported in .NET 5.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
@@ -45,7 +47,7 @@
   <!-- Features in .NET Core 3.x, .NET 5.x, and .NET 6.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
 
-    <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_MODIFY_CONTINUEENUMERATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_COLLECTIONSMARSHAL_ASSPAN_LIST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMERICBITOPERATIONS</DefineConstants>
 
   </PropertyGroup>
@@ -53,18 +55,19 @@
   <!-- Features in .NET Standard 2.1, .NET Core 3.x, .NET 5.x, and .NET 6.x only -->
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
 
+    <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_CTOR_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CHARUNICODEINFO_GETUNICODECATEGORY_CODEPOINT</DefineConstants>
 
     <!--<DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ENUMERATOR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CONDITIONALWEAKTABLE_ADDORUPDATE</DefineConstants>-->
 
-    <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_CTOR_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_ENSURECAPACITY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_REMOVE_OUTVALUE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRIMEXCESS</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_DICTIONARY_TRYADD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMBER_TRYFORMAT</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CREATE</DefineConstants>
@@ -75,6 +78,8 @@
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_EQUALS_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_INSERT_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TEXTWRITER_WRITE_READONLYSPAN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_UNSAFE_ISNULLREF</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_UNSAFE_NULLREF</DefineConstants>
 
   </PropertyGroup>
 
@@ -104,6 +109,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_GETBYTES_OFFSET_COUNT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_CHARPTR</DefineConstants>
 
   </PropertyGroup>

--- a/src/J2N/Array.Enumerators.cs
+++ b/src/J2N/Array.Enumerators.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace J2N
+{
+    using SR2 = J2N.Resources.Strings;
+
+    internal abstract class SZGenericArrayEnumeratorBase : IDisposable
+    {
+        protected int _index;
+        protected readonly int _endIndex;
+
+        protected SZGenericArrayEnumeratorBase(int endIndex)
+        {
+            _index = -1;
+            _endIndex = endIndex;
+        }
+
+        public bool MoveNext()
+        {
+            int index = _index + 1;
+            if ((uint)index < (uint)_endIndex)
+            {
+                _index = index;
+                return true;
+            }
+            _index = _endIndex;
+            return false;
+        }
+
+        public void Reset() => _index = -1;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    internal sealed class SZGenericArrayEnumerator<T> : SZGenericArrayEnumeratorBase, IEnumerator<T>
+    {
+        private readonly T[]? _array;
+
+        /// <summary>Provides an empty enumerator singleton.</summary>
+        /// <remarks>
+        /// If the consumer is using SZGenericArrayEnumerator elsewhere or is otherwise likely
+        /// to be using T[] elsewhere, this singleton should be used.  Otherwise, GenericEmptyEnumerator's
+        /// singleton should be used instead, as it doesn't reference T[] in order to reduce footprint.
+        /// </remarks>
+        internal static readonly SZGenericArrayEnumerator<T> Empty = new SZGenericArrayEnumerator<T>(null, 0);
+
+        internal SZGenericArrayEnumerator(T[]? array, int endIndex)
+            : base(endIndex)
+        {
+            Debug.Assert(array == null || endIndex == array.Length);
+            _array = array;
+        }
+
+        public T Current
+        {
+            get
+            {
+                if ((uint)_index >= (uint)_endIndex)
+                    throw new InvalidOperationException(_index < 0 ? SR2.InvalidOperation_EnumNotStarted : SR2.InvalidOperation_EnumEnded);
+                return _array![_index];
+            }
+        }
+
+        object? IEnumerator.Current => Current;
+    }
+
+    internal abstract class GenericEmptyEnumeratorBase : IDisposable, IEnumerator
+    {
+#pragma warning disable CA1822 // https://github.com/dotnet/roslyn-analyzers/issues/5911
+        public bool MoveNext() => false;
+
+        public object Current
+        {
+            get
+            {
+                throw new InvalidOperationException(SR2.InvalidOperation_EnumNotStarted);
+            }
+        }
+
+        public void Reset() { }
+
+        public void Dispose() { }
+#pragma warning restore CA1822
+    }
+
+    /// <summary>Provides an empty enumerator singleton.</summary>
+    /// <remarks>
+    /// If the consumer is using SZGenericArrayEnumerator elsewhere or is otherwise likely
+    /// to be using T[] elsewhere, SZGenericArrayEnumerator's singleton should be used.  Otherwise,
+    /// this singleton should be used, as it doesn't reference T[] in order to reduce footprint.
+    /// </remarks>
+    internal sealed class GenericEmptyEnumerator<T> : GenericEmptyEnumeratorBase, IEnumerator<T>
+    {
+        public static readonly GenericEmptyEnumerator<T> Instance = new();
+
+        private GenericEmptyEnumerator() { }
+
+        public new T Current
+        {
+            get
+            {
+                throw new InvalidOperationException(SR2.InvalidOperation_EnumNotStarted);
+            }
+        }
+    }
+}

--- a/src/J2N/BitConversion.cs
+++ b/src/J2N/BitConversion.cs
@@ -82,9 +82,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The integer to convert.</param>
         /// <returns>A single-precision floating-point value that represents the converted integer.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe float Int32BitsToSingle(int value)
         {
             return *((float*)&value);
@@ -127,9 +125,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">A floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe int SingleToRawInt32Bits(float value)
         {
             return *((int*)&value);
@@ -169,9 +165,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">A floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe int SingleToInt32Bits(float value)
         {
             if (float.IsNaN(value))
@@ -190,9 +184,7 @@ namespace J2N
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe long SingleToInt64Bits(float value)
         {
             return *((long*)&value);
@@ -262,9 +254,7 @@ namespace J2N
         /// <param name="value">Any <see cref="long"/> integer.</param>
         /// <returns>The <see cref="double"/> floating-point value with
         /// the same bit pattern.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static double Int64BitsToDouble(long value)
         {
             return BitConverter.Int64BitsToDouble(value);
@@ -305,9 +295,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">A <see cref="double"/> precision floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static long DoubleToInt64Bits(double value)
         {
             if (double.IsNaN(value))
@@ -354,9 +342,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">A <see cref="double"/> precision floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static long DoubleToRawInt64Bits(double value)
         {
             return BitConverter.DoubleToInt64Bits(value);

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -492,9 +492,7 @@ namespace J2N
         /// </summary>
         /// <param name="codePoint">The code point to test.</param>
         /// <returns><c>true</c> if <paramref name="codePoint"/> is a valid Unicode code point; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsValidCodePoint(int codePoint)
         {
             return (MinCodePoint <= codePoint && MaxCodePoint >= codePoint);
@@ -506,9 +504,7 @@ namespace J2N
         /// <param name="codePoint">The code point to test.</param>
         /// <returns><c>true</c> if <paramref name="codePoint"/> is within the supplementary
         /// code point range; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsSupplementaryCodePoint(int codePoint)
         {
             return (MinSupplementaryCodePoint <= codePoint && MaxCodePoint >= codePoint);
@@ -528,9 +524,7 @@ namespace J2N
         /// <param name="codePoint">The code point for which to calculate the number of required
         /// chars.</param>
         /// <returns><c>2</c> if <c><paramref name="codePoint"/> >= 0x10000</c>; <c>1</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int CharCount(int codePoint)
         {
             // A given codepoint can be represented in .NET either by 1 char (up to UTF16),
@@ -552,9 +546,7 @@ namespace J2N
         /// <param name="low">The low surrogate unit.</param>
         /// <returns>The Unicode code point corresponding to the surrogate unit pair.</returns>
         /// <seealso cref="char.IsSurrogatePair(char, char)"/>.
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int ToCodePoint(char high, char low)
         {
             // Optimized form of:
@@ -1929,9 +1921,7 @@ namespace J2N
             return OffsetByCodePointsImpl(seq, start, count, index, codePointOffset);
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int OffsetByCodePointsImpl(char[] seq, int start, int count,
                                           int index, int codePointOffset)
         {
@@ -2064,9 +2054,7 @@ namespace J2N
             return -1;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static bool IsAsciiHexDigit(int c)
         {
             if (c < 128)
@@ -2083,9 +2071,7 @@ namespace J2N
         /// <param name="data">The String to search.</param>
         /// <param name="c">The character to search for.</param>
         /// <returns>The nearest index.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int BinarySearchRange(string data, char c)
         {
             char value = (char)0;
@@ -2110,9 +2096,7 @@ namespace J2N
         /// <param name="data">The String to search.</param>
         /// <param name="codePoint">The character to search for.</param>
         /// <returns>The nearest index.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int BinarySearchRange(uint[] data, int codePoint)
         {
             uint value = 0;
@@ -2137,9 +2121,7 @@ namespace J2N
         /// <param name="data">The String to search.</param>
         /// <param name="codePoint">The character to search for.</param>
         /// <returns>The nearest index.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int BinarySearchRange(ushort[] data, int codePoint)
         {
             ushort value = 0;
@@ -2352,9 +2334,7 @@ namespace J2N
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if the general Unicode category of the character is
         /// not <see cref="UnicodeCategory.OtherNotAssigned"/>; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsDefined(char c)
         {
             return GetType(c) != UnicodeCategory.OtherNotAssigned;
@@ -2367,9 +2347,7 @@ namespace J2N
         /// <param name="codePoint">The code point to check.</param>
         /// <returns><c>true</c> if the general Unicode category of the code point is
         /// not <see cref="UnicodeCategory.OtherNotAssigned"/>; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsDefined(int codePoint)
         {
             return GetType(codePoint) != UnicodeCategory.OtherNotAssigned;
@@ -2380,9 +2358,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is a digit; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsDigit(char c)
         {
             return char.IsDigit(c);
@@ -2413,9 +2389,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is ignorable; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsIdentifierIgnorable(char c)
         {
             return (c >= 0 && c <= 8) || (c >= 0xe && c <= 0x1b)
@@ -2428,9 +2402,7 @@ namespace J2N
         /// </summary>
         /// <param name="codePoint">The code point to check.</param>
         /// <returns><c>true</c> if <paramref name="codePoint"/> is ignorable; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsIdentifierIgnorable(int codePoint)
         {
             return (codePoint >= 0 && codePoint <= 8) || (codePoint >= 0xe && codePoint <= 0x1b)
@@ -2442,9 +2414,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is an ISO control character; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsISOControl(char c)
         {
             return (c >= 0 && c <= 0x1f) || (c >= 0x7f && c <= 0x9f);
@@ -2455,9 +2425,7 @@ namespace J2N
         /// </summary>
         /// <param name="codePoint">The code point to check.</param>
         /// <returns><c>true</c> if <paramref name="codePoint"/> is an ISO control character; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsISOControl(int codePoint)
         {
             return (codePoint >= 0 && codePoint <= 0x1f) || (codePoint >= 0x7f && codePoint <= 0x9f);
@@ -2479,9 +2447,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is a letter; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsLetter(char c)
         {
             return char.IsLetter(c);
@@ -2512,9 +2478,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is a letter or a digit; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsLetterOrDigit(char c)
         {
             return char.IsLetterOrDigit(c);
@@ -2546,9 +2510,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is a lower case letter; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsLower(char c)
         {
             return char.IsLower(c);
@@ -2755,9 +2717,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is an upper case letter, <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsUpper(char c)
         {
             return char.IsUpper(c);
@@ -2812,9 +2772,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to check.</param>
         /// <returns><c>true</c> if <paramref name="c"/> is a Java whitespace character, <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsWhiteSpace(char c)
         {
             return IsWhiteSpace((int)c);
@@ -2867,9 +2825,7 @@ namespace J2N
         /// </summary>
         /// <param name="c">The character to reverse.</param>
         /// <returns>The character with reordered bytes.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static char ReverseBytes(char c)
         {
             return (char)((c << 8) | (c >> 8));
@@ -2883,9 +2839,7 @@ namespace J2N
         /// <param name="c">The character to be converted.</param>
         /// <returns>The lowercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToLower(char c) => char.ToLower(c);
 
         /// <summary>
@@ -2907,9 +2861,7 @@ namespace J2N
         /// <returns>The lowercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
         /// <exception cref="ArgumentException">If the <paramref name="codePoint"/> is invalid.</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToLower(int codePoint) => ToLower(codePoint, CultureInfo.CurrentCulture);
 
         /// <summary>
@@ -2991,9 +2943,7 @@ namespace J2N
         /// <param name="c">The character to be converted.</param>
         /// <returns>The uppercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToUpper(char c) => char.ToUpper(c);
 
         /// <summary>
@@ -3005,9 +2955,7 @@ namespace J2N
         /// <returns>The uppercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="culture"/> is <c>null</c>.</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToUpper(char c, CultureInfo culture) => char.ToUpper(c, culture);
 
         /// <summary>
@@ -3018,9 +2966,7 @@ namespace J2N
         /// <returns>The uppercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
         /// <exception cref="ArgumentException">If the <paramref name="codePoint"/> is invalid.</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToUpper(int codePoint) => ToUpper(codePoint, CultureInfo.CurrentCulture);
 
         /// <summary>
@@ -3063,9 +3009,7 @@ namespace J2N
         /// <param name="c">The character to be converted.</param>
         /// <returns>The uppercase equivalent of the character, if any;
         /// otherwise, the character itself.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ToUpperInvariant(char c) => char.ToUpperInvariant(c);
 
         /// <summary>
@@ -3274,9 +3218,7 @@ namespace J2N
             return ToStringSlow(codePoints, startIndex, length);
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int GetStringLength(ReadOnlySpan<int> codePoints, int startIndex, int length)
         {
             int result = 0;
@@ -3352,9 +3294,7 @@ namespace J2N
         /// <returns>The total number of <see cref="char"/>s copied to the buffer.</returns>
         /// <exception cref="ArgumentException">One of the <paramref name="codePoints"/> is not a valid Unicode
         /// code point (see <see cref="IsValidCodePoint(int)"/>).</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private unsafe static int WriteCodePointsToCharBuffer(char* buffer, int* codePoints, int startIndex, int length)
         {
             int index = 0;

--- a/src/J2N/Collections/Arrays.cs
+++ b/src/J2N/Collections/Arrays.cs
@@ -55,9 +55,7 @@ namespace J2N.Collections
         /// same length and the elements at each index in the two arrays are
         /// equal according to <see cref="IEqualityComparer{T}.Equals(T, T)"/> of
         /// <see cref="EqualityComparer{T}.Default"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool DeepEquals<T>(T[]? arrayA, T[]? arrayB)
         {
             return StructuralEqualityComparer.Default.Equals(arrayA, arrayB);
@@ -82,9 +80,7 @@ namespace J2N.Collections
         /// <see cref="IList{T}"/>, or <see cref="ISet{T}"/>, its values and any nested collection values
         /// will be compared for equality as well.
         /// </returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool Equals<T>(T[]? arrayA, T[]? arrayB)
         {
             return ArrayEqualityComparer<T>.OneDimensional.Equals(arrayA!, arrayB!);
@@ -116,9 +112,7 @@ namespace J2N.Collections
         /// <typeparam name="T">The type of array.</typeparam>
         /// <param name="array">The array whose hash code to compute.</param>
         /// <returns>The deep hash code for <paramref name="array"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int GetDeepHashCode<T>(T[]? array)
         {
             return StructuralEqualityComparer.Default.GetHashCode(array);
@@ -133,9 +127,7 @@ namespace J2N.Collections
         /// <typeparam name="T">The array element type.</typeparam>
         /// <param name="array">The array whose hash code to compute.</param>
         /// <returns>The hash code for <paramref name="array"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int GetHashCode<T>(T[]? array)
         {
             return ArrayEqualityComparer<T>.OneDimensional.GetHashCode(array!); // J2N TODO: array can be null here, but need to override the constraint
@@ -302,9 +294,7 @@ namespace J2N.Collections
         /// <returns>A copy of the original array, truncated or padded with zeros to obtain the specified length.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="original"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="newLength"/> is less than zero.</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static T[] CopyOf<T>(T[] original, int newLength)
         {
             if (original is null)
@@ -329,9 +319,7 @@ namespace J2N.Collections
         /// <returns>An empty array.</returns>
         // J2N: Since Array.Empty<T>() doesn't exist in all supported platforms, we
         // have this wrapper method to add support.
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static T[] Empty<T>()
         {
 #if FEATURE_ARRAYEMPTY

--- a/src/J2N/Collections/CollectionUtil.cs
+++ b/src/J2N/Collections/CollectionUtil.cs
@@ -47,9 +47,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool Equals<T>(IList<T>? listA, IList<T>? listB)
         {
             return ListEqualityComparer<T>.Aggressive.Equals(listA, listB);
@@ -66,9 +64,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool Equals<T>(ISet<T>? setA, ISet<T>? setB)
         {
             return SetEqualityComparer<T>.Aggressive.Equals(setA, setB);
@@ -85,9 +81,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool Equals<TKey, TValue>(IDictionary<TKey, TValue>? dictionaryA, IDictionary<TKey, TValue>? dictionaryB)
         {
             return DictionaryEqualityComparer<TKey, TValue>.Aggressive.Equals(dictionaryA, dictionaryB);
@@ -180,9 +174,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int GetHashCode<T>(IList<T>? list)
         {
             return ListEqualityComparer<T>.Aggressive.GetHashCode(list);
@@ -199,9 +191,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int GetHashCode<T>(ISet<T>? set)
         {
             return SetEqualityComparer<T>.Aggressive.GetHashCode(set);
@@ -218,9 +208,7 @@ namespace J2N.Collections
         /// Note this operation currently only supports <see cref="IList{T}"/>, <see cref="ISet{T}"/>, 
         /// and <see cref="IDictionary{TKey, TValue}"/>.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int GetHashCode<TKey, TValue>(IDictionary<TKey, TValue>? dictionary)
         {
             return DictionaryEqualityComparer<TKey, TValue>.Aggressive.GetHashCode(dictionary);

--- a/src/J2N/Collections/CollectionUtil.cs
+++ b/src/J2N/Collections/CollectionUtil.cs
@@ -28,9 +28,6 @@ using System.Text;
 
 namespace J2N.Collections
 {
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-
     /// <summary>
     /// Static methods for assisting with making .NET collections check for equality and print
     /// strings the same way they are done in Java.
@@ -437,7 +434,5 @@ namespace J2N.Collections
             dynamic? genericType = Convert.ChangeType(obj, type);
             return ToString(genericType, provider);
         }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
     }
 }

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -2690,17 +2690,13 @@ namespace J2N.Collections.Concurrent
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         private int GetHash([AllowNull] TKey key)
         {
             return (key is null ? 0 : _comparer.GetHashCode(key)) & int.MaxValue;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         private bool KeyEquals([AllowNull] TKey key1, [AllowNull] TKey key2)
         {
             if (key1 is null)

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -810,9 +810,9 @@ namespace J2N.Collections.Concurrent
             set
             {
                 // J2N: Only throw if the generic closing type is not nullable
-                if (key is null && !typeof(TKey).IsNullableType())
+                if (!(default(TKey) == null) && key is null)
                     throw new ArgumentNullException(nameof(key));
-                if (value is null && !typeof(TValue).IsNullableType())
+                if (!(default(TValue) == null) && value is null)
                     throw new ArgumentNullException(nameof(value));
 
                 try
@@ -837,9 +837,9 @@ namespace J2N.Collections.Concurrent
         void IDictionary.Add(object? key, object? value)
         {
             // J2N: Only throw if the generic closing type is not nullable
-            if (key is null && !typeof(TKey).IsNullableType())
+            if (!(default(TKey) == null) && key is null)
                 throw new ArgumentNullException(nameof(key));
-            if (value is null && !typeof(TValue).IsNullableType())
+            if (!(default(TValue) == null) && value is null)
                 throw new ArgumentNullException(nameof(value));
 
             try
@@ -926,7 +926,7 @@ namespace J2N.Collections.Concurrent
         private static bool IsCompatibleKey(object key)
         {
             if (key is null)
-                return typeof(TKey).IsNullableType();
+                return default(TKey) == null;
 
             return (key is TKey);
         }

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -62,15 +62,11 @@ namespace J2N.Collections.Concurrent
     [SuppressMessage("Style", "IDE0019:Use pattern matching", Justification = "Using Microsoft's code styles")]
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
     public class LurchTable<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
         IDisposable
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
     {
         /// <summary> Method signature for the ItemUpdated event </summary>
         public delegate void ItemUpdatedMethod(KeyValuePair<TKey, TValue> previous, KeyValuePair<TKey, TValue> next);
@@ -277,11 +273,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(n) operation, where n is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary) : this(dictionary, LurchTableOrder.None, null) { }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements
@@ -309,11 +301,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(n) operation, where n is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering) : this(dictionary, ordering, null) { }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements copied
@@ -346,11 +334,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer) : this(dictionary, LurchTableOrder.None, comparer) { }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LurchTable{TKey, TValue}"/> class that contains elements copied
@@ -384,11 +368,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, IEqualityComparer<TKey>? comparer)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
             : this(dictionary, ordering, int.MaxValue, comparer) { }
 
         /// <summary>
@@ -424,11 +404,7 @@ namespace J2N.Collections.Concurrent
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LurchTable(IDictionary<TKey, TValue> dictionary, LurchTableOrder ordering, int limit, IEqualityComparer<TKey>? comparer)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
             : this(dictionary is null ? 0 : dictionary.Count, ordering, limit, comparer)
         {
             if (dictionary == null)
@@ -1896,15 +1872,11 @@ namespace J2N.Collections.Concurrent
         /// </summary>
         public KeyCollection Keys => _keyCollection ??= new KeyCollection(this);
 
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
 #if FEATURE_IREADONLYCOLLECTIONS
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 #endif
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
 
         #endregion
 
@@ -2199,15 +2171,11 @@ namespace J2N.Collections.Concurrent
         /// </summary>
         public ValueCollection Values => _valueCollection ??= new ValueCollection(this);
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
 #if FEATURE_IREADONLYCOLLECTIONS
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
 #endif
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         #endregion
 

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -799,7 +799,7 @@ namespace J2N.Collections.Concurrent
             {
                 if (IsCompatibleKey(key))
                 {
-                    if (TryGetValue((TKey)key, out TValue value))
+                    if (TryGetValue((TKey)key, out TValue? value))
                     {
                         return value;
                     }
@@ -817,7 +817,7 @@ namespace J2N.Collections.Concurrent
 
                 try
                 {
-                    TKey tempKey = (TKey)key;
+                    TKey tempKey = (TKey)key!;
                     try
                     {
                         this[tempKey!] = (TValue)value!;
@@ -844,11 +844,11 @@ namespace J2N.Collections.Concurrent
 
             try
             {
-                TKey tempKey = (TKey)key;
+                TKey tempKey = (TKey)key!;
 
                 try
                 {
-                    Add(tempKey!, (TValue)value!);
+                    Add(tempKey, (TValue)value!);
                 }
                 catch (InvalidCastException)
                 {
@@ -985,7 +985,7 @@ namespace J2N.Collections.Concurrent
         {
             get
             {
-                if (!TryGetValue(key, out TValue value))
+                if (!TryGetValue(key, out TValue? value))
                     throw new KeyNotFoundException(J2N.SR.Format(SR.Arg_KeyNotFoundWithKey, key));
                 return value;
             }
@@ -1306,7 +1306,7 @@ namespace J2N.Collections.Concurrent
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
         {
-            if (TryGetValue(item.Key, out TValue test))
+            if (TryGetValue(item.Key, out TValue? test))
                 return J2N.Collections.Generic.EqualityComparer<TValue>.Default.Equals(item.Value, test);
             return false;
         }
@@ -2439,7 +2439,7 @@ namespace J2N.Collections.Concurrent
                     {
                         temp = _entries[index >> _shift][index & _shiftMask].Value;
                         var original = temp;
-                        if (value.UpdateValue(key, ref temp))
+                        if (value.UpdateValue(key, ref temp!))
                         {
                             _entries[index >> _shift][index & _shiftMask].Value = temp;
 
@@ -2460,7 +2460,7 @@ namespace J2N.Collections.Concurrent
                     }
                     index = _entries[index >> _shift][index & _shiftMask].Link;
                 }
-                if (value.CreateValue(key, out temp))
+                if (value.CreateValue(key, out temp!))
                 {
                     index = AllocSlot();
                     _entries[index >> _shift][index & _shiftMask].Hash = hash;

--- a/src/J2N/Collections/Generic/ArraySortHelper.cs
+++ b/src/J2N/Collections/Generic/ArraySortHelper.cs
@@ -54,9 +54,7 @@ namespace J2N.Collections.Generic
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static void Swap(Span<T> a, int i, int j)
         {
             Debug.Assert(i != j);
@@ -252,9 +250,7 @@ namespace J2N.Collections.Generic
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static void Swap(T[] a, int i, int j)
         {
             Debug.Assert(i != j);

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -2043,9 +2043,7 @@ namespace J2N.Collections.Generic
             _freeCount = 0;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private ref int GetBucket(uint hashCode)
         {
             int[] buckets = _buckets!;

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -58,11 +58,7 @@ namespace J2N.Collections.Generic
 #endif
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
     public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
@@ -252,11 +248,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This constructor is an O(n) operation, where n is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public Dictionary(IDictionary<TKey, TValue> dictionary) : this(dictionary, null) { /* Intentionally blank */ }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Dictionary{TKey, TValue}"/> class that contains elements copied
@@ -289,11 +281,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This constructor is an O(<c>n</c>) operation, where <c>n</c> is the number of elements in <paramref name="dictionary"/>.
         /// </remarks>
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
             : this(dictionary?.Count ?? 0, comparer)
         {
             if (dictionary == null)
@@ -1586,13 +1574,9 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         #region IReadOnlyDictionary<TKey, TValue> Members
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         #endregion IReadOnlyDictionary<TKey, TValue> Members
 #endif

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -28,7 +28,7 @@ namespace J2N.Collections.Generic
     /// <list type="bullet">
     ///     <item><description>
     ///         If <typeparamref name="TKey"/> is <see cref="Nullable{T}"/> or a reference type, the key can be
-    ///         <c>null</c> without throwing an exception.
+    ///         <c>null</c> and the value can be retrieved again by with a <c>null</c> key.
     ///     </description></item>
     ///     <item><description>
     ///         Overrides the <see cref="Equals(object)"/> and <see cref="GetHashCode()"/> methods to compare collections
@@ -36,13 +36,18 @@ namespace J2N.Collections.Generic
     ///         default behavior can be overridden.
     ///     </description></item>
     ///     <item><description>
-    ///         Overrides the <see cref="ToString()"/> method to list the contents of the set
+    ///         Overrides the <see cref="ToString()"/> method to list the contents of the dictionary
     ///         by default. Also, <see cref="IFormatProvider"/> is implemented so the
     ///         default behavior can be overridden.
     ///     </description></item>
     ///     <item><description>
     ///         Uses <see cref="EqualityComparer{T}.Default"/> by default, which provides some specialized equality comparisons
     ///         for specific types to match the behavior of Java.
+    ///     </description></item>
+    ///     <item><description>
+    ///         This implementation allows deleting while enumerating, much like the collections in Java and .NET Core 3.0+ do.
+    ///         However, rather than having a method to delete on the enumerator itself, one must call
+    ///         <see cref="Dictionary{TKey, TValue}.Remove(TKey)"/>.
     ///     </description></item>
     /// </list>
     /// <para/>

--- a/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
@@ -138,7 +138,7 @@ namespace J2N.Collections.Generic
                     }
                     else
                     {
-                        if (!dictionaryA.TryGetValue(keyB, out TValue valueA) || !valueEquals(valueA, valueB))
+                        if (!dictionaryA.TryGetValue(keyB, out TValue? valueA) || !valueEquals(valueA, valueB))
                             return false;
                     }
                 }

--- a/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/DictionaryEqualityComparer.cs
@@ -25,11 +25,6 @@ using System.Reflection;
 
 namespace J2N.Collections.Generic
 {
-    // J2N: For some reason, Microsoft decided that no implementation of IDictionary<TKey, TValue> should be allowed to use a null key according
-    // to the nullable constraints. Fortunately, we can ignore this, but it doesn't make for the best user experience, since we allow nulls.
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-
     /// <summary>
     /// Provides comparers that can be used to compare <see cref="IDictionary{TKey, TValue}"/>
     /// implementations for structural equality using rules similar to those
@@ -336,8 +331,6 @@ namespace J2N.Collections.Generic
             { }
         }
     }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
     // A simple interface used to identify a dictionary equality comparer without knowing its
     // generic closing types.

--- a/src/J2N/Collections/Generic/EqualityComparer.cs
+++ b/src/J2N/Collections/Generic/EqualityComparer.cs
@@ -104,9 +104,7 @@ namespace J2N.Collections.Generic
             return true;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode(double? obj) => obj.HasValue ? DoubleComparer.Default.GetHashCode(obj.Value) : 0;
 
         // Equals method for the comparer itself.
@@ -145,9 +143,7 @@ namespace J2N.Collections.Generic
             return true;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode(float? obj) => obj.HasValue ? SingleComparer.Default.GetHashCode(obj.Value) : 0;
 
         // Equals method for the comparer itself.

--- a/src/J2N/Collections/Generic/Extensions/CollectionExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/CollectionExtensions.cs
@@ -43,9 +43,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static ICollection<T> AsReadOnly<T>(this ICollection<T> collection)
         {
             return new ReadOnlyCollection<T>(collection);
@@ -61,9 +59,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <typeparam name="T">The type of the elements of <paramref name="source"/>.</typeparam>
         /// <param name="source">An <see cref="ICollection{T}"/> to create an array from.</param>
         /// <returns>An array that contains the elements from the input sequence.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static T[] ToArray<T>(this ICollection<T> source)
         {
             if (source == null)

--- a/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
@@ -43,9 +43,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static J2N.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> collection)
         {
             return new J2N.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>(collection);

--- a/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/DictionaryExtensions.cs
@@ -46,11 +46,7 @@ namespace J2N.Collections.Generic.Extensions
 #if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public static J2N.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this IDictionary<TKey, TValue> collection)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
         {
             return new J2N.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>(collection);
         }

--- a/src/J2N/Collections/Generic/Extensions/ListExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/ListExtensions.cs
@@ -47,9 +47,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static ReadOnlyList<T> AsReadOnly<T>(this IList<T> collection)
         {
             return new ReadOnlyList<T>(collection);
@@ -72,9 +70,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <returns>The non-negative index of the element, or a negative index which
         /// is the <c>-index - 1</c> where the element would be inserted.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="list"/> is <c>null</c>.</exception>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int BinarySearch<T>(this IList<T> list, T item)
             => BinarySearch(list, item, null);
 
@@ -439,9 +435,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <param name="list">The <see cref="IList{T}"/> to shuffle.</param>
         /// <exception cref="ArgumentNullException">If <paramref name="list"/> is <c>null</c>.</exception>
         /// <seealso cref="Shuffle{T}(IList{T}, System.Random)"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static void Shuffle<T>(this IList<T> list)
         {
             Shuffle(list, new Random());

--- a/src/J2N/Collections/Generic/Extensions/SetExtensions.cs
+++ b/src/J2N/Collections/Generic/Extensions/SetExtensions.cs
@@ -43,9 +43,7 @@ namespace J2N.Collections.Generic.Extensions
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static ReadOnlySet<T> AsReadOnly<T>(this ISet<T> collection)
         {
             return new ReadOnlySet<T>(collection);

--- a/src/J2N/Collections/Generic/HashHelpers.SerializationInfoTable.cs
+++ b/src/J2N/Collections/Generic/HashHelpers.SerializationInfoTable.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Used by Hashtable and Dictionary's SeralizationInfo .ctor's to store the SeralizationInfo
+// object until OnDeserialization is called.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Threading;
+
+namespace System.Collections
+{
+    internal static partial class HashHelpers
+    {
+        private static ConditionalWeakTable<object, SerializationInfo>? s_serializationInfoTable;
+
+        public static ConditionalWeakTable<object, SerializationInfo> SerializationInfoTable
+        {
+            get
+            {
+                if (s_serializationInfoTable == null)
+                    Interlocked.CompareExchange(ref s_serializationInfoTable, new ConditionalWeakTable<object, SerializationInfo>(), null);
+
+                return s_serializationInfoTable;
+            }
+        }
+    }
+}

--- a/src/J2N/Collections/Generic/HashHelpers.cs
+++ b/src/J2N/Collections/Generic/HashHelpers.cs
@@ -4,7 +4,9 @@
 using J2N;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-
+#if !FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+using MethodImplOptions = J2N.MethodImplOptions;
+#endif
 
 namespace System.Collections
 {
@@ -95,9 +97,7 @@ namespace System.Collections
         public static ulong GetFastModMultiplier(uint divisor)
             => ulong.MaxValue / divisor + 1;
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static uint FastMod(uint value, uint divisor, ulong multiplier)
         {
             // Using fastmod from Daniel Lemire https://lemire.me/blog/2019/02/08/faster-remainders-when-the-divisor-is-a-constant-beating-compilers-and-libdivide/

--- a/src/J2N/Collections/Generic/HashHelpers.cs
+++ b/src/J2N/Collections/Generic/HashHelpers.cs
@@ -92,7 +92,6 @@ namespace System.Collections
             return GetPrime(newSize);
         }
 
-#if BIT64
         public static ulong GetFastModMultiplier(uint divisor)
             => ulong.MaxValue / divisor + 1;
 
@@ -111,6 +110,5 @@ namespace System.Collections
             Debug.Assert(high == value % divisor);
             return high;
         }
-#endif
     }
 }

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -2292,9 +2292,7 @@ namespace J2N.Collections.Generic
         /// <param name="item"></param>
         /// <param name="comparer"></param>
         /// <returns>hash code</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         private static int InternalGetHashCode(T item, IEqualityComparer<T>? comparer)
         {
             if (item == null)
@@ -2306,9 +2304,7 @@ namespace J2N.Collections.Generic
             return hashCode & Lower31BitMask;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         private static int InternalGetHashCode(int hashCode)
         {
             return hashCode & Lower31BitMask;

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.ObjectModel;
+using J2N.Runtime.CompilerServices;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -59,10 +60,6 @@ namespace J2N.Collections.Generic
         , System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable
 #endif
     {
-#if !FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-        private static readonly bool TIsNullableType = typeof(T).IsNullableType();
-#endif
-
         // store lower 31 bits of hash code
         private const int Lower31BitMask = 0x7FFFFFFF;
         // cutoff point, above which we won't do stackallocs. This corresponds to 100 integers.
@@ -577,11 +574,7 @@ namespace J2N.Collections.Generic
                 slots[last].next = slots[i].next;
             }
             slots[i].hashCode = -1;
-#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-#else
-            if (TIsNullableType)
-#endif
+            if (RuntimeHelper.IsReferenceOrContainsReferences<T>())
             {
                 slots[i].value = default!;
             }

--- a/src/J2N/Collections/Generic/IInternalStringEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/IInternalStringEqualityComparer.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace J2N.Collections.Generic
+{
+    /// <summary>
+    /// Represents an <see cref="IEqualityComparer{String}"/> that's meant for internal
+    /// use only and isn't intended to be serialized or returned back to the user.
+    /// Use the <see cref="GetUnderlyingEqualityComparer()"/> method to get the object
+    /// that should actually be returned to the caller.
+    /// </summary>
+    internal interface IInternalStringEqualityComparer : IEqualityComparer<string?>
+    {
+        IEqualityComparer<string?> GetUnderlyingEqualityComparer();
+    }
+
+    internal static class InternalStringEqualityComparer
+    {
+        /// <summary>
+        /// Unwraps the internal equality comparer, if proxied.
+        /// Otherwise returns the equality comparer itself or its default equivalent.
+        /// </summary>
+        internal static IEqualityComparer<string?> GetUnderlyingEqualityComparer(IEqualityComparer<string?> outerComparer)
+        {
+            if (outerComparer is IInternalStringEqualityComparer internalComparer)
+            {
+                return internalComparer.GetUnderlyingEqualityComparer();
+            }
+            else
+            {
+                return outerComparer;
+            }
+        }
+    }
+}

--- a/src/J2N/Collections/Generic/InsertionBehavior.cs
+++ b/src/J2N/Collections/Generic/InsertionBehavior.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace J2N.Collections.Generic
+{
+    /// <summary>
+    /// Used internally to control behavior of insertion into a <see cref="Dictionary{TKey, TValue}"/>
+    /// or <see cref="HashSet{T}"/>.
+    /// </summary>
+    internal enum InsertionBehavior : byte
+    {
+        /// <summary>
+        /// The default insertion behavior.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies that an existing entry with the same key should be overwritten if encountered.
+        /// </summary>
+        OverwriteExisting = 1,
+
+        /// <summary>
+        /// Specifies that if an existing entry with the same key is encountered, an exception should be thrown.
+        /// </summary>
+        ThrowOnExisting = 2
+    }
+}

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -719,7 +719,7 @@ namespace J2N.Collections.Generic
         /// </remarks>
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
-        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767 // Nullability of reference types in type of parameter doesn't match implicitly implemented member (possibly because of nullability attributes).
 #pragma warning restore IDE0079 // Remove unnecessary suppression
         {
@@ -878,7 +878,7 @@ namespace J2N.Collections.Generic
             {
                 if (IsCompatibleKey(key))
                 {
-                    if (TryGetValue((TKey)key, out TValue value))
+                    if (TryGetValue((TKey)key!, out TValue? value))
                     {
                         return value;
                     }
@@ -896,7 +896,7 @@ namespace J2N.Collections.Generic
 
                 try
                 {
-                    TKey tempKey = (TKey)key;
+                    TKey tempKey = (TKey)key!;
                     try
                     {
                         this[tempKey] = (TValue)value!;
@@ -923,11 +923,11 @@ namespace J2N.Collections.Generic
 
             try
             {
-                TKey tempKey = (TKey)key;
+                TKey tempKey = (TKey)key!;
 
                 try
                 {
-                    Add(tempKey, (TValue)value);
+                    Add(tempKey, (TValue)value!);
                 }
                 catch (InvalidCastException)
                 {
@@ -944,7 +944,7 @@ namespace J2N.Collections.Generic
         {
             if (IsCompatibleKey(key))
             {
-                return ContainsKey((TKey)key);
+                return ContainsKey((TKey)key!);
             }
             return false;
         }
@@ -958,7 +958,7 @@ namespace J2N.Collections.Generic
         {
             if (IsCompatibleKey(key))
             {
-                Remove((TKey)key);
+                Remove((TKey)key!);
             }
         }
 

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -79,12 +79,7 @@ namespace J2N.Collections.Generic
 #endif
     [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
     [DebuggerDisplay("Count = {Count}")]
-
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type 'TKey' cannot be used as type parameter 'TKey' in the generic type or method 'IDictionary<TKey, TValue>'. Nullability of type argument 'TKey' doesn't match 'notnull' constraint.
     public class LinkedDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
-#pragma warning restore CS8714 // The type 'TKey' cannot be used as type parameter 'TKey' in the generic type or method 'IDictionary<TKey, TValue>'. Nullability of type argument 'TKey' doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
@@ -153,13 +148,9 @@ namespace J2N.Collections.Generic
             list = new LinkedList<KeyValuePair<TKey, TValue>>();
         }
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public LinkedDictionary(IDictionary<TKey, TValue> dictionary) : this(dictionary, null) { }
 
         public LinkedDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
             : this(dictionary != null ? dictionary.Count : 0, comparer)
         {
             if (dictionary == null)
@@ -1016,13 +1007,9 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         #region IReadOnlyDictionary<TKey, TValue> Members
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         #endregion IReadOnlyDictionary<TKey, TValue> Members
 #endif

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #endregion
 
 using J2N.Collections.ObjectModel;
+using J2N.Runtime.CompilerServices;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -781,7 +782,7 @@ namespace J2N.Collections.Generic
         private static bool IsCompatibleKey(object? key)
         {
             if (key is null)
-                return typeof(TKey).IsNullableType();
+                return default(TKey) == null;
 
             return (key is TKey);
         }
@@ -883,9 +884,9 @@ namespace J2N.Collections.Generic
             set
             {
                 // J2N: Only throw if the generic closing type is not nullable
-                if (key is null && !typeof(TKey).IsNullableType())
+                if (!(default(TKey) == null) && key is null)
                     throw new ArgumentNullException(nameof(key));
-                if (value is null && !typeof(TValue).IsNullableType())
+                if (!(default(TValue) == null) && value is null)
                     throw new ArgumentNullException(nameof(value));
 
                 try
@@ -910,9 +911,9 @@ namespace J2N.Collections.Generic
         void IDictionary.Add(object? key, object? value)
         {
             // J2N: Only throw if the generic closing type is not nullable
-            if (key is null && !typeof(TKey).IsNullableType())
+            if (!(default(TKey) == null) && key is null)
                 throw new ArgumentNullException(nameof(key));
-            if (value is null && !typeof(TValue).IsNullableType())
+            if (!(default(TValue) == null) && value is null)
                 throw new ArgumentNullException(nameof(value));
 
             try

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -310,9 +310,6 @@ namespace J2N.Collections.Generic
                 array[index++] = item;
         }
 
-
-#if FEATURE_DICTIONARY_ENSURECAPACITY
-
         /// <summary>
         /// Ensures that the dictionary can hold up to a specified number of entries without any
         /// further expansion of its backing storage.
@@ -328,7 +325,7 @@ namespace J2N.Collections.Generic
             version++;
             return dictionary.EnsureCapacity(capacity);
         }
-#endif
+
 #if FEATURE_SERIALIZABLE
 
         /// <summary>
@@ -403,8 +400,6 @@ namespace J2N.Collections.Generic
         }
 #endif
 
-#if FEATURE_DICTIONARY_TRIMEXCESS
-
         /// <summary>
         /// Sets the capacity of this dictionary to hold up a specified number of entries
         /// without any further expansion of its backing storage.
@@ -440,7 +435,6 @@ namespace J2N.Collections.Generic
             version++;
             dictionary.TrimExcess();
         }
-#endif
 
         /// <summary>
         /// Attempts to add the specified key and value to the dictionary.

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.ObjectModel;
+using J2N.Runtime.CompilerServices;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -55,10 +56,6 @@ namespace J2N.Collections.Generic
     {
         private const int MaxArrayLength = 0X7FEFFFFF;
         private const int DefaultCapacity = 4;
-
-#if !FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-        internal static readonly bool TIsNullableType = typeof(T).IsNullableType();
-#endif
 
 #if FEATURE_SERIALIZABLE
         [NonSerialized]
@@ -696,11 +693,7 @@ namespace J2N.Collections.Generic
         internal virtual void DoClear()
         {
             _version++;
-#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-#else
-            if (TIsNullableType)
-#endif
+            if (RuntimeHelper.IsReferenceOrContainsReferences<T>())
             {
                 int size = _size;
                 _size = 0;
@@ -1956,11 +1949,7 @@ namespace J2N.Collections.Generic
                 _items[freeIndex++] = _items[current++];
             }
 
-#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-#else
-            if (TIsNullableType)
-#endif
+            if (RuntimeHelper.IsReferenceOrContainsReferences<T>())
             {
                 Array.Clear(_items, freeIndex, _size - freeIndex); // Clear the elements so that the gc can reclaim the references.
             }
@@ -2003,11 +1992,7 @@ namespace J2N.Collections.Generic
             {
                 Array.Copy(_items, index + 1, _items, index, _size - index);
             }
-#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-#else
-            if (TIsNullableType)
-#endif
+            if (RuntimeHelper.IsReferenceOrContainsReferences<T>())
             {
                 _items[_size] = default!;
             }
@@ -2055,11 +2040,7 @@ namespace J2N.Collections.Generic
                 }
 
                 _version++;
-#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
-                if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-#else
-                if (TIsNullableType)
-#endif
+                if (RuntimeHelper.IsReferenceOrContainsReferences<T>())
                 {
                     Array.Clear(_items, _size, count);
                 }

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -381,9 +381,7 @@ namespace J2N.Collections.Generic
         }
 
         // From System.ThrowHelper
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool NullAndNullsAreIllegal(object? value)
         {
             // Note that default(T) is not equal to null for value types except when T is Nullable<U>.
@@ -425,15 +423,11 @@ namespace J2N.Collections.Generic
         /// capacity needs to be increased to accommodate the new element, this method becomes an O(<c>n</c>)
         /// operation, where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void Add(T item)
             => DoAdd(item); // Hack so we can override
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal virtual void DoAdd(T item)
         {
             _version++;
@@ -568,9 +562,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation, where <c>n</c> is the number of elements in the range.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public int BinarySearch(int index, int count, T item, IComparer<T>? comparer)
         {
             CoModificationCheck();
@@ -683,9 +675,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void Clear()
             => DoClear(); // Hack so we can override
 

--- a/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -23,10 +23,9 @@ namespace J2N.Collections.Generic
     /// keeps the performance not affected till we hit collision threshold and then we switch to the comparer which is using
     /// randomized string hashing.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    [Serializable] // Required for compatibility with .NET Core 2.0 as we exposed the NonRandomizedStringEqualityComparer inside the serialization blob
-    // Needs to be public to support binary serialization compatibility
-    public class NonRandomizedStringEqualityComparer : IEqualityComparer<string?>, IInternalStringEqualityComparer, ISerializable
+    // J2N: Although, this is public in .NET, we don't need to maintain compatibility with .NET Core 2.0 so this is internal.
+    // This has never been exposed in the J2N serialization blob.
+    internal class NonRandomizedStringEqualityComparer : IEqualityComparer<string?>, IInternalStringEqualityComparer, ISerializable
     {
         // Dictionary<...>.Comparer and similar methods need to return the original IEqualityComparer
         // that was passed in to the ctor. The caller chooses one of these singletons so that the

--- a/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -1,0 +1,287 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.Numerics;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace J2N.Collections.Generic
+{
+    /// <summary>
+    /// NonRandomizedStringEqualityComparer is the comparer used by default with the Dictionary&lt;string,...&gt;
+    /// We use NonRandomizedStringEqualityComparer as default comparer as it doesnt use the randomized string hashing which
+    /// keeps the performance not affected till we hit collision threshold and then we switch to the comparer which is using
+    /// randomized string hashing.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Serializable] // Required for compatibility with .NET Core 2.0 as we exposed the NonRandomizedStringEqualityComparer inside the serialization blob
+    // Needs to be public to support binary serialization compatibility
+    public class NonRandomizedStringEqualityComparer : IEqualityComparer<string?>, IInternalStringEqualityComparer, ISerializable
+    {
+        // Dictionary<...>.Comparer and similar methods need to return the original IEqualityComparer
+        // that was passed in to the ctor. The caller chooses one of these singletons so that the
+        // GetUnderlyingEqualityComparer method can return the correct value.
+
+        private static readonly NonRandomizedStringEqualityComparer WrappedAroundDefaultComparer = new OrdinalComparer(EqualityComparer<string?>.Default);
+        private static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinal = new OrdinalComparer(StringComparer.Ordinal);
+        //private static readonly NonRandomizedStringEqualityComparer WrappedAroundStringComparerOrdinalIgnoreCase = new OrdinalIgnoreCaseComparer(StringComparer.OrdinalIgnoreCase);
+
+        private readonly IEqualityComparer<string?> _underlyingComparer;
+
+        private NonRandomizedStringEqualityComparer(IEqualityComparer<string?> underlyingComparer)
+        {
+            Debug.Assert(underlyingComparer != null);
+            _underlyingComparer = underlyingComparer!;
+        }
+
+        // This is used by the serialization engine.
+        //[Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        protected NonRandomizedStringEqualityComparer(SerializationInfo information, StreamingContext context)
+            : this(EqualityComparer<string?>.Default)
+        {
+        }
+
+        public virtual bool Equals(string? x, string? y)
+        {
+            // This instance may have been deserialized into a class that doesn't guarantee
+            // these parameters are non-null. Can't short-circuit the null checks.
+
+            return string.Equals(x, y);
+        }
+
+        public virtual int GetHashCode(string? obj)
+        {
+            // This instance may have been deserialized into a class that doesn't guarantee
+            // these parameters are non-null. Can't short-circuit the null checks.
+
+            //return obj?.GetNonRandomizedHashCode() ?? 0;
+            if (obj is null)
+                return 0;
+            return GetNonRandomizedHashCode(obj);
+        }
+
+        internal virtual RandomizedStringEqualityComparer GetRandomizedEqualityComparer()
+        {
+            return RandomizedStringEqualityComparer.Create(_underlyingComparer, ignoreCase: false);
+        }
+
+        // Gets the comparer that should be returned back to the caller when querying the
+        // ICollection.Comparer property. Also used for serialization purposes.
+        public virtual IEqualityComparer<string?> GetUnderlyingEqualityComparer() => _underlyingComparer;
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            // We are doing this to stay compatible with .NET Framework.
+            // Our own collection types will never call this (since this type is a wrapper),
+            // but perhaps third-party collection types could try serializing an instance
+            // of this.
+            //System.Collections.Generic.EqualityComparer<string>.
+
+            //info.SetType(typeof(System.Collections.Generic.GenericEqualityComparer<string>));
+            info.SetType(typeof(EqualityComparer<string>));
+        }
+
+        private sealed class OrdinalComparer : NonRandomizedStringEqualityComparer
+        {
+            internal OrdinalComparer(IEqualityComparer<string?> wrappedComparer)
+                : base(wrappedComparer)
+            {
+            }
+
+            public override bool Equals(string? x, string? y) => string.Equals(x, y, StringComparison.Ordinal);
+
+            public override int GetHashCode(string? obj)
+            {
+                //Debug.Assert(obj != null, "This implementation is only called from first-party collection types that guarantee non-null parameters.");
+                //return obj.GetNonRandomizedHashCode();
+                return obj is null ? 0 : GetNonRandomizedHashCode(obj);
+            }
+        }
+
+        //private sealed class OrdinalIgnoreCaseComparer : NonRandomizedStringEqualityComparer
+        //{
+        //    internal OrdinalIgnoreCaseComparer(IEqualityComparer<string?> wrappedComparer)
+        //        : base(wrappedComparer)
+        //    {
+        //    }
+
+        //    public override bool Equals(string? x, string? y) => string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
+
+        //    public override int GetHashCode(string? obj)
+        //    {
+        //        Debug.Assert(obj != null, "This implementation is only called from first-party collection types that guarantee non-null parameters.");
+        //        return obj.GetNonRandomizedHashCodeOrdinalIgnoreCase();
+        //    }
+
+        //    //internal override RandomizedStringEqualityComparer GetRandomizedEqualityComparer()
+        //    //{
+        //    //    return RandomizedStringEqualityComparer.Create(_underlyingComparer, ignoreCase: true);
+        //    //}
+
+        //    //internal unsafe int GetNonRandomizedHashCodeOrdinalIgnoreCase(string value) // From String class
+        //    //{
+        //    //    uint hash1 = (5381 << 16) + 5381;
+        //    //    uint hash2 = hash1;
+
+        //    //    fixed (char* src = value)
+        //    //    {
+        //    //        Debug.Assert(src[value.Length] == '\0', "src[this.Length] == '\\0'");
+        //    //        Debug.Assert(((int)src) % 4 == 0, "Managed string should start at 4 bytes boundary");
+
+        //    //        uint* ptr = (uint*)src;
+        //    //        int length = value.Length;
+
+        //    //        // We "normalize to lowercase" every char by ORing with 0x0020. This casts
+        //    //        // a very wide net because it will change, e.g., '^' to '~'. But that should
+        //    //        // be ok because we expect this to be very rare in practice.
+        //    //        const uint NormalizeToLowercase = 0x0020_0020u; // valid both for big-endian and for little-endian
+
+        //    //        while (length > 2)
+        //    //        {
+        //    //            uint p0 = ptr[0];
+        //    //            uint p1 = ptr[1];
+        //    //            if (!Utf16Utility.AllCharsInUInt32AreAscii(p0 | p1))
+        //    //            {
+        //    //                goto NotAscii;
+        //    //            }
+
+        //    //            length -= 4;
+        //    //            // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
+        //    //            hash1 = (BitOperation.RotateLeft(hash1, 5) + hash1) ^ (p0 | NormalizeToLowercase);
+        //    //            hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ (p1 | NormalizeToLowercase);
+        //    //            ptr += 2;
+        //    //        }
+
+        //    //        if (length > 0)
+        //    //        {
+        //    //            uint p0 = ptr[0];
+        //    //            if (!Utf16Utility.AllCharsInUInt32AreAscii(p0))
+        //    //            {
+        //    //                goto NotAscii;
+        //    //            }
+
+        //    //            // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
+        //    //            hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ (p0 | NormalizeToLowercase);
+        //    //        }
+        //    //    }
+
+        //    //    return (int)(hash1 + (hash2 * 1566083941));
+
+        //    //NotAscii:
+        //    //    return GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(value);
+
+        //    //    static int GetNonRandomizedHashCodeOrdinalIgnoreCaseSlow(string str)
+        //    //    {
+        //    //        int length = str.Length;
+        //    //        char[]? borrowedArr = null;
+        //    //        // Important: leave an additional space for '\0'
+        //    //        Span<char> scratch = (uint)length < 64 ?
+        //    //            stackalloc char[64] : (borrowedArr = ArrayPool<char>.Shared.Rent(length + 1));
+
+        //    //        //int charsWritten = Ordinal.ToUpperOrdinal(str, scratch);
+        //    //        //int charsWritten = System.MemoryExtensions.ToUpper(str.AsSpan, scratch, )
+        //    //        Debug.Assert(charsWritten == length);
+        //    //        scratch[length] = '\0';
+
+        //    //        const uint NormalizeToLowercase = 0x0020_0020u;
+        //    //        uint hash1 = (5381 << 16) + 5381;
+        //    //        uint hash2 = hash1;
+
+        //    //        // Duplicate the main loop, can be removed once JIT gets "Loop Unswitching" optimization
+        //    //        fixed (char* src = scratch)
+        //    //        {
+        //    //            uint* ptr = (uint*)src;
+        //    //            while (length > 2)
+        //    //            {
+        //    //                length -= 4;
+        //    //                hash1 = (BitOperation.RotateLeft(hash1, 5) + hash1) ^ (ptr[0] | NormalizeToLowercase);
+        //    //                hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ (ptr[1] | NormalizeToLowercase);
+        //    //                ptr += 2;
+        //    //            }
+
+        //    //            if (length > 0)
+        //    //            {
+        //    //                hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ (ptr[0] | NormalizeToLowercase);
+        //    //            }
+        //    //        }
+
+        //    //        if (borrowedArr != null)
+        //    //        {
+        //    //            ArrayPool<char>.Shared.Return(borrowedArr);
+        //    //        }
+        //    //        return (int)(hash1 + (hash2 * 1566083941));
+        //    //    }
+        //    //}
+        //}
+
+        public static IEqualityComparer<string>? GetStringComparer(object comparer)
+        {
+            // Special-case EqualityComparer<string>.Default, StringComparer.Ordinal, and StringComparer.OrdinalIgnoreCase.
+            // We use a non-randomized comparer for improved perf, falling back to a randomized comparer if the
+            // hash buckets become unbalanced.
+
+            if (ReferenceEquals(comparer, EqualityComparer<string>.Default))
+            {
+                return WrappedAroundDefaultComparer;
+            }
+
+            if (ReferenceEquals(comparer, StringComparer.Ordinal))
+            {
+                return WrappedAroundStringComparerOrdinal;
+            }
+
+            // J2N TODO: Finish implementation for OrdinalIgnoreCase
+            //if (ReferenceEquals(comparer, StringComparer.OrdinalIgnoreCase))
+            //{
+            //    return WrappedAroundStringComparerOrdinalIgnoreCase;
+            //}
+
+            return null;
+        }
+
+        // Use this if and only if 'Denial of Service' attacks are not a concern (i.e. never used for free-form user input),
+        // or are otherwise mitigated
+        internal unsafe int GetNonRandomizedHashCode(string value) // From String class
+        {
+            fixed (char* src = value)
+            {
+                Debug.Assert(src[value.Length] == '\0', "src[this.Length] == '\\0'");
+                Debug.Assert(((int)src) % 4 == 0, "Managed string should start at 4 bytes boundary");
+
+                uint hash1 = (5381 << 16) + 5381;
+                uint hash2 = hash1;
+
+                uint* ptr = (uint*)src;
+                int length = value.Length;
+
+                while (length > 2)
+                {
+                    length -= 4;
+                    // Where length is 4n-1 (e.g. 3,7,11,15,19) this additionally consumes the null terminator
+                    hash1 = (BitOperation.RotateLeft(hash1, 5) + hash1) ^ ptr[0];
+                    hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ ptr[1];
+                    ptr += 2;
+                }
+
+                if (length > 0)
+                {
+                    // Where length is 4n-3 (e.g. 1,5,9,13,17) this additionally consumes the null terminator
+                    hash2 = (BitOperation.RotateLeft(hash2, 5) + hash2) ^ ptr[0];
+                }
+
+                return (int)(hash1 + (hash2 * 1566083941));
+            }
+        }
+    }
+}

--- a/src/J2N/Collections/Generic/RandomizedStringEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/RandomizedStringEqualityComparer.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.Security.Cryptography;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using SCG = System.Collections.Generic;
+
+namespace J2N.Collections.Generic
+{
+    /// <summary>
+    /// A randomized <see cref="EqualityComparer{String}"/> which uses a different seed on each
+    /// construction as a general good hygiene + defense-in-depth mechanism. This implementation
+    /// *does not* need to stay in sync with string.GetHashCode, which for stability
+    /// is required to use an app-global seed.
+    /// </summary>
+    internal abstract class RandomizedStringEqualityComparer : SCG.EqualityComparer<string?>, IInternalStringEqualityComparer
+    {
+        private readonly MarvinSeed _seed;
+        private readonly IEqualityComparer<string?> _underlyingComparer;
+
+        private unsafe RandomizedStringEqualityComparer(IEqualityComparer<string?> underlyingComparer)
+        {
+            _underlyingComparer = underlyingComparer;
+
+            // Use RandomHelpers to fill MarvinSeed with random bytes
+            fixed (MarvinSeed* seed = &_seed)
+            {
+                RandomHelpers.GetRandomBytes((byte*)seed, sizeof(MarvinSeed));
+            }
+        }
+
+        internal static RandomizedStringEqualityComparer Create(IEqualityComparer<string?> underlyingComparer, bool ignoreCase)
+        {
+            if (!ignoreCase)
+            {
+                return new OrdinalComparer(underlyingComparer);
+            }
+            else
+            {
+                return new OrdinalIgnoreCaseComparer(underlyingComparer);
+            }
+        }
+
+        public IEqualityComparer<string?> GetUnderlyingEqualityComparer() => _underlyingComparer;
+
+        private struct MarvinSeed
+        {
+            internal uint p0;
+            internal uint p1;
+        }
+
+        private sealed class OrdinalComparer : RandomizedStringEqualityComparer
+        {
+            internal OrdinalComparer(IEqualityComparer<string?> wrappedComparer)
+                : base(wrappedComparer)
+            {
+            }
+
+            public override bool Equals(string? x, string? y) => string.Equals(x, y);
+
+            public override int GetHashCode(string? obj)
+            {
+                if (obj is null)
+                {
+                    return 0;
+                }
+
+                // The Ordinal version of Marvin32 operates over bytes.
+                // The multiplication from # chars -> # bytes will never integer overflow.
+                unsafe
+                {
+                    fixed (char* charPtr = obj)
+                    {
+                        // Treat the char* as a byte* to operate over bytes
+                        byte* bytePtr = (byte*)charPtr;
+
+                        // Compute the hash using the Marvin algorithm
+                        return Marvin.ComputeHash32(ref *bytePtr, (uint)obj.Length * 2, _seed.p0, _seed.p1);
+                    }
+                }
+            }
+        }
+
+        private sealed class OrdinalIgnoreCaseComparer : RandomizedStringEqualityComparer
+        {
+            private static readonly StringComparer _stringComparer = StringComparer.OrdinalIgnoreCase;
+
+            internal OrdinalIgnoreCaseComparer(IEqualityComparer<string?> wrappedComparer)
+                : base(wrappedComparer)
+            {
+            }
+
+            public override bool Equals(string? x, string? y) => _stringComparer.Equals(x, y); //string.EqualsOrdinalIgnoreCase(x, y);
+
+            public override int GetHashCode(string? obj)
+            {
+                if (obj is null)
+                {
+                    return 0;
+                }
+
+                // J2N TODO: Finsh randomized implementation for OrdinalIgnoreCase
+                return _stringComparer.GetHashCode(obj);
+
+                //// The OrdinalIgnoreCase version of Marvin32 operates over chars,
+                //// so pass in the char count directly.
+                //return Marvin.ComputeHash32OrdinalIgnoreCase(
+                //    ref obj.GetRawStringData(),
+                //    obj.Length,
+                //    _seed.p0, _seed.p1);
+            }
+        }
+    }
+}

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -18,9 +18,6 @@ namespace J2N.Collections.Generic
 {
     using SR = J2N.Resources.Strings;
 
-#pragma warning disable IDE0079 // Remove unnecessary supppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-
     /// <summary>
     /// Represents a collection of key/value pairs that are sorted on the key.
     /// <para/>
@@ -1961,7 +1958,4 @@ namespace J2N.Collections.Generic
             return ret;
         }
     }
-
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary supppression
 }

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.ObjectModel;
+using J2N.Runtime.CompilerServices;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -758,9 +759,9 @@ namespace J2N.Collections.Generic
                 //}
 
                 // J2N: Only throw if the generic closing type is not nullable
-                if (key is null && !typeof(TKey).IsNullableType())
+                if (!(default(TKey) == null) && key is null)
                     throw new ArgumentNullException(nameof(key));
-                if (value is null && !typeof(TValue).IsNullableType())
+                if (!(default(TValue) == null) && value is null)
                     throw new ArgumentNullException(nameof(value));
 
                 try
@@ -790,9 +791,9 @@ namespace J2N.Collections.Generic
             //}
 
             // J2N: Only throw if the generic closing type is not nullable
-            if (key is null && !typeof(TKey).IsNullableType())
+            if (!(default(TKey) == null) && key is null)
                 throw new ArgumentNullException(nameof(key));
-            if (value is null && !typeof(TValue).IsNullableType())
+            if (!(default(TValue) == null) && value is null)
                 throw new ArgumentNullException(nameof(value));
 
             try
@@ -830,7 +831,7 @@ namespace J2N.Collections.Generic
             //    throw new ArgumentNullException(nameof(key));
             //}
             if (key is null)
-                return typeof(TKey).IsNullableType();
+                return default(TKey) == null;
 
             return (key is TKey);
         }

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -742,7 +742,7 @@ namespace J2N.Collections.Generic
             {
                 if (IsCompatibleKey(key))
                 {
-                    if (TryGetValue((TKey)key, out TValue value))
+                    if (TryGetValue((TKey)key, out TValue? value))
                     {
                         return value;
                     }

--- a/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -187,7 +187,7 @@ namespace J2N.Collections.Generic
                 get
                 {
                     Node? current = root;
-                    T result = default!;
+                    T? result = default;
 
                     while (current != null)
                     {
@@ -221,7 +221,7 @@ namespace J2N.Collections.Generic
                 get
                 {
                     Node? current = root;
-                    T result = default!;
+                    T? result = default;
 
                     while (current != null)
                     {

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -259,8 +259,8 @@ namespace J2N.Collections.Generic
 
         private void RemoveAllElements(IEnumerable<T> collection)
         {
-            T min = Min;
-            T max = Max;
+            T? min = Min;
+            T? max = Max;
             foreach (T item in collection)
             {
                 if (!(comparer.Compare(item!, min!) < 0 || comparer.Compare(item!, max!) > 0) && Contains(item))
@@ -1356,7 +1356,7 @@ namespace J2N.Collections.Generic
                 IEnumerator<T> mine = this.GetEnumerator();
                 IEnumerator<T> theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
-                T max = Max;
+                T? max = Max;
 
                 while (!mineEnded && !theirsEnded && Comparer.Compare(theirs.Current!, max!) <= 0)
                 {
@@ -1446,8 +1446,8 @@ namespace J2N.Collections.Generic
                 // Outside range, no point in doing anything
                 if (comparer.Compare(asSorted.Max!, Min!) >= 0 && comparer.Compare(asSorted.Min!, Max!) <= 0)
                 {
-                    T min = Min;
-                    T max = Max;
+                    T? min = Min;
+                    T? max = Max;
                     foreach (T item in other)
                     {
                         if (comparer.Compare(item!, min!) < 0)

--- a/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -29,25 +29,17 @@ namespace J2N.Collections.ObjectModel
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary,
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyDictionary<TKey, TValue>,
 #endif
         IStructuralEquatable, IStructuralFormattable
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
     {
         private static readonly bool TKeyIsValueTypeOrStringOrStructuralEquatable = typeof(TKey).IsValueType || typeof(IStructuralEquatable).IsAssignableFrom(typeof(TKey)) || typeof(string).Equals(typeof(TKey));
         private static readonly bool TValueIsValueTypeOrStringOrStructuralEquatable = typeof(TValue).IsValueType || typeof(IStructuralEquatable).IsAssignableFrom(typeof(TValue)) || typeof(string).Equals(typeof(TValue));
         private static readonly bool TKeyIsNullable = typeof(TKey).IsNullableType();
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         internal readonly IDictionary<TKey, TValue> dictionary; // Internal for testing
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
         private readonly DictionaryEqualityComparer<TKey, TValue> structuralEqualityComparer;
         private readonly IFormatProvider toStringFormatProvider;
 
@@ -69,11 +61,7 @@ namespace J2N.Collections.ObjectModel
         /// </summary>
         /// <param name="dictionary">The dictionary to wrap.</param>
         /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <c>null</c>.</exception>
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         public ReadOnlyDictionary(IDictionary<TKey, TValue> dictionary)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
            : this(dictionary,
                  TKeyIsValueTypeOrStringOrStructuralEquatable && TValueIsValueTypeOrStringOrStructuralEquatable ? 
                     DictionaryEqualityComparer<TKey, TValue>.Default :
@@ -82,11 +70,7 @@ namespace J2N.Collections.ObjectModel
         {
         }
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         internal ReadOnlyDictionary(IDictionary<TKey, TValue> dictionary, DictionaryEqualityComparer<TKey, TValue> structuralEqualityComparer, IFormatProvider toStringFormatProvider)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
         {
             this.dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
             this.structuralEqualityComparer = structuralEqualityComparer ?? throw new ArgumentNullException(nameof(structuralEqualityComparer));
@@ -96,11 +80,7 @@ namespace J2N.Collections.ObjectModel
         /// <summary>
         /// Gets the dictionary that is wrapped by this <see cref="ReadOnlyDictionary{TKey, TValue}"/> object.
         /// </summary>
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         protected internal IDictionary<TKey, TValue> Dictionary => dictionary;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         /// <summary>
         /// Gets a key collection that contains the keys of the dictionary.
@@ -146,11 +126,7 @@ namespace J2N.Collections.ObjectModel
             return dictionary.ContainsKey(key);
         }
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         /// <summary>
         /// Retrieves the value that is associated with the specified key.
@@ -168,11 +144,7 @@ namespace J2N.Collections.ObjectModel
 #pragma warning restore IDE0079 // Remove unnecessary suppression
             => dictionary.TryGetValue(key!, out value!);
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         /// <summary>
         /// Gets the element that has the specified key.
@@ -181,8 +153,6 @@ namespace J2N.Collections.ObjectModel
         /// <returns>The element that has the specified key.</returns>
         public TValue this[[AllowNull] TKey key] => dictionary[key];
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         void IDictionary<TKey, TValue>.Add([AllowNull] TKey key, [AllowNull] TValue value)
         {
             throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
@@ -198,8 +168,6 @@ namespace J2N.Collections.ObjectModel
             get => dictionary[key];
             set => throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         #endregion
 
@@ -409,13 +377,9 @@ namespace J2N.Collections.ObjectModel
 
 #if FEATURE_IREADONLYCOLLECTIONS
         #region IReadOnlyDictionary members
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
 
         IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
 
         #endregion IReadOnlyDictionary members
 #endif
@@ -538,18 +502,10 @@ namespace J2N.Collections.ObjectModel
 #endif
         private struct DictionaryEnumerator : IDictionaryEnumerator
         {
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
             private readonly IDictionary<TKey, TValue> dictionary;
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
             private readonly IEnumerator<KeyValuePair<TKey, TValue>> enumerator;
 
-#pragma warning disable IDE0079 // Remove unnecessary suppression
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
             public DictionaryEnumerator(IDictionary<TKey, TValue> dictionary)
-#pragma warning restore CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
-#pragma warning restore IDE0079 // Remove unnecessary suppression
             {
                 this.dictionary = dictionary;
                 enumerator = this.dictionary.GetEnumerator();

--- a/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.Generic;
+using J2N.Runtime.CompilerServices;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -37,7 +38,6 @@ namespace J2N.Collections.ObjectModel
     {
         private static readonly bool TKeyIsValueTypeOrStringOrStructuralEquatable = typeof(TKey).IsValueType || typeof(IStructuralEquatable).IsAssignableFrom(typeof(TKey)) || typeof(string).Equals(typeof(TKey));
         private static readonly bool TValueIsValueTypeOrStringOrStructuralEquatable = typeof(TValue).IsValueType || typeof(IStructuralEquatable).IsAssignableFrom(typeof(TValue)) || typeof(string).Equals(typeof(TValue));
-        private static readonly bool TKeyIsNullable = typeof(TKey).IsNullableType();
 
         internal readonly IDictionary<TKey, TValue> dictionary; // Internal for testing
         private readonly DictionaryEqualityComparer<TKey, TValue> structuralEqualityComparer;
@@ -231,7 +231,7 @@ namespace J2N.Collections.ObjectModel
         private static bool IsCompatibleKey(object? key)
         {
             if (key is null)
-                return TKeyIsNullable;
+                return default(TKey) == null;
 
             return key is TKey;
         }
@@ -432,7 +432,7 @@ namespace J2N.Collections.ObjectModel
 
 #endregion
 
-#region ToString
+        #region ToString
 
         /// <summary>
         /// Returns a string that represents the current dictionary using the specified

--- a/src/J2N/DoubleExtensions.cs
+++ b/src/J2N/DoubleExtensions.cs
@@ -35,9 +35,7 @@ namespace J2N
         /// </summary>
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is finite (zero, subnormal or normal); otherwise <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsFinite(this double d)
         {
             long bits = BitConversion.DoubleToRawInt64Bits(d);
@@ -54,9 +52,7 @@ namespace J2N
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value evaluates to <see cref="double.PositiveInfinity"/> or
         /// <see cref="double.NegativeInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsInfinity(this double d)
         {
             long bits = BitConversion.DoubleToRawInt64Bits(d);
@@ -74,9 +70,7 @@ namespace J2N
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value evaluates to <see cref="double.NaN"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsNaN(this double d)
         {
             // A NaN will never equal itself so this is an
@@ -97,9 +91,7 @@ namespace J2N
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is negative; otherwise, <c>false</c>.</returns>
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNegative(this double d)
         {
             return BitConversion.DoubleToRawInt64Bits(d) < 0;
@@ -116,9 +108,7 @@ namespace J2N
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if <paramref name="d"/> evaluates to <see cref="double.NegativeInfinity"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNegativeInfinity(this double d)
         {
             return d == double.NegativeInfinity;
@@ -135,9 +125,7 @@ namespace J2N
         /// </summary>
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the current value represents negative zero; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsNegativeZero(this double d)
         {
             return d == 0 && IsNegative(d);
@@ -152,9 +140,7 @@ namespace J2N
         /// </summary>
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is normal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNormal(this double d)
         {
             long bits = BitConversion.DoubleToRawInt64Bits(d);
@@ -171,9 +157,7 @@ namespace J2N
         /// </summary>
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if <paramref name="d"/> evaluates to <see cref="double.PositiveInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsPositiveInfinity(this double d)
         {
             return d == double.PositiveInfinity;
@@ -188,9 +172,7 @@ namespace J2N
         /// </summary>
         /// <param name="d">A double-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is subnormal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsSubnormal(this double d)
         {
             long bits = BitConversion.DoubleToRawInt64Bits(d);

--- a/src/J2N/IntegralNumberExtensions.cs
+++ b/src/J2N/IntegralNumberExtensions.cs
@@ -35,9 +35,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="char"/> to convert</param>
         /// <returns>The binary string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToBinaryString(this char value) => Convert.ToString(value, 2);
 
         /// <summary>
@@ -46,9 +44,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="short"/> to convert</param>
         /// <returns>The binary string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToBinaryString(this short value)
         {
             if (value > 0)
@@ -62,9 +58,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="int"/> to convert</param>
         /// <returns>The binary string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToBinaryString(this int value) => Convert.ToString(value, 2);
 
         /// <summary>
@@ -73,9 +67,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="long"/> to convert</param>
         /// <returns>The binary string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToBinaryString(this long value) => Convert.ToString(value, 2);
 
         #endregion ToBinaryString
@@ -89,9 +81,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="char"/> to convert.</param>
         /// <returns>The hexadecimal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToHexString(this char value) => Convert.ToString(value, 16);
 
         /// <summary>
@@ -101,9 +91,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="short"/> to convert.</param>
         /// <returns>The hexadecimal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToHexString(this short value)
         {
             if (value > 0)
@@ -118,9 +106,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="int"/> to convert.</param>
         /// <returns>The hexadecimal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToHexString(this int value) => Convert.ToString(value, 16);
 
         /// <summary>
@@ -130,9 +116,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="long"/> to convert.</param>
         /// <returns>The hexadecimal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToHexString(this long value) => Convert.ToString(value, 16);
 
         #endregion
@@ -145,9 +129,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="char"/> to convert.</param>
         /// <returns>The octal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToOctalString(this char value) => Convert.ToString(value, 8);
 
         /// <summary>
@@ -156,9 +138,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="short"/> to convert.</param>
         /// <returns>The octal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToOctalString(this short value)
         {
             if (value > 0)
@@ -172,9 +152,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="int"/> to convert.</param>
         /// <returns>The octal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToOctalString(this int value) => Convert.ToString(value, 8);
 
         /// <summary>
@@ -183,9 +161,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The <see cref="long"/> to convert.</param>
         /// <returns>The octal string representation of <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static string ToOctalString(this long value) => Convert.ToString(value, 8);
 
         #endregion

--- a/src/J2N/Marvin.cs
+++ b/src/J2N/Marvin.cs
@@ -15,9 +15,7 @@ namespace J2N
         /// <summary>
         /// Compute a Marvin hash and collapse it into a 32-bit hash.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ComputeHash32(ReadOnlySpan<byte> data, ulong seed) => ComputeHash32(ref MemoryMarshal.GetReference(data), (uint)data.Length, (uint)seed, (uint)(seed >> 32));
 
         /// <summary>
@@ -217,9 +215,7 @@ namespace J2N
             goto DoFinalRoundsAndReturn;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static void Block(ref uint rp0, ref uint rp1)
         {
             // Intrinsified in mono interpreter

--- a/src/J2N/Marvin.cs
+++ b/src/J2N/Marvin.cs
@@ -1,0 +1,254 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.Numerics;
+using J2N.Security.Cryptography;
+using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace J2N
+{
+    internal static partial class Marvin
+    {
+        /// <summary>
+        /// Compute a Marvin hash and collapse it into a 32-bit hash.
+        /// </summary>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static int ComputeHash32(ReadOnlySpan<byte> data, ulong seed) => ComputeHash32(ref MemoryMarshal.GetReference(data), (uint)data.Length, (uint)seed, (uint)(seed >> 32));
+
+        /// <summary>
+        /// Compute a Marvin hash and collapse it into a 32-bit hash.
+        /// </summary>
+        public static int ComputeHash32(ref byte data, uint count, uint p0, uint p1)
+        {
+            // Control flow of this method generally flows top-to-bottom, trying to
+            // minimize the number of branches taken for large (>= 8 bytes, 4 chars) inputs.
+            // If small inputs (< 8 bytes, 4 chars) are given, this jumps to a "small inputs"
+            // handler at the end of the method.
+
+            if (count < 8)
+            {
+                // We can't run the main loop, but we might still have 4 or more bytes available to us.
+                // If so, jump to the 4 .. 7 bytes logic immediately after the main loop.
+
+                if (count >= 4)
+                {
+                    goto Between4And7BytesRemain;
+                }
+                else
+                {
+                    goto InputTooSmallToEnterMainLoop;
+                }
+            }
+
+            // Main loop - read 8 bytes at a time.
+            // The block function is unrolled 2x in this loop.
+
+            uint loopCount = count / 8;
+            Debug.Assert(loopCount > 0, "Shouldn't reach this code path for small inputs.");
+
+            do
+            {
+                // Most x86 processors have two dispatch ports for reads, so we can read 2x 32-bit
+                // values in parallel. We opt for this instead of a single 64-bit read since the
+                // typical use case for Marvin32 is computing String hash codes, and the particular
+                // layout of String instances means the starting data is never 8-byte aligned when
+                // running in a 64-bit process.
+
+                p0 += Unsafe.ReadUnaligned<uint>(ref data);
+                uint nextUInt32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.AddByteOffset(ref data, (IntPtr)4));
+
+                // One block round for each of the 32-bit integers we just read, 2x rounds total.
+
+                Block(ref p0, ref p1);
+                p0 += nextUInt32;
+                Block(ref p0, ref p1);
+
+                // Bump the data reference pointer and decrement the loop count.
+
+                // Decrementing by 1 every time and comparing against zero allows the JIT to produce
+                // better codegen compared to a standard 'for' loop with an incrementing counter.
+                // Requires https://github.com/dotnet/runtime/issues/6794 to be addressed first
+                // before we can realize the full benefits of this.
+
+                data = ref Unsafe.AddByteOffset(ref data, (IntPtr)8);
+            } while (--loopCount > 0);
+
+            // n.b. We've not been updating the original 'count' parameter, so its actual value is
+            // still the original data length. However, we can still rely on its least significant
+            // 3 bits to tell us how much data remains (0 .. 7 bytes) after the loop above is
+            // completed.
+
+            if ((count & 0b_0100) == 0)
+            {
+                goto DoFinalPartialRead;
+            }
+
+        Between4And7BytesRemain:
+
+            // If after finishing the main loop we still have 4 or more leftover bytes, or if we had
+            // 4 .. 7 bytes to begin with and couldn't enter the loop in the first place, we need to
+            // consume 4 bytes immediately and send them through one round of the block function.
+
+            Debug.Assert(count >= 4, "Only should've gotten here if the original count was >= 4.");
+
+            p0 += Unsafe.ReadUnaligned<uint>(ref data);
+            Block(ref p0, ref p1);
+
+        DoFinalPartialRead:
+
+            // Finally, we have 0 .. 3 bytes leftover. Since we know the original data length was at
+            // least 4 bytes (smaller lengths are handled at the end of this routine), we can safely
+            // read the 4 bytes at the end of the buffer without reading past the beginning of the
+            // original buffer. This necessarily means the data we're about to read will overlap with
+            // some data we've already processed, but we can handle that below.
+
+            Debug.Assert(count >= 4, "Only should've gotten here if the original count was >= 4.");
+
+            // Read the last 4 bytes of the buffer.
+
+            uint partialResult = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref Unsafe.AddByteOffset(ref data, ((IntPtr)(count & 7))), -4));
+
+            // The 'partialResult' local above contains any data we have yet to read, plus some number
+            // of bytes which we've already read from the buffer. An example of this is given below
+            // for little-endian architectures. In this table, AA BB CC are the bytes which we still
+            // need to consume, and ## are bytes which we want to throw away since we've already
+            // consumed them as part of a previous read.
+            //
+            //                                                    (partialResult contains)   (we want it to contain)
+            // count mod 4 = 0 -> [ ## ## ## ## |             ] -> 0x####_####             -> 0x0000_0080
+            // count mod 4 = 1 -> [ ## ## ## ## | AA          ] -> 0xAA##_####             -> 0x0000_80AA
+            // count mod 4 = 2 -> [ ## ## ## ## | AA BB       ] -> 0xBBAA_####             -> 0x0080_BBAA
+            // count mod 4 = 3 -> [ ## ## ## ## | AA BB CC    ] -> 0xCCBB_AA##             -> 0x80CC_BBAA
+
+            count = ~count << 3;
+
+            if (BitConverter.IsLittleEndian)
+            {
+                partialResult >>= 8; // make some room for the 0x80 byte
+                partialResult |= 0x8000_0000u; // put the 0x80 byte at the beginning
+                partialResult >>= (int)count & 0x1F; // shift out all previously consumed bytes
+            }
+            else
+            {
+                partialResult <<= 8; // make some room for the 0x80 byte
+                partialResult |= 0x80u; // put the 0x80 byte at the end
+                partialResult <<= (int)count & 0x1F; // shift out all previously consumed bytes
+            }
+
+        DoFinalRoundsAndReturn:
+
+            // Now that we've computed the final partial result, merge it in and run two rounds of
+            // the block function to finish out the Marvin algorithm.
+
+            p0 += partialResult;
+            Block(ref p0, ref p1);
+            Block(ref p0, ref p1);
+
+            return (int)(p1 ^ p0);
+
+        InputTooSmallToEnterMainLoop:
+
+            // We had only 0 .. 3 bytes to begin with, so we can't perform any 32-bit reads.
+            // This means that we're going to be building up the final result right away and
+            // will only ever run two rounds total of the block function. Let's initialize
+            // the partial result to "no data".
+
+            if (BitConverter.IsLittleEndian)
+            {
+                partialResult = 0x80u;
+            }
+            else
+            {
+                partialResult = 0x80000000u;
+            }
+
+            if ((count & 0b_0001) != 0)
+            {
+                // If the buffer is 1 or 3 bytes in length, let's read a single byte now
+                // and merge it into our partial result. This will result in partialResult
+                // having one of the two values below, where AA BB CC are the buffer bytes.
+                //
+                //                  (little-endian / big-endian)
+                // [ AA          ]  -> 0x0000_80AA / 0xAA80_0000
+                // [ AA BB CC    ]  -> 0x0000_80CC / 0xCC80_0000
+
+                partialResult = Unsafe.AddByteOffset(ref data, ((IntPtr)(count & 2)));
+
+                if (BitConverter.IsLittleEndian)
+                {
+                    partialResult |= 0x8000;
+                }
+                else
+                {
+                    partialResult <<= 24;
+                    partialResult |= 0x800000u;
+                }
+            }
+
+            if ((count & 0b_0010) != 0)
+            {
+                // If the buffer is 2 or 3 bytes in length, let's read a single ushort now
+                // and merge it into the partial result. This will result in partialResult
+                // having one of the two values below, where AA BB CC are the buffer bytes.
+                //
+                //                  (little-endian / big-endian)
+                // [ AA BB       ]  -> 0x0080_BBAA / 0xAABB_8000
+                // [ AA BB CC    ]  -> 0x80CC_BBAA / 0xAABB_CC80 (carried over from above)
+
+                if (BitConverter.IsLittleEndian)
+                {
+                    partialResult <<= 16;
+                    partialResult |= (uint)Unsafe.ReadUnaligned<ushort>(ref data);
+                }
+                else
+                {
+                    partialResult |= (uint)Unsafe.ReadUnaligned<ushort>(ref data);
+                    partialResult = BitOperation.RotateLeft(partialResult, 16);
+                }
+            }
+
+            // Everything is consumed! Go perform the final rounds and return.
+
+            goto DoFinalRoundsAndReturn;
+        }
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        private static void Block(ref uint rp0, ref uint rp1)
+        {
+            // Intrinsified in mono interpreter
+            uint p0 = rp0;
+            uint p1 = rp1;
+
+            p1 ^= p0;
+            p0 = BitOperation.RotateLeft(p0, 20);
+
+            p0 += p1;
+            p1 = BitOperation.RotateLeft(p1, 9);
+
+            p1 ^= p0;
+            p0 = BitOperation.RotateLeft(p0, 27);
+
+            p0 += p1;
+            p1 = BitOperation.RotateLeft(p1, 19);
+
+            rp0 = p0;
+            rp1 = p1;
+        }
+
+        public static ulong DefaultSeed { get; } = GenerateSeed();
+
+        private static unsafe ulong GenerateSeed()
+        {
+            ulong seed;
+            RandomHelpers.GetRandomBytes((byte*)&seed, sizeof(ulong));
+            return seed;
+        }
+    }
+}

--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -50,9 +50,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The value whose signum has to be computed.</param>
         /// <returns>The signum function of the specified <see cref="int"/> value.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int Signum(this int value)
         {
             // HD, Section 2-7
@@ -66,9 +64,7 @@ namespace J2N
         /// </summary>
         /// <param name="value">The value whose signum has to be computed.</param>
         /// <returns>The signum function of the specified <see cref="long"/> value.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int Signum(this long value)
         {
             // HD, Section 2-7
@@ -81,9 +77,7 @@ namespace J2N
         /// </summary>
         /// <param name="degrees">An angle in degrees to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static double ToRadians(this double degrees)
         {
             return degrees / 180 * Math.PI;
@@ -95,9 +89,7 @@ namespace J2N
         /// </summary>
         /// <param name="degrees">An angle in degrees to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static decimal ToRadians(this decimal degrees)
         {
             return degrees / 180 * (decimal)Math.PI;
@@ -109,9 +101,7 @@ namespace J2N
         /// </summary>
         /// <param name="degrees">An angle in degrees to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static double ToRadians(this int degrees)
         {
             return ((double)degrees) / 180 * Math.PI;
@@ -124,9 +114,7 @@ namespace J2N
         /// </summary>
         /// <param name="radians">An angle in radians to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static double ToDegrees(this double radians)
         {
             return radians * 180 / Math.PI;
@@ -139,9 +127,7 @@ namespace J2N
         /// </summary>
         /// <param name="radians">An angle in radians to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static decimal ToDegrees(this decimal radians)
         {
             return radians * 180 / (decimal)Math.PI;
@@ -154,9 +140,7 @@ namespace J2N
         /// </summary>
         /// <param name="radians">An angle in radians to convert to radians</param>
         /// <returns>The value in radians</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static double ToDegrees(this int radians)
         {
             return ((double)radians) * 180 / Math.PI;

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -23,9 +23,7 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int IndexOf(this ReadOnlySpan<char> text, char value)
             => System.MemoryExtensions.IndexOf(text, value);
 
@@ -41,9 +39,7 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the occurrence of the value in the span. If not found, returns -1.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int IndexOf(this Span<char> text, char value)
             => System.MemoryExtensions.IndexOf(text, value);
 
@@ -179,9 +175,7 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int LastIndexOf(this ReadOnlySpan<char> text, char value)
             => System.MemoryExtensions.LastIndexOf(text, value);
 
@@ -197,9 +191,7 @@ namespace J2N
         /// <param name="text">The span to search.</param>
         /// <param name="value">The value to search for.</param>
         /// <returns>The index of the last occurrence of the value in the span. If not found, returns -1.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int LastIndexOf(this Span<char> text, char value)
             => System.MemoryExtensions.LastIndexOf(text, value);
 

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -102,9 +102,7 @@ namespace J2N.Numerics
         /// ("leftmost") one-bit in the two's complement binary representation
         /// of the specified <paramref name="value"/>, or 32 if the value
         /// is equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int LeadingZeroCount(this int value)
         {
             if (value == 0)
@@ -144,9 +142,7 @@ namespace J2N.Numerics
         /// ("leftmost") one-bit in the two's complement binary representation
         /// of the specified <paramref name="value"/>, or 64 if the value
         /// is equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int LeadingZeroCount(this long value)
         {
             if (value == 0)
@@ -184,9 +180,7 @@ namespace J2N.Numerics
         /// one-bit in the two's complement binary representation of the
         /// specified <paramref name="value"/>, or 32 if the value is equal
         /// to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int TrailingZeroCount(this int value)
         {
             if (value == 0)
@@ -210,9 +204,7 @@ namespace J2N.Numerics
         /// one-bit in the two's complement binary representation of the
         /// specified <paramref name="value"/>, or 64 if the value is equal
         /// to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int TrailingZeroCount(this long value)
         {
             if (value == 0)
@@ -239,9 +231,7 @@ namespace J2N.Numerics
         /// <returns>An <see cref="int"/> value with a single one-bit, in the position
         /// of the highest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static int HighestOneBit(this int value) // Harmony
         {
             value |= (value >> 1);
@@ -263,9 +253,7 @@ namespace J2N.Numerics
         /// <returns>A <see cref="long"/> value with a single one-bit, in the position
         /// of the highest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static long HighestOneBit(this long value)
         {
             value |= (value >> 1);
@@ -281,9 +269,7 @@ namespace J2N.Numerics
 
         #region Log2
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int Log2(this uint value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
@@ -296,9 +282,7 @@ namespace J2N.Numerics
 #endif
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int Log2(this ulong value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
@@ -324,9 +308,7 @@ namespace J2N.Numerics
         /// <returns>An <see cref="int"/> value with a single one-bit, in the position
         /// of the lowest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int LowestOneBit(this int value)
         {
             // From Hacker's Delight, Section 2-1
@@ -344,9 +326,7 @@ namespace J2N.Numerics
         /// <returns>A <see cref="long"/> value with a single one-bit, in the position
         /// of the lowest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long LowestOneBit(this long value)
         {
             // From Hacker's Delight, Section 2-1
@@ -466,9 +446,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> left by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int RotateLeft(this int value, int distance)
         {
             if (distance == 0)
@@ -506,9 +484,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> left by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long RotateLeft(this long value, int distance)
         {
             if (distance == 0)
@@ -547,9 +523,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> right by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int RotateRight(this int value, int distance)
         {
             if (distance == 0)
@@ -584,9 +558,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> right by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long RotateRight(this long value, int distance)
         {
             if (distance == 0)
@@ -618,9 +590,7 @@ namespace J2N.Numerics
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="int"/>.</returns>
         // See http://stackoverflow.com/a/6625912
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int TripleShift(this byte number, int bits)
         {
             return TripleShift((sbyte)number, bits);
@@ -635,9 +605,7 @@ namespace J2N.Numerics
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="int"/>.</returns>
         // See http://stackoverflow.com/a/6625912
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         [CLSCompliant(false)]
         public static int TripleShift(this sbyte number, int bits)
         {
@@ -655,9 +623,7 @@ namespace J2N.Numerics
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="int"/>.</returns>
         // See http://stackoverflow.com/a/6625912
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int TripleShift(this char number, int bits)
         {
             if (number >= 0)
@@ -674,9 +640,7 @@ namespace J2N.Numerics
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="short"/>.</returns>
         // See http://stackoverflow.com/a/6625912
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int TripleShift(this short number, int bits)
         {
             if (number >= 0)
@@ -693,9 +657,7 @@ namespace J2N.Numerics
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="int"/>.</returns>
         // See http://stackoverflow.com/a/6625912
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int TripleShift(this int number, int bits)
         {
             if (number >= 0)
@@ -711,9 +673,7 @@ namespace J2N.Numerics
         /// <param name="number">Number to operate on.</param>
         /// <param name="bits">Ammount of bits to shift.</param>
         /// <returns>The resulting number from the shift operation as <see cref="long"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long TripleShift(this long number, int bits)
         {
             return (long)((ulong)number >> bits);

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -485,6 +485,9 @@ namespace J2N.Numerics
 #endif
         }
 
+        internal static uint RotateLeft(this uint value, int distance) // J2N TODO: API - Make public once we have implementations for all methods accepting uint and ulong
+            => (value << distance) | (value >> (32 - distance));
+
         /// <summary>
         /// Returns the value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> left by the

--- a/src/J2N/Numerics/Byte.cs
+++ b/src/J2N/Numerics/Byte.cs
@@ -1799,9 +1799,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(string, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, NumberStyle, IFormatProvider?, out byte)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, out byte result) // Culture Sensitive!
         {
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
@@ -1873,9 +1871,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out byte)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse(ReadOnlySpan<char> s, out byte result) // Culture Sensitive!
         {
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);

--- a/src/J2N/Numerics/DotNetNumber.Formatting.cs
+++ b/src/J2N/Numerics/DotNetNumber.Formatting.cs
@@ -1565,9 +1565,7 @@ namespace J2N.Numerics
         //    }
         //}
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
-#endif
         private static unsafe void Int32ToNumber(int value, ref NumberBuffer number)
         {
             number.DigitsCount = Int32Precision;
@@ -1704,9 +1702,7 @@ namespace J2N.Numerics
             return buffer;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called from only one location
-#endif
         private static unsafe void UInt32ToNumber(uint value, ref NumberBuffer number)
         {
             number.DigitsCount = UInt32Precision;

--- a/src/J2N/Numerics/DotNetNumber.Parsing.cs
+++ b/src/J2N/Numerics/DotNetNumber.Parsing.cs
@@ -786,9 +786,7 @@ namespace J2N.Numerics
             return false;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static ParsingStatus TryParseInt32(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out int result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)
@@ -1169,9 +1167,7 @@ namespace J2N.Numerics
             goto DoneAtEndButPotentialOverflow;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static ParsingStatus TryParseInt64(ReadOnlySpan<char> value, NumberStyle styles, NumberFormatInfo info, out long result)
         {
             if ((styles & ~NumberStyle.Integer) == 0)

--- a/src/J2N/Numerics/Double.cs
+++ b/src/J2N/Numerics/Double.cs
@@ -247,9 +247,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">A <see cref="double"/> precision floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static long DoubleToInt64Bits(double value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.DoubleToInt64Bits(value);
@@ -297,9 +295,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">A <see cref="double"/> precision floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static long DoubleToRawInt64Bits(double value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.DoubleToRawInt64Bits(value);
@@ -480,9 +476,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value is finite (zero, subnormal, or normal).
         /// </summary>
         /// <returns><c>true</c> if the value is finite (zero, subnormal or normal); otherwise <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsFinite()
         {
             return value.IsFinite();
@@ -497,9 +491,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if this object's value evaluates to <see cref="double.PositiveInfinity"/> or
         /// <see cref="double.NegativeInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsInfinity()
         {
             return value.IsInfinity();
@@ -515,9 +507,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if this object's' value evaluates to <see cref="double.NaN"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNaN()
         {
             return value.IsNaN();
@@ -532,9 +522,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if the value is negative; otherwise, <c>false</c>.</returns>
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegative()
         {
             return value.IsNegative();
@@ -550,9 +538,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if the value evaluates to <see cref="double.NegativeInfinity"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegativeInfinity()
         {
             return value.IsNegativeInfinity();
@@ -568,9 +554,7 @@ namespace J2N.Numerics
         /// this feature. This method allows a simple way to check whether the current <see cref="double"/> has the value negative zero.
         /// </summary>
         /// <returns><c>true</c> if the current value represents negative zero; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegativeZero()
         {
             return value.IsNegativeZero();
@@ -584,9 +568,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value specified value is normal.
         /// </summary>
         /// <returns><c>true</c> if the value is normal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNormal()
         {
             return value.IsNormal();
@@ -600,9 +582,7 @@ namespace J2N.Numerics
         /// Returns a value indicating whether this object's value evaluates to positive infinity.
         /// </summary>
         /// <returns><c>true</c> if the value evaluates to <see cref="double.PositiveInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsPositiveInfinity()
         {
             return value.IsPositiveInfinity();
@@ -616,9 +596,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value is subnormal.
         /// </summary>
         /// <returns><c>true</c> if the value is subnormal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsSubnormal()
         {
             return value.IsSubnormal();
@@ -692,9 +670,7 @@ namespace J2N.Numerics
         /// <param name="value">Any <see cref="long"/> integer.</param>
         /// <returns>The <see cref="double"/> floating-point value with
         /// the same bit pattern.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static double Int64BitsToDouble(long value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.Int64BitsToDouble(value);
@@ -3109,9 +3085,7 @@ namespace J2N.Numerics
         ///     </item>
         /// </list>
         /// </returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int Compare(double doubleA, double doubleB)
         {
             return JCG.Comparer<double>.Default.Compare(doubleA, doubleB);
@@ -3613,9 +3587,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <returns>A hex string representing the current instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToHexString(IFormatProvider? provider)
         {
             return value.ToHexString(provider);

--- a/src/J2N/Numerics/FormattingHelpers.cs
+++ b/src/J2N/Numerics/FormattingHelpers.cs
@@ -9,9 +9,7 @@ namespace J2N.Numerics //J2N.Buffers.Text
 {
     internal static partial class FormattingHelpers
     {
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int CountDigits(ulong value)
         {
             int digits = 1;
@@ -67,9 +65,7 @@ namespace J2N.Numerics //J2N.Buffers.Text
             return digits;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int CountDigits(uint value)
         {
             int digits = 1;
@@ -104,9 +100,7 @@ namespace J2N.Numerics //J2N.Buffers.Text
             return digits;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int CountHexDigits(ulong value)
         {
             // The number of hex digits is log16(value) + 1, or log2(value) / 4 + 1
@@ -117,9 +111,7 @@ namespace J2N.Numerics //J2N.Buffers.Text
         // e.g., value =      0 => retVal = 0, valueWithoutTrailingZeros = 0
         //       value =   1234 => retVal = 0, valueWithoutTrailingZeros = 1234
         //       value = 320900 => retVal = 2, valueWithoutTrailingZeros = 3209
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int CountDecimalTrailingZeros(uint value, out uint valueWithoutTrailingZeros)
         {
             int zeroCount = 0;

--- a/src/J2N/Numerics/Int16.cs
+++ b/src/J2N/Numerics/Int16.cs
@@ -1748,9 +1748,7 @@ namespace J2N.Numerics
         /// </remarks>
         /// <seealso cref="Parse(string, IFormatProvider?)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, out short result)
         {
             if (s == null)
@@ -1827,9 +1825,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out short)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse(ReadOnlySpan<char> s, out short result)
         {
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
@@ -2299,9 +2295,7 @@ namespace J2N.Numerics
 
         #region TryParse_CharSequence_NumberStyle_NumberFormatInfo_Int16
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, NumberFormatInfo info, out short result)
         {
             // For hex number styles AllowHexSpecifier << 6 == 0x8000 and cancels out MinValue so the check is effectively: (uint)i > ushort.MaxValue
@@ -2541,9 +2535,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(string?, out short)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out short result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -2779,9 +2771,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(ReadOnlySpan{char}, out short)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out short result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -3343,9 +3333,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="short"/> value for which to reverse the byte order.</param>
         /// <returns>The value obtained by reversing the bytes in the specified
         /// <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static short ReverseBytes(short value) // J2N: Only used as a proxy for testing purposes
         {
             return value.ReverseBytes();

--- a/src/J2N/Numerics/Int32.cs
+++ b/src/J2N/Numerics/Int32.cs
@@ -1589,9 +1589,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(string, IFormatProvider?)"/>
         /// <seealso cref="Parse(string, int)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, out int result)
         {
             if (s == null)
@@ -1668,9 +1666,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out int)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool TryParse(ReadOnlySpan<char> s, out int result)
         {
             return DotNetNumber.TryParseInt32IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
@@ -2337,9 +2333,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(string?, out int)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -2575,9 +2569,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(ReadOnlySpan{char}, out int)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out int result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -2593,9 +2585,7 @@ namespace J2N.Numerics
         /// returned string is a concatenation of '0' and '1' characters.
         /// </summary>
         /// <returns>The binary string representation of this instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToBinaryString()
         {
             return value.ToBinaryString();
@@ -2611,9 +2601,7 @@ namespace J2N.Numerics
         /// concatenation of characters from '0' to '9' and 'a' to 'f'.
         /// </summary>
         /// <returns>The hexadecimal string representation of this instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToHexString()
         {
             return value.ToHexString();
@@ -2628,9 +2616,7 @@ namespace J2N.Numerics
         /// returned string is a concatenation of characters from '0' to '7'.
         /// </summary>
         /// <returns>The octal string representation of this instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToOctalString()
         {
             return value.ToOctalString();
@@ -3195,9 +3181,7 @@ namespace J2N.Numerics
         /// <returns>An <see cref="int"/> value with a single one-bit, in the position
         /// of the highest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int HighestOneBit(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.HighestOneBit();
@@ -3218,9 +3202,7 @@ namespace J2N.Numerics
         /// <returns>An <see cref="int"/> value with a single one-bit, in the position
         /// of the lowest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int LowestOneBit(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.LowestOneBit();
@@ -3251,9 +3233,7 @@ namespace J2N.Numerics
         /// ("leftmost") one-bit in the two's complement binary representation
         /// of the specified <paramref name="value"/>, or 32 if the value
         /// is equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int LeadingZeroCount(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.LeadingZeroCount();
@@ -3277,9 +3257,7 @@ namespace J2N.Numerics
         /// one-bit in the two's complement binary representation of the
         /// specified <paramref name="value"/>, or 32 if the value is equal
         /// to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int TrailingZeroCount(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.TrailingZeroCount();
@@ -3297,9 +3275,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="int"/> to examine.</param>
         /// <returns>The number of one-bits in the two's complement binary
         /// representation of the specified <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int PopCount(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.PopCount();
@@ -3327,9 +3303,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> left by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int RotateLeft(int value, int distance) // J2N: Only used as a proxy for testing purposes
         {
             return value.RotateLeft(distance);
@@ -3357,9 +3331,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> right by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int RotateRight(int value, int distance) // J2N: Only used as a proxy for testing purposes
         {
             return value.RotateRight(distance);
@@ -3376,9 +3348,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="int"/> value for which to reverse the byte order.</param>
         /// <returns>The value obtained by reversing the bytes in the specified
         /// <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int ReverseBytes(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.ReverseBytes();
@@ -3395,9 +3365,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="int"/> value for which to reverse the bit order.</param>
         /// <returns>The value obtained by reversing order of the bits in the
         /// specified <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int Reverse(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.Reverse();
@@ -3417,9 +3385,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">The value whose signum has to be computed.</param>
         /// <returns>The signum function of the specified <see cref="int"/> value.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int Signum(int value) // J2N: Only used as a proxy for testing purposes
         {
             return value.Signum();

--- a/src/J2N/Numerics/Int64.cs
+++ b/src/J2N/Numerics/Int64.cs
@@ -1594,9 +1594,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(string, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out long)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, out long result)
         {
             return long.TryParse(s, out result);
@@ -1667,9 +1665,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out long)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse(ReadOnlySpan<char> s, out long result)
         {
             return DotNetNumber.TryParseInt64IntegerStyle(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result) == DotNetNumber.ParsingStatus.OK;
@@ -2338,9 +2334,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(string?, out long)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyle style, IFormatProvider? provider, out long result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -2576,9 +2570,7 @@ namespace J2N.Numerics
         /// <seealso cref="TryParse(ReadOnlySpan{char}, out long)"/>
         /// <seealso cref="Number.ToString()"/>
         /// <seealso cref="NumberStyle"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyle style, IFormatProvider? provider, out long result)
         {
             NumberStyleExtensions.ValidateParseStyleInteger(style);
@@ -2594,9 +2586,7 @@ namespace J2N.Numerics
         /// returned string is a concatenation of '0' and '1' characters.
         /// </summary>
         /// <returns>The binary string representation of the current instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToBinaryString()
         {
             return value.ToBinaryString();
@@ -2612,9 +2602,7 @@ namespace J2N.Numerics
         /// concatenation of characters from '0' to '9' and 'a' to 'f'.
         /// </summary>
         /// <returns>The hexadecimal string representation of the current instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToHexString()
         {
             return value.ToHexString();
@@ -2629,9 +2617,7 @@ namespace J2N.Numerics
         /// returned string is a concatenation of characters from '0' to '7'.
         /// </summary>
         /// <returns>The octal string representation of the current instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToOctalString()
         {
             return value.ToOctalString();
@@ -3196,9 +3182,7 @@ namespace J2N.Numerics
         /// <returns>A <see cref="long"/> value with a single one-bit, in the position
         /// of the highest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long HighestOneBit(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.HighestOneBit();
@@ -3219,9 +3203,7 @@ namespace J2N.Numerics
         /// <returns>A <see cref="long"/> value with a single one-bit, in the position
         /// of the lowest-order one-bit in the specified <paramref name="value"/>, or zero if
         /// the specified <paramref name="value"/> is itself equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long LowestOneBit(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.LowestOneBit();
@@ -3252,9 +3234,7 @@ namespace J2N.Numerics
         /// ("leftmost") one-bit in the two's complement binary representation
         /// of the specified <paramref name="value"/>, or 64 if the value
         /// is equal to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int LeadingZeroCount(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.LeadingZeroCount();
@@ -3278,9 +3258,7 @@ namespace J2N.Numerics
         /// one-bit in the two's complement binary representation of the
         /// specified <paramref name="value"/>, or 64 if the value is equal
         /// to zero.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int TrailingZeroCount(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.TrailingZeroCount();
@@ -3298,9 +3276,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="long"/> to examine.</param>
         /// <returns>The number of one-bits in the two's complement binary
         /// representation of the specified <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int PopCount(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.PopCount();
@@ -3328,9 +3304,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> left by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long RotateLeft(long value, int distance) // J2N: Only used as a proxy for testing purposes
         {
             return value.RotateLeft(distance);
@@ -3358,9 +3332,7 @@ namespace J2N.Numerics
         /// <returns>The value obtained by rotating the two's complement binary
         /// representation of the specified <paramref name="value"/> right by the
         /// specified number of bits.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long RotateRight(long value, int distance) // J2N: Only used as a proxy for testing purposes
         {
             return value.RotateRight(distance);
@@ -3377,9 +3349,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="long"/> value for which to reverse the byte order.</param>
         /// <returns>The value obtained by reversing the bytes in the specified
         /// <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long ReverseBytes(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.ReverseBytes();
@@ -3396,9 +3366,7 @@ namespace J2N.Numerics
         /// <param name="value">The <see cref="long"/> value for which to reverse the bit order.</param>
         /// <returns>The value obtained by reversing order of the bits in the
         /// specified <paramref name="value"/>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static long Reverse(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.Reverse();
@@ -3415,9 +3383,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">The value whose signum has to be computed.</param>
         /// <returns>The signum function of the specified <see cref="long"/> value.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static int Signum(long value) // J2N: Only used as a proxy for testing purposes
         {
             return value.Signum();

--- a/src/J2N/Numerics/Number.cs
+++ b/src/J2N/Numerics/Number.cs
@@ -491,9 +491,7 @@ namespace J2N.Numerics
         /// remove this method. This is only intended for integral types
         /// that do not actually support the "J" format.
         /// </summary>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         internal static string? ConvertFormat(string? format)
         {
             if (string.IsNullOrEmpty(format))

--- a/src/J2N/Numerics/ParseNumbers.cs
+++ b/src/J2N/Numerics/ParseNumbers.cs
@@ -1511,9 +1511,7 @@ namespace J2N.Numerics
 
         #region IsLongOverflow
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool IsLongOverflow(long value, int radix, int flags, int sign)
         {
             // Return the value properly signed.
@@ -1532,9 +1530,7 @@ namespace J2N.Numerics
 
         #region IsIntOverflow
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool IsIntOverflow(int value, int radix, int flags, int sign)
         {
             if ((flags & TreatAsI1) != 0 && ((flags & TreatAsUnsigned) != 0))
@@ -1584,9 +1580,7 @@ namespace J2N.Numerics
 
         #region GetLongOverflowTypeCode
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static TypeCode GetLongOverflowTypeCode(int flags)
         {
             return (flags & TreatAsUnsigned) != 0 ? TypeCode.UInt64 : TypeCode.Int64;
@@ -1596,9 +1590,7 @@ namespace J2N.Numerics
 
         #region GetIntOverflowTypeCode
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static TypeCode GetIntOverflowTypeCode(int flags)
         {
             bool isUnsigned = (flags & TreatAsUnsigned) != 0;
@@ -1615,9 +1607,7 @@ namespace J2N.Numerics
 
         #region IsDigit
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool IsDigit(ReadOnlySpan<char> s, int i, int end, int radix, out int result, out int charCount) // KEEP OVERLOADS FOR ICharSequence and ReadOnlySpan<char> IN SYNC
         {
             if (char.IsHighSurrogate(s[i]) && i + 1 < end && char.IsLowSurrogate(s[i + 1]))
@@ -1631,9 +1621,7 @@ namespace J2N.Numerics
             return result != -1;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool IsDigit(ICharSequence s, int i, int end, int radix, out int result, out int charCount) // KEEP OVERLOADS FOR ICharSequence and ReadOnlySpan<char> IN SYNC
         {
             if (char.IsHighSurrogate(s[i]) && i + 1 < end && char.IsLowSurrogate(s[i + 1]))

--- a/src/J2N/Numerics/RyuDouble.cs
+++ b/src/J2N/Numerics/RyuDouble.cs
@@ -1177,9 +1177,7 @@ namespace J2N.Numerics
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private unsafe static void WriteBuffer(char* result, ref int index, long output, int olength, bool upperCase, bool sign, int exp, bool scientificNotation, string negSign, int negSignLength, string decimalSeparator, int decimalSeparatorLength)
         {
             if (sign)
@@ -1303,17 +1301,13 @@ namespace J2N.Numerics
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int Pow5bits(int e)
         {
             return ((e * 1217359).TripleShift(19)) + 1;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // J2N: Only called in one place
-#endif
         private static int DecimalLength(long v)
         {
             if (v >= 1000000000000000000L) return 19;
@@ -1337,17 +1331,13 @@ namespace J2N.Numerics
             return 1;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static bool MultipleOfPowerOf5(long value, int q)
         {
             return Pow5Factor(value) >= q;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int Pow5Factor(long value)
         {
             // We want to find the largest power of 5 that divides value.

--- a/src/J2N/Numerics/RyuSingle.cs
+++ b/src/J2N/Numerics/RyuSingle.cs
@@ -453,9 +453,7 @@ namespace J2N.Numerics
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private unsafe static void WriteBuffer(char* result, ref int index, int output, int olength, bool upperCase, bool sign, int exp, bool scientificNotation, string negSign, int negSignLength, string decimalSeparator, int decimalSeparatorLength)
         {
             if (sign)
@@ -572,9 +570,7 @@ namespace J2N.Numerics
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int Pow5Bits(int e)
         {
             return e == 0 ? 1 : (int)((e * LOG2_5_NUMERATOR + LOG2_5_DENOMINATOR - 1) / LOG2_5_DENOMINATOR);
@@ -639,9 +635,7 @@ namespace J2N.Numerics
             return (uint)shiftedSum;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // J2N: Only called in one place
-#endif
         private static int DecimalLength(int v)
         {
             int length = 10;

--- a/src/J2N/Numerics/SByte.cs
+++ b/src/J2N/Numerics/SByte.cs
@@ -1749,9 +1749,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(string, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, NumberStyle, IFormatProvider?, out sbyte)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool TryParse([NotNullWhen(true)] string? s, out sbyte result) // Culture Sensitive!
         {
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);
@@ -1822,9 +1820,7 @@ namespace J2N.Numerics
         /// <seealso cref="Parse(ReadOnlySpan{char}, NumberStyle, IFormatProvider?)"/>
         /// <seealso cref="TryParse(string?, out sbyte)"/>
         /// <seealso cref="Number.ToString()"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool TryParse(ReadOnlySpan<char> s, out sbyte result) // Culture Sensitive!
         {
             return TryParse(s, NumberStyle.Integer, NumberFormatInfo.CurrentInfo, out result);

--- a/src/J2N/Numerics/Single.cs
+++ b/src/J2N/Numerics/Single.cs
@@ -402,9 +402,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">A floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int SingleToInt32Bits(float value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.SingleToInt32Bits(value);
@@ -451,9 +449,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">A floating-point number.</param>
         /// <returns>The bits that represent the floating-point number.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static int SingleToRawInt32Bits(float value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.SingleToRawInt32Bits(value);
@@ -537,9 +533,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="value">The integer to convert.</param>
         /// <returns>A single-precision floating-point value that represents the converted integer.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         internal static float Int32BitsToSingle(int value) // J2N: Only used as a proxy for testing purposes
         {
             return BitConversion.Int32BitsToSingle(value);
@@ -553,9 +547,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value is finite (zero, subnormal, or normal).
         /// </summary>
         /// <returns><c>true</c> if the value is finite (zero, subnormal or normal); otherwise <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsFinite()
         {
             return value.IsFinite();
@@ -570,9 +562,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if this object's value evaluates to <see cref="float.PositiveInfinity"/> or
         /// <see cref="float.NegativeInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsInfinity()
         {
             return value.IsInfinity();
@@ -588,9 +578,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if this object's' value evaluates to <see cref="float.NaN"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNaN()
         {
             return value.IsNaN();
@@ -605,9 +593,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if the value is negative; otherwise, <c>false</c>.</returns>
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegative()
         {
             return value.IsNegative();
@@ -623,9 +609,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <returns><c>true</c> if the value evaluates to <see cref="float.NegativeInfinity"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegativeInfinity()
         {
             return value.IsNegativeInfinity();
@@ -641,9 +625,7 @@ namespace J2N.Numerics
         /// this feature. This method allows a simple way to check whether the current <see cref="float"/> has the value negative zero.
         /// </summary>
         /// <returns><c>true</c> if the current value represents negative zero; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNegativeZero()
         {
             return value.IsNegativeZero();
@@ -657,9 +639,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value specified value is normal.
         /// </summary>
         /// <returns><c>true</c> if the value is normal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsNormal()
         {
             return value.IsNormal();
@@ -673,9 +653,7 @@ namespace J2N.Numerics
         /// Returns a value indicating whether this object's value evaluates to positive infinity.
         /// </summary>
         /// <returns><c>true</c> if the value evaluates to <see cref="float.PositiveInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsPositiveInfinity()
         {
             return value.IsPositiveInfinity();
@@ -689,9 +667,7 @@ namespace J2N.Numerics
         /// Determines whether this object's value is subnormal.
         /// </summary>
         /// <returns><c>true</c> if the value is subnormal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public bool IsSubnormal()
         {
             return value.IsSubnormal();
@@ -3110,9 +3086,7 @@ namespace J2N.Numerics
         ///     </item>
         /// </list>
         /// </returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int Compare(float floatA, float floatB)
         {
             return JCG.Comparer<float>.Default.Compare(floatA, floatB);
@@ -3611,9 +3585,7 @@ namespace J2N.Numerics
         /// </summary>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <returns>A hex string representing the current instance.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public string ToHexString(IFormatProvider? provider)
         {
             return value.ToHexString(provider);

--- a/src/J2N/Runtime/CompilerServices/RuntimeHelper.cs
+++ b/src/J2N/Runtime/CompilerServices/RuntimeHelper.cs
@@ -35,9 +35,7 @@ namespace J2N.Runtime.CompilerServices
         /// <typeparam name="T">The type.</typeparam>
         /// <returns><c>true</c> if the given type is a reference type or a value type that
         /// contains references; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsReferenceOrContainsReferences<T>()
 #if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
             => RuntimeHelpers.IsReferenceOrContainsReferences<T>();

--- a/src/J2N/Runtime/CompilerServices/RuntimeHelper.cs
+++ b/src/J2N/Runtime/CompilerServices/RuntimeHelper.cs
@@ -1,0 +1,88 @@
+﻿#region Copyright 2019-2024 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace J2N.Runtime.CompilerServices
+{
+    internal static class RuntimeHelper
+    {
+        /// <summary>
+        /// Returns a value that indicates whether the specified type is a reference type or
+        /// a value type that contains references.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <returns><c>true</c> if the given type is a reference type or a value type that
+        /// contains references; otherwise, <c>false</c>.</returns>
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static bool IsReferenceOrContainsReferences<T>()
+#if FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
+            => RuntimeHelpers.IsReferenceOrContainsReferences<T>();
+#else
+            => ReferenceOrContainsReferencesHolder<T>.Value;
+#endif
+
+#if !FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES
+        private static class ReferenceOrContainsReferencesHolder<T>
+        {
+            public static bool Value = LoadValue();
+
+            private static bool LoadValue()
+            {
+                Type type = typeof(T);
+
+                // If not a value type, it's a reference type
+                if (!type.IsValueType)
+                    return true;
+
+                // Check if any fields in the value type are reference types or contain references
+                return IsReferenceOrContainsReferences(type, new HashSet<Type>());
+            }
+
+            private static bool IsReferenceOrContainsReferences(Type type, HashSet<Type> processedTypes)
+            {
+                // If we've already processed this type for the current structure, skip it
+                if (!processedTypes.Add(type))
+                    return false;
+
+                // If it's not a value type, it's a reference type
+                if (!type.IsValueType)
+                    return true;
+
+                // Iterate through all fields of the type
+                foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+                {
+                    // If the field is a reference type, or contains references, return true
+                    if (IsReferenceOrContainsReferences(field.FieldType, processedTypes))
+                        return true;
+                }
+
+                return false;
+            }
+        }
+#endif
+    }
+}

--- a/src/J2N/Runtime/CompilerServices/UnsafeHelpers.cs
+++ b/src/J2N/Runtime/CompilerServices/UnsafeHelpers.cs
@@ -1,0 +1,60 @@
+﻿#region Copyright 2019-2024 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace J2N.Runtime.CompilerServices
+{
+    internal static class UnsafeHelpers
+    {
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static ref T NullRef<T>()
+#if FEATURE_UNSAFE_NULLREF
+            => ref Unsafe.NullRef<T>();
+#else
+        {
+            unsafe
+            {
+                return ref Unsafe.AsRef<T>(null);
+            }
+        }
+#endif
+
+#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING && FEATURE_UNSAFE_ISNULLREF
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static bool IsNullRef<T>(ref T source)
+#if FEATURE_UNSAFE_ISNULLREF
+            => Unsafe.IsNullRef<T>(ref source);
+#else
+        {
+            unsafe
+            {
+                return Unsafe.AsPointer(ref source) == Unsafe.AsPointer(ref NullRef<T>());
+            }
+        }
+#endif
+    }
+}

--- a/src/J2N/Runtime/CompilerServices/UnsafeHelpers.cs
+++ b/src/J2N/Runtime/CompilerServices/UnsafeHelpers.cs
@@ -27,9 +27,7 @@ namespace J2N.Runtime.CompilerServices
 {
     internal static class UnsafeHelpers
     {
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static ref T NullRef<T>()
 #if FEATURE_UNSAFE_NULLREF
             => ref Unsafe.NullRef<T>();
@@ -42,9 +40,7 @@ namespace J2N.Runtime.CompilerServices
         }
 #endif
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING && FEATURE_UNSAFE_ISNULLREF
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsNullRef<T>(ref T source)
 #if FEATURE_UNSAFE_ISNULLREF
             => Unsafe.IsNullRef<T>(ref source);

--- a/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
+++ b/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
@@ -24,9 +24,7 @@ namespace J2N.Runtime.InteropServices
         /// </summary>
         /// <param name="list">The list to get the data view over.</param>
         /// <typeparam name="T">The type of the elements in the list.</typeparam>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static Span<T> AsSpan<T>(List<T>? list) // J2N NOTE: This implementation is from .NET 9 RC1
         {
             Span<T> span = default;

--- a/src/J2N/Security/Cryptography/RandomHelpers.cs
+++ b/src/J2N/Security/Cryptography/RandomHelpers.cs
@@ -1,0 +1,78 @@
+﻿#region Copyright 2019-2024 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using System;
+using System.Buffers;
+using System.Security.Cryptography;
+
+namespace J2N.Security.Cryptography
+{
+    internal static class RandomHelpers
+    {
+        // Mimics Interop.GetRandomBytes(byte* buffer, int size) using RandomNumberGenerator
+        internal static unsafe void GetRandomBytes(byte* buffer, int size)
+        {
+#if FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN
+            Span<byte> span = new Span<byte>(buffer, size);
+            RandomNumberGenerator.Fill(span);
+#elif FEATURE_RANDOMNUMBERGENERATOR_GETBYTES_OFFSET_COUNT
+            byte[]? rentedArray = null;
+
+            try
+            {
+                // Rent a buffer from the ArrayPool
+                rentedArray = ArrayPool<byte>.Shared.Rent(size);
+
+                // Fill the rented buffer with random bytes
+                using (var rng = RandomNumberGenerator.Create())
+                {
+                    rng.GetBytes(rentedArray, 0, (int)size);
+                }
+
+                // Efficiently copy the random bytes to the provided buffer
+                fixed (byte* source = rentedArray)
+                {
+                    Buffer.MemoryCopy(source, buffer, size, size);
+                }
+            }
+            finally
+            {
+                if (rentedArray != null)
+                {
+                    // Return the array to the pool
+                    ArrayPool<byte>.Shared.Return(rentedArray);
+                }
+            }
+#else
+            byte[] tempArray = new byte[size];
+
+            // Fill the tempArray with random bytes
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(tempArray);
+            }
+
+            // Manually copy each byte to the buffer
+            for (int i = 0; i < size; i++)
+            {
+                buffer[i] = tempArray[i];
+            }
+#endif
+        }
+    }
+}

--- a/src/J2N/SingleExtensions.cs
+++ b/src/J2N/SingleExtensions.cs
@@ -35,9 +35,7 @@ namespace J2N
         /// </summary>
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is finite (zero, subnormal or normal); otherwise <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsFinite(this float f)
         {
             int bits = BitConversion.SingleToRawInt32Bits(f);
@@ -54,9 +52,7 @@ namespace J2N
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value evaluates to <see cref="float.PositiveInfinity"/> or
         /// <see cref="float.NegativeInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsInfinity(this float f)
         {
             int bits = BitConversion.SingleToRawInt32Bits(f);
@@ -74,9 +70,7 @@ namespace J2N
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value evaluates to <see cref="float.NaN"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsNaN(this float f)
         {
             // A NaN will never equal itself so this is an
@@ -97,9 +91,7 @@ namespace J2N
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is negative; otherwise, <c>false</c>.</returns>
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNegative(this float f)
         {
             return BitConversion.SingleToRawInt32Bits(f) < 0;
@@ -116,9 +108,7 @@ namespace J2N
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if <paramref name="f"/> evaluates to <see cref="float.NegativeInfinity"/>;
         /// otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNegativeInfinity(this float f)
         {
             return f == float.NegativeInfinity;
@@ -135,9 +125,7 @@ namespace J2N
         /// </summary>
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the current value represents negative zero; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsNegativeZero(this float f)
         {
             return f == 0 && IsNegative(f);
@@ -152,9 +140,7 @@ namespace J2N
         /// </summary>
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is normal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsNormal(this float f)
         {
             int bits = BitConversion.SingleToRawInt32Bits(f);
@@ -171,9 +157,7 @@ namespace J2N
         /// </summary>
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if <paramref name="f"/> evaluates to <see cref="float.PositiveInfinity"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool IsPositiveInfinity(this float f)
         {
             return f == float.PositiveInfinity;
@@ -188,9 +172,7 @@ namespace J2N
         /// </summary>
         /// <param name="f">A single-precision floating-point number.</param>
         /// <returns><c>true</c> if the value is subnormal; <c>false</c> otherwise.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static unsafe bool IsSubnormal(this float f)
         {
             int bits = BitConversion.SingleToRawInt32Bits(f);

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -960,9 +960,7 @@ namespace J2N.Text
             };
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int IndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
             int length = value.Length;
@@ -1005,9 +1003,7 @@ namespace J2N.Text
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int IndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
             int length = value.Length;
@@ -1680,9 +1676,7 @@ namespace J2N.Text
             };
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int LastIndexOfOrdinal(StringBuilder text, string value, int startIndex)
         {
             int textLength = text.Length;
@@ -1747,9 +1741,7 @@ namespace J2N.Text
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static int LastIndexOfOrdinalIgnoreCase(StringBuilder text, string value, int startIndex)
         {
             int textLength = text.Length;

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -316,9 +316,7 @@ namespace J2N.Text
         /// <param name="charSequence">The character sequence to compare to.</param>
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool ContentEquals(this string? text, ICharSequence? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
@@ -338,9 +336,7 @@ namespace J2N.Text
         /// <param name="charSequence">The character sequence to compare to.</param>
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool ContentEquals(this string? text, char[]? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
@@ -360,9 +356,7 @@ namespace J2N.Text
         /// <param name="charSequence">The character sequence to compare to.</param>
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool ContentEquals(this string? text, StringBuilder? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);
@@ -382,9 +376,7 @@ namespace J2N.Text
         /// <param name="charSequence">The character sequence to compare to.</param>
         /// <returns><c>true</c> if this <see cref="string"/> represents the same
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif 
         public static bool ContentEquals(this string? text, string? charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
             return ContentEquals(text, charSequence, StringComparison.Ordinal);

--- a/src/J2N/Text/ValueStringBuilder.cs
+++ b/src/J2N/Text/ValueStringBuilder.cs
@@ -167,9 +167,7 @@ namespace J2N.Text
             _pos += count;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void Append(char c)
         {
             int pos = _pos;
@@ -184,9 +182,7 @@ namespace J2N.Text
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void Append(string? s)
         {
             if (s == null)
@@ -265,9 +261,7 @@ namespace J2N.Text
             _pos += value.Length;
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public Span<char> AppendSpan(int length)
         {
             int origPos = _pos;
@@ -314,9 +308,7 @@ namespace J2N.Text
             }
         }
 
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void Dispose()
         {
             char[]? toReturn = _arrayToReturnToPool;

--- a/src/J2N/Time.cs
+++ b/src/J2N/Time.cs
@@ -89,9 +89,7 @@ namespace J2N
         /// double seconds = ((dobule)t1 - t0) / Time.SecondsPerNanosecond;
         /// </code>
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long NanoTime()
         {
             return unchecked((long)(1_000_000_000.0d * Stopwatch.GetTimestamp() / Stopwatch.Frequency));
@@ -108,9 +106,7 @@ namespace J2N
         /// </summary>
         /// <returns>The difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC
         /// also known as the "epoch".</returns>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long CurrentTimeMilliseconds()
         {
             return (long)(DateTime.UtcNow - UnixEpoch).TotalMilliseconds;
@@ -125,9 +121,7 @@ namespace J2N
         /// <returns>The number of milliseconds since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.</returns>
         /// <seealso cref="GetTimeSpanSinceUnixEpoch(DateTime)"/>
         /// <seealso cref="UnixEpoch"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long GetMillisecondsSinceUnixEpoch(this DateTime dateTime)
         {
             return (long)(dateTime - UnixEpoch).TotalMilliseconds;
@@ -143,9 +137,7 @@ namespace J2N
         /// <returns>The <see cref="TimeSpan"/> since January 1, 1970, 00:00:00 UTC represented by <paramref name="dateTime"/>.</returns>
         /// <seealso cref="GetMillisecondsSinceUnixEpoch(DateTime)"/>
         /// <seealso cref="UnixEpoch"/>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static TimeSpan GetTimeSpanSinceUnixEpoch(this DateTime dateTime)
         {
             return dateTime - UnixEpoch;

--- a/src/J2N/TypeExtensions.cs
+++ b/src/J2N/TypeExtensions.cs
@@ -120,27 +120,5 @@ namespace J2N
 
             return AssemblyExtensions.FindResource(type.Assembly, type, name);
         }
-
-        /// <summary>
-        /// Returns <c>true</c> if a type is either a reference type
-        /// or is a <see cref="Nullable{T}"/> type.
-        /// </summary>
-        /// <param name="type">The type to check.</param>
-        /// <returns><c>true</c> if a type is either a reference type
-        /// or is a <see cref="Nullable{T}"/> type; otherwise, <c>false</c>.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="type"/> is <c>null</c>.</exception>
-        internal static bool IsNullableType(this Type type)
-        {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-
-            // If this is not a value type, it is a reference type, so it is automatically nullable
-            //  (NOTE: All forms of Nullable<T> are value types)
-            if (!type.IsValueType)
-                return true;
-
-            // Report whether type is a form of the Nullable<> type
-            return Nullable.GetUnderlyingType(type) != null;
-        }
     }
 }

--- a/src/J2N/compatibility/IndexAndRangeSupport.cs
+++ b/src/J2N/compatibility/IndexAndRangeSupport.cs
@@ -52,9 +52,7 @@ namespace System
         /// <remarks>
         /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public Index(int value, bool fromEnd = false)
         {
             if (value < 0)
@@ -82,9 +80,7 @@ namespace System
 
         /// <summary>Create an Index from the start at the position indicated by the value.</summary>
         /// <param name="value">The index value from the start.</param>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static Index FromStart(int value)
         {
             if (value < 0)
@@ -97,9 +93,7 @@ namespace System
 
         /// <summary>Create an Index from the end at the position indicated by the value.</summary>
         /// <param name="value">The index value from the end.</param>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static Index FromEnd(int value)
         {
             if (value < 0)
@@ -137,9 +131,7 @@ namespace System
         /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
         /// then used to index a collection will get out of range exception which will be same affect as the validation.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public int GetOffset(int length)
         {
             var offset = _value;
@@ -245,9 +237,7 @@ namespace System
         /// It is expected Range will be used with collections which always have non negative length/count.
         /// We validate the range is inside the length scope though.
         /// </remarks>
-#if FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void GetOffsetAndLength(int lengthIn, out int offset, out int length) // J2N: Using out parameters so we don't have to have a dependency on ValueTuple
         {
             int start;

--- a/src/J2N/compatibility/MethodImplOptions.cs
+++ b/src/J2N/compatibility/MethodImplOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#if !FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING
+
+namespace J2N
+{
+    internal static class MethodImplOptions
+    {
+        public const short Unmanaged = 4;
+        public const short NoInlining = 8;
+        public const short ForwardRef = 16;
+        public const short Synchronized = 32;
+        public const short NoOptimization = 64;
+        public const short PreserveSig = 128;
+        public const short AggressiveInlining = 256;
+        public const short AggressiveOptimization = 512;
+        public const short InternalCall = 4096;
+    }
+}
+
+#endif

--- a/tests/J2N.Tests.xUnit/Collections/CollectionAsserts.cs
+++ b/tests/J2N.Tests.xUnit/Collections/CollectionAsserts.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Generic.Tests.cs
@@ -18,9 +18,11 @@ namespace J2N.Collections.Concurrent.Tests
     {
         protected override ModifyOperation ModifyEnumeratorThrows => ModifyOperation.None;
 
-        protected override ModifyOperation ModifyEnumeratorAllowed => ModifyOperation.Add | ModifyOperation.Insert | ModifyOperation.Remove | ModifyOperation.Clear;
+        protected override ModifyOperation ModifyEnumeratorAllowed => ModifyOperation.Add | ModifyOperation.Insert | ModifyOperation.Overwrite | ModifyOperation.Remove | ModifyOperation.Clear;
 
         //protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
+
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
 
         /// <summary>
         /// Used in IDictionary_Generic_Values_Enumeration_ParentDictionaryModifiedInvalidates and

--- a/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Generic.Tests.cs
@@ -317,8 +317,6 @@ namespace J2N.Collections.Concurrent.Tests
 
         //        #region EnsureCapacity
 
-        //#if FEATURE_DICTIONARY_ENSURECAPACITY
-
         //        [Theory]
         //        [MemberData(nameof(ValidCollectionSizes))]
         //        public void EnsureCapacity_Generic_RequestingLargerCapacity_DoesInvalidateEnumeration(int count)
@@ -442,13 +440,9 @@ namespace J2N.Collections.Concurrent.Tests
         //            Assert.Equal(17, dictionary.EnsureCapacity(13));
         //        }
 
-        //#endif
-
         //        #endregion
 
         //        #region TrimExcess
-
-        //#if FEATURE_DICTIONARY_TRIMEXCESS
 
         //        [Fact]
         //        public void TrimExcess_Generic_NegativeCapacity_Throw()
@@ -652,8 +646,6 @@ namespace J2N.Collections.Concurrent.Tests
 
         //            Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
         //        }
-
-        //#endif
 
         //        #endregion
     }

--- a/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Concurrent/LurchTable/LurchTable.Tests.cs
@@ -29,6 +29,8 @@ namespace J2N.Collections.Concurrent.Tests
 
         protected override bool IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates => false;
 
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
+
 
         /// <summary>
         /// Creates an object that is dependent on the seed given. The object may be either

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
@@ -1,129 +1,134 @@
-﻿//// Licensed to the .NET Foundation under one or more agreements.
-//// The .NET Foundation licenses this file to you under the MIT license.
-//// See the LICENSE file in the project root for more information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
-//using System;
-//using System.Collections;
-//using System.Collections.Generic;
-//using System.Reflection;
-//using System.Threading.Tasks;
-//using Xunit;
+using J2N;
+using J2N.Collections.Generic;
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+using SCG = System.Collections.Generic;
 
-//namespace Generic.Dictionary
-//{
-//    public class DictionaryConcurrentAccessDetectionTests
-//    {
-//        private async Task DictionaryConcurrentAccessDetection<TKey, TValue>(Dictionary<TKey, TValue> dictionary, bool isValueType, object comparer, Action<Dictionary<TKey, TValue>> add, Action<Dictionary<TKey, TValue>> get, Action<Dictionary<TKey, TValue>> remove, Action<Dictionary<TKey, TValue>> removeOutParam)
-//        {
-//            Task task = Task.Factory.StartNew(() =>
-//            {
-//                // Get the Dictionary into a corrupted state, as if it had been corrupted by concurrent access.
-//                // We this deterministically by clearing the _entries array using reflection;
-//                // this means that every Entry struct has a 'next' field of zero, which causes the infinite loop
-//                // that we want Dictionary to break out of
-//                FieldInfo entriesType = dictionary.GetType().GetField("_entries", BindingFlags.NonPublic | BindingFlags.Instance);
-//                Array entriesInstance = (Array)entriesType.GetValue(dictionary);
-//                Array entryArray = (Array)Activator.CreateInstance(entriesInstance.GetType(), new object[] { ((IDictionary)dictionary).Count });
-//                entriesType.SetValue(dictionary, entryArray);
+namespace J2N.Collections.Tests
+{
+    public class DictionaryConcurrentAccessDetectionTests
+    {
+        private async Task DictionaryConcurrentAccessDetection<TKey, TValue>(Dictionary<TKey, TValue> dictionary, bool isValueType, object comparer, Action<Dictionary<TKey, TValue>> add, Action<Dictionary<TKey, TValue>> get, Action<Dictionary<TKey, TValue>> remove, Action<Dictionary<TKey, TValue>> removeOutParam)
+        {
+            Task task = Task.Factory.StartNew(() =>
+            {
+                // Get the Dictionary into a corrupted state, as if it had been corrupted by concurrent access.
+                // We this deterministically by clearing the _entries array using reflection;
+                // this means that every Entry struct has a 'next' field of zero, which causes the infinite loop
+                // that we want Dictionary to break out of
+                FieldInfo entriesType = dictionary.GetType().GetField("_entries", BindingFlags.NonPublic | BindingFlags.Instance);
+                Array entriesInstance = (Array)entriesType.GetValue(dictionary);
+                Array entryArray = (Array)Activator.CreateInstance(entriesInstance.GetType(), new object[] { ((IDictionary)dictionary).Count });
+                entriesType.SetValue(dictionary, entryArray);
 
-//                Assert.Equal(comparer, dictionary.GetType().GetField("_comparer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(dictionary));
-//                Assert.Equal(isValueType, dictionary.GetType().GetGenericArguments()[0].IsValueType);
-//                Assert.Throws<InvalidOperationException>(() => add(dictionary));
-//                Assert.Throws<InvalidOperationException>(() => get(dictionary));
-//                Assert.Throws<InvalidOperationException>(() => remove(dictionary));
-//                Assert.Throws<InvalidOperationException>(() => removeOutParam(dictionary));
-//            }, TaskCreationOptions.LongRunning);
+                Assert.Equal(comparer, dictionary.GetType().GetField("_comparer", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(dictionary));
+                Assert.Equal(isValueType, dictionary.GetType().GetGenericArguments()[0].IsValueType);
+                Assert.Throws<InvalidOperationException>(() => add(dictionary));
+                Assert.Throws<InvalidOperationException>(() => get(dictionary));
+                Assert.Throws<InvalidOperationException>(() => remove(dictionary));
+                Assert.Throws<InvalidOperationException>(() => removeOutParam(dictionary));
+            }, TaskCreationOptions.LongRunning);
 
-//            // If Dictionary regresses, we do not want to hang here indefinitely
-//            Assert.True((await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(60))) == task) && task.IsCompletedSuccessfully);
-//        }
+            // If Dictionary regresses, we do not want to hang here indefinitely
+            //await task.WaitAsync(TimeSpan.FromSeconds(60)); // net6.0 and up
 
-//        [Theory]
-//        [InlineData(null)]
-//        [InlineData(typeof(CustomEqualityComparerInt32ValueType))]
-//        public async Task DictionaryConcurrentAccessDetection_ValueTypeKey(Type comparerType)
-//        {
-//            IEqualityComparer<int> customComparer = null;
+            //Assert.True((await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(60))) == task) && task.IsCompletedSuccessfully); // net5.0 and up
 
-//            Dictionary<int, int> dic = comparerType == null ?
-//                new Dictionary<int, int>() :
-//                new Dictionary<int, int>((customComparer = (IEqualityComparer<int>)Activator.CreateInstance(comparerType)));
+            Assert.True((await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(60))) == task) && task.IsCompleted && !task.IsFaulted && !task.IsCanceled);
+        }
 
-//            dic.Add(1, 1);
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(null)]
+        [InlineData(typeof(CustomEqualityComparerInt32ValueType))]
+        public async Task DictionaryConcurrentAccessDetection_ValueTypeKey(Type comparerType)
+        {
+            SCG.IEqualityComparer<int> customComparer = null;
 
-//            await DictionaryConcurrentAccessDetection(dic,
-//                typeof(int).IsValueType,
-//                customComparer,
-//                d => d.Add(1, 1),
-//                d => { var v = d[1]; },
-//                d => d.Remove(1),
-//                d => d.Remove(1, out int value));
-//        }
+            Dictionary<int, int> dic = comparerType == null ?
+                new Dictionary<int, int>() :
+                new Dictionary<int, int>((customComparer = (SCG.IEqualityComparer<int>)Activator.CreateInstance(comparerType)));
 
-//        [Theory]
-//        [InlineData(null)]
-//        [InlineData(typeof(CustomEqualityComparerDummyRefType))]
-//        public async Task DictionaryConcurrentAccessDetection_ReferenceTypeKey(Type comparerType)
-//        {
-//            IEqualityComparer<DummyRefType> customComparer = null;
+            dic.Add(1, 1);
 
-//            Dictionary<DummyRefType, DummyRefType> dic = comparerType == null ?
-//                new Dictionary<DummyRefType, DummyRefType>() :
-//                new Dictionary<DummyRefType, DummyRefType>((customComparer = (IEqualityComparer<DummyRefType>)Activator.CreateInstance(comparerType)));
+            await DictionaryConcurrentAccessDetection(dic,
+                typeof(int).IsValueType,
+                customComparer,
+                d => d.Add(1, 1),
+                d => { var v = d[1]; },
+                d => d.Remove(1),
+                d => d.Remove(1, out int value));
+        }
 
-//            var keyValueSample = new DummyRefType() { Value = 1 };
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(null)]
+        [InlineData(typeof(CustomEqualityComparerDummyRefType))]
+        public async Task DictionaryConcurrentAccessDetection_ReferenceTypeKey(Type comparerType)
+        {
+            SCG.IEqualityComparer<DummyRefType> customComparer = null;
 
-//            dic.Add(keyValueSample, keyValueSample);
+            Dictionary<DummyRefType, DummyRefType> dic = comparerType == null ?
+                new Dictionary<DummyRefType, DummyRefType>(customComparer = EqualityComparer<DummyRefType>.Default) :
+                new Dictionary<DummyRefType, DummyRefType>((customComparer = (SCG.IEqualityComparer<DummyRefType>)Activator.CreateInstance(comparerType)));
 
-//            await DictionaryConcurrentAccessDetection(dic,
-//                typeof(DummyRefType).IsValueType,
-//                customComparer,
-//                d => d.Add(keyValueSample, keyValueSample),
-//                d => { var v = d[keyValueSample]; },
-//                d => d.Remove(keyValueSample),
-//                d => d.Remove(keyValueSample, out DummyRefType value));
-//        }
-//    }
+            var keyValueSample = new DummyRefType() { Value = 1 };
 
-//    // We use a custom type instead of string because string use optimized comparer https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs#L79
-//    // We want to test case with _comparer = null
-//    public class DummyRefType
-//    {
-//        public int Value { get; set; }
-//        public override bool Equals(object obj)
-//        {
-//            return ((DummyRefType)obj).Equals(this.Value);
-//        }
+            dic.Add(keyValueSample, keyValueSample);
 
-//        public override int GetHashCode()
-//        {
-//            return Value.GetHashCode();
-//        }
-//    }
+            await DictionaryConcurrentAccessDetection(dic,
+                typeof(DummyRefType).IsValueType,
+                customComparer,
+                d => d.Add(keyValueSample, keyValueSample),
+                d => { var v = d[keyValueSample]; },
+                d => d.Remove(keyValueSample),
+                d => d.Remove(keyValueSample, out DummyRefType value));
+        }
+    }
 
-//    public class CustomEqualityComparerDummyRefType : EqualityComparer<DummyRefType>
-//    {
-//        public override bool Equals(DummyRefType x, DummyRefType y)
-//        {
-//            return x.Value == y.Value;
-//        }
+    // We use a custom type instead of string because string use optimized comparer https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Collections/Generic/Dictionary.cs#L79
+    // We want to test case with _comparer = null
+    public class DummyRefType
+    {
+        public int Value { get; set; }
+        public override bool Equals(object obj)
+        {
+            return ((DummyRefType)obj).Equals(this.Value);
+        }
 
-//        public override int GetHashCode(DummyRefType obj)
-//        {
-//            return obj.GetHashCode();
-//        }
-//    }
+        public override int GetHashCode()
+        {
+            return Value.GetHashCode();
+        }
+    }
 
-//    public class CustomEqualityComparerInt32ValueType : EqualityComparer<int>
-//    {
-//        public override bool Equals(int x, int y)
-//        {
-//            return J2N.Collections.Generic.EqualityComparer<int>.Default.Equals(x, y);
-//        }
+    public class CustomEqualityComparerDummyRefType : SCG.EqualityComparer<DummyRefType>
+    {
+        public override bool Equals(DummyRefType x, DummyRefType y)
+        {
+            return x.Value == y.Value;
+        }
 
-//        public override int GetHashCode(int obj)
-//        {
-//            return J2N.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(obj);
-//        }
-//    }
-//}
+        public override int GetHashCode(DummyRefType obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+
+    public class CustomEqualityComparerInt32ValueType : SCG.EqualityComparer<int>
+    {
+        public override bool Equals(int x, int y)
+        {
+            return J2N.Collections.Generic.EqualityComparer<int>.Default.Equals(x, y);
+        }
+
+        public override int GetHashCode(int obj)
+        {
+            return J2N.Collections.Generic.EqualityComparer<int>.Default.GetHashCode(obj);
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -1,29 +1,31 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+using JCG = J2N.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
     public class Dictionary_Generic_Tests_Keys : ICollection_Generic_Tests<string>
     {
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
         protected override bool DefaultValueAllowed => false;
         protected override bool DuplicateValuesAllowed => false;
         protected override bool IsReadOnly => true;
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new JCG.List<ModifyEnumerable>();
         protected override ICollection<string> GenericICollectionFactory()
         {
-            return new Dictionary<string, string>().Keys;
+            return new JCG.Dictionary<string, string>().Keys;
         }
 
         protected override ICollection<string> GenericICollectionFactory(int count)
         {
-            Dictionary<string, string> list = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> list = new JCG.Dictionary<string, string>();
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));
@@ -44,14 +46,14 @@ namespace J2N.Collections.Tests
         [Fact]
         public void Dictionary_Generic_KeyCollection_Constructor_NullDictionary()
         {
-            Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.KeyCollection(null));
+            Assert.Throws<ArgumentNullException>(() => new JCG.Dictionary<string, string>.KeyCollection(null));
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_KeyCollection_GetEnumerator(int count)
         {
-            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> dictionary = new JCG.Dictionary<string, string>();
             int seed = 13453;
             while (dictionary.Count < count)
                 dictionary.Add(CreateT(seed++), CreateT(seed++));
@@ -64,6 +66,7 @@ namespace J2N.Collections.Tests
         protected override bool NullAllowed => true;
         protected override bool DuplicateValuesAllowed => false;
         protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
         protected override bool SupportsSerialization => false;
@@ -72,12 +75,12 @@ namespace J2N.Collections.Tests
 
         protected override ICollection NonGenericICollectionFactory()
         {
-            return new Dictionary<string, string>().Keys;
+            return new JCG.Dictionary<string, string>().Keys;
         }
 
         protected override ICollection NonGenericICollectionFactory(int count)
         {
-            Dictionary<string, string> list = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> list = new JCG.Dictionary<string, string>();
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -1,12 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+using JCG = J2N.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
@@ -15,16 +15,19 @@ namespace J2N.Collections.Tests
         protected override bool DefaultValueAllowed => true;
         protected override bool DuplicateValuesAllowed => true;
         protected override bool IsReadOnly => true;
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new JCG.List<ModifyEnumerable>();
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
 
         protected override ICollection<string> GenericICollectionFactory()
         {
-            return new Dictionary<string, string>().Values;
+            return new JCG.Dictionary<string, string>().Values;
         }
 
         protected override ICollection<string> GenericICollectionFactory(int count)
         {
-            Dictionary<string, string> list = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> list = new JCG.Dictionary<string, string>();
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));
@@ -45,14 +48,14 @@ namespace J2N.Collections.Tests
         [Fact]
         public void Dictionary_Generic_ValueCollection_Constructor_NullDictionary()
         {
-            Assert.Throws<ArgumentNullException>(() => new Dictionary<string, string>.ValueCollection(null));
+            Assert.Throws<ArgumentNullException>(() => new JCG.Dictionary<string, string>.ValueCollection(null));
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void Dictionary_Generic_ValueCollection_GetEnumerator(int count)
         {
-            Dictionary<string, string> dictionary = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> dictionary = new JCG.Dictionary<string, string>();
             int seed = 13453;
             while (dictionary.Count < count)
                 dictionary.Add(CreateT(seed++), CreateT(seed++));
@@ -65,21 +68,23 @@ namespace J2N.Collections.Tests
         protected override bool NullAllowed => true;
         protected override bool DuplicateValuesAllowed => true;
         protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
         protected override Type ICollection_NonGeneric_CopyTo_ArrayOfEnumType_ThrowType => typeof(ArgumentException);
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new JCG.List<ModifyEnumerable>();
         protected override bool SupportsSerialization => false;
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
 
         protected override Type ICollection_NonGeneric_CopyTo_IndexLargerThanArrayCount_ThrowType => typeof(ArgumentOutOfRangeException);
 
         protected override ICollection NonGenericICollectionFactory()
         {
-            return new Dictionary<string, string>().Values;
+            return new JCG.Dictionary<string, string>().Values;
         }
 
         protected override ICollection NonGenericICollectionFactory(int count)
         {
-            Dictionary<string, string> list = new Dictionary<string, string>();
+            JCG.Dictionary<string, string> list = new JCG.Dictionary<string, string>();
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using J2N.Collections.Generic;
 using System;
@@ -15,21 +14,20 @@ namespace J2N.Collections.Tests
 {
     public partial class Dictionary_IDictionary_NonGeneric_Tests : IDictionary_NonGeneric_Tests
     {
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
+
         protected override IDictionary NonGenericIDictionaryFactory()
         {
             return new Dictionary<string, string>();
         }
 
-        // This is only valid for .NET Standard 2.1+
-#if FEATURE_DICTIONARY_MODIFY_CONTINUEENUMERATION
 
-        protected override ModifyOperation ModifyEnumeratorThrows => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorThrows : ModifyOperation.Add | ModifyOperation.Insert;
+        protected override ModifyOperation ModifyEnumeratorThrows => ModifyOperation.Add | ModifyOperation.Insert; // J2N Supports these on .NET Framework
 
-        protected override ModifyOperation ModifyEnumeratorAllowed => PlatformDetection.IsFullFramework ? base.ModifyEnumeratorAllowed : ModifyOperation.Remove | ModifyOperation.Clear;
+        protected override ModifyOperation ModifyEnumeratorAllowed => ModifyOperation.Overwrite | ModifyOperation.Remove | ModifyOperation.Clear; // J2N Supports these on .NET Framework
 
-#endif
-
-        protected override bool NullAllowed => true;
+        protected override bool NullAllowed => true; // J2N Allows null keys
 
         /// <summary>
         /// Creates an object that is dependent on the seed given. The object may be either
@@ -347,6 +345,22 @@ namespace J2N.Collections.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => new Dictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
+        // https://github.com/dotnet/runtime/issues/44681
+        public void DictionaryOrdinalIgnoreCaseCyrillicKeys()
+        {
+            const string Lower = "\u0430\u0431\u0432\u0433\u0434\u0435\u0451\u0436\u0437\u0438\u0439\u043A\u043B\u043C\u043D\u043E\u043F\u0440\u0441\u0442\u0443\u0444\u0445\u0446\u0447\u0448\u0449\u044C\u044B\u044A\u044D\u044E\u044F";
+            const string Higher = "\u0410\u0411\u0412\u0413\u0414\u0415\u0401\u0416\u0417\u0418\u0419\u041A\u041B\u041C\u041D\u041E\u041F\u0420\u0421\u0422\u0423\u0424\u0425\u0426\u0427\u0428\u0429\u042C\u042B\u042A\u042D\u042E\u042F";
+
+            var dictionary = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < Lower.Length; i++)
+            {
+                dictionary[Lower[i].ToString()] = i;
+                Assert.Equal(i, dictionary[Higher[i].ToString()]);
+            }
+        }
+
         public static SCG.IEnumerable<object[]> CopyConstructorStringComparerData
         {
             get
@@ -411,7 +425,7 @@ namespace J2N.Collections.Tests
         }
 
 #if FEATURE_SERIALIZABLE
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public void ComparerSerialization()
         {
             // Strings switch between randomized and non-randomized comparers,

--- a/tests/J2N.Tests.xUnit/Collections/Generic/LinkedDictionary/LinkedDictionary.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/LinkedDictionary/LinkedDictionary.Generic.Tests.cs
@@ -290,8 +290,6 @@ namespace J2N.Collections.Tests
 
         #region EnsureCapacity
 
-#if FEATURE_DICTIONARY_ENSURECAPACITY
-
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void EnsureCapacity_Generic_RequestingLargerCapacity_DoesInvalidateEnumeration(int count)
@@ -415,13 +413,9 @@ namespace J2N.Collections.Tests
             Assert.Equal(17, dictionary.EnsureCapacity(13));
         }
 
-#endif
-
         #endregion
 
         #region TrimExcess
-
-#if FEATURE_DICTIONARY_TRIMEXCESS
 
         [Fact]
         public void TrimExcess_Generic_NegativeCapacity_Throw()
@@ -625,8 +619,6 @@ namespace J2N.Collections.Tests
 
             Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
         }
-
-#endif
 
         #endregion
     }

--- a/tests/J2N.Tests.xUnit/Collections/ICollection.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ICollection.Generic.Tests.cs
@@ -1,10 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using Xunit;
 using JCG = J2N.Collections.Generic;
 
@@ -42,9 +43,7 @@ namespace J2N.Collections.Tests
         protected virtual bool IsReadOnly_ValidityValue => IsReadOnly;
         protected virtual bool AddRemoveClear_ThrowsNotSupported => false;
         protected virtual bool DefaultValueAllowed => true;
-        protected virtual IEnumerable<T> InvalidValues => ArrayEmpty;
-
-        protected static readonly T[] ArrayEmpty = Arrays.Empty<T>();
+        protected virtual IEnumerable<T> InvalidValues => Arrays.Empty<T>();
 
         protected virtual void AddToCollection(ICollection<T> collection, int numberOfItemsToAdd)
         {
@@ -336,6 +335,46 @@ namespace J2N.Collections.Tests
                 collection.Clear();
                 collection.Clear();
                 Assert.Equal(0, collection.Count);
+            }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ICollection_Generic_Remove_ReferenceRemovedFromCollection(bool useRemove)
+        {
+            if (typeof(T).IsValueType || IsReadOnly || AddRemoveClear_ThrowsNotSupported)
+            {
+                return;
+            }
+
+            ICollection<T> collection = GenericICollectionFactory();
+
+            WeakReference<object> wr = PopulateAndRemove(collection, useRemove);
+            Assert.True(SpinWait.SpinUntil(() =>
+            {
+                GC.Collect();
+                return !wr.TryGetTarget(out _);
+            }, 30_000));
+            GC.KeepAlive(collection);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            WeakReference<object> PopulateAndRemove(ICollection<T> collection, bool useRemove)
+            {
+                AddToCollection(collection, 1);
+                T value = collection.First();
+
+                if (useRemove)
+                {
+                    Assert.True(collection.Remove(value));
+                }
+                else
+                {
+                    collection.Clear();
+                    Assert.Equal(0, collection.Count);
+                }
+
+                return new WeakReference<object>(value);
             }
         }
 

--- a/tests/J2N.Tests.xUnit/Collections/ICollection.NonGeneric.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ICollection.NonGeneric.Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -157,7 +156,10 @@ namespace J2N.Collections.Tests
             {
                 ICollection collection1 = NonGenericICollectionFactory(count);
                 ICollection collection2 = NonGenericICollectionFactory(count);
-                Assert.NotSame(collection1.SyncRoot, collection2.SyncRoot);
+                if (!ReferenceEquals(collection1, collection2))
+                {
+                    Assert.NotSame(collection1.SyncRoot, collection2.SyncRoot);
+                }
             }
         }
 
@@ -186,19 +188,18 @@ namespace J2N.Collections.Tests
             }
         }
 
-        // J2N TODO: Finish
-//#pragma warning disable xUnit1013 // xunit analyzer bug https://github.com/xunit/xunit/issues/1973
-//        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
-//        [MemberData(nameof(ValidCollectionSizes))]
-//        public virtual void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
-//        {
-//            ICollection collection = NonGenericICollectionFactory(count);
-//            Array arr = Array.CreateInstance(typeof(object), new int[1] { count }, new int[1] { 2 });
-//            Assert.Equal(1, arr.Rank);
-//            Assert.Equal(2, arr.GetLowerBound(0));
-//            Assert.Throws(ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ThrowType, () => collection.CopyTo(arr, 0));
-//        }
-//#pragma warning restore xUnit1013
+#pragma warning disable xUnit1013 // xunit analyzer bug https://github.com/xunit/xunit/issues/1973
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public virtual void ICollection_NonGeneric_CopyTo_NonZeroLowerBound(int count)
+        {
+            ICollection collection = NonGenericICollectionFactory(count);
+            Array arr = Array.CreateInstance(typeof(object), new int[1] { count }, new int[1] { 2 });
+            Assert.Equal(1, arr.Rank);
+            Assert.Equal(2, arr.GetLowerBound(0));
+            Assert.Throws(ICollection_NonGeneric_CopyTo_NonZeroLowerBound_ThrowType, () => collection.CopyTo(arr, 0));
+        }
+#pragma warning restore xUnit1013
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]

--- a/tests/J2N.Tests.xUnit/Collections/ICollectionTest.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ICollectionTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using J2N;
 using System;

--- a/tests/J2N.Tests.xUnit/Collections/IDictionary.NonGeneric.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/IDictionary.NonGeneric.Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
@@ -97,6 +96,8 @@ namespace J2N.Collections.Tests
         /// </summary>
         protected virtual bool IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates => true;
 
+        protected virtual bool ExpectedIsFixedSize => false;
+
         #endregion
 
         #region ICollection Helper Methods
@@ -150,6 +151,21 @@ namespace J2N.Collections.Tests
                     return true;
                 };
             }
+            if ((operations & ModifyOperation.Overwrite) == ModifyOperation.Overwrite)
+            {
+                yield return (IEnumerable enumerable) =>
+                {
+                    IDictionary casted = ((IDictionary)enumerable);
+                    if (casted.Count > 0)
+                    {
+                        IEnumerator keys = casted.Keys.GetEnumerator();
+                        keys.MoveNext();
+                        casted[keys.Current] = CreateTValue(12);
+                        return true;
+                    }
+                    return false;
+                };
+            }
             if ((operations & ModifyOperation.Remove) == ModifyOperation.Remove)
             {
                 yield return (IEnumerable enumerable) =>
@@ -157,7 +173,7 @@ namespace J2N.Collections.Tests
                     IDictionary casted = ((IDictionary)enumerable);
                     if (casted.Count > 0)
                     {
-                        var keys = casted.Keys.GetEnumerator();
+                        IEnumerator keys = casted.Keys.GetEnumerator();
                         keys.MoveNext();
                         casted.Remove(keys.Current);
                         return true;
@@ -196,7 +212,7 @@ namespace J2N.Collections.Tests
         public void IDictionary_NonGeneric_IsFixedSize_Validity(int count)
         {
             IDictionary collection = NonGenericIDictionaryFactory(count);
-            Assert.False(collection.IsFixedSize);
+            Assert.Equal(ExpectedIsFixedSize, collection.IsFixedSize);
         }
 
         #endregion
@@ -274,16 +290,19 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_NullKey(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            if (!NullAllowed)
+            if (!IsReadOnly)
             {
-                Assert.Throws<ArgumentNullException>(() => dictionary[null] = CreateTValue(3));
-            }
-            else
-            {
-                object value = CreateTValue(3452);
-                dictionary[null] = value;
-                Assert.Equal(value, dictionary[null]);
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                if (!NullAllowed)
+                {
+                    Assert.Throws<ArgumentNullException>(() => dictionary[null] = CreateTValue(3));
+                }
+                else
+                {
+                    object value = CreateTValue(3452);
+                    dictionary[null] = value;
+                    Assert.Equal(value, dictionary[null]);
+                }
             }
         }
 
@@ -303,23 +322,29 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_AddsNewValueWhenNotPresent(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            object missingKey = GetNewKey(dictionary);
-            dictionary[missingKey] = CreateTValue(543);
-            Assert.Equal(count + 1, dictionary.Count);
+            if (!IsReadOnly)
+            {
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                object missingKey = GetNewKey(dictionary);
+                dictionary[missingKey] = CreateTValue(543);
+                Assert.Equal(count + 1, dictionary.Count);
+            }
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_ItemSet_ReplacesExistingValueWhenPresent(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            object existingKey = GetNewKey(dictionary);
-            dictionary.Add(existingKey, CreateTValue(5342));
-            object newValue = CreateTValue(1234);
-            dictionary[existingKey] = newValue;
-            Assert.Equal(count + 1, dictionary.Count);
-            Assert.Equal(newValue, dictionary[existingKey]);
+            if (!IsReadOnly)
+            {
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                object existingKey = GetNewKey(dictionary);
+                dictionary.Add(existingKey, CreateTValue(5342));
+                object newValue = CreateTValue(1234);
+                dictionary[existingKey] = newValue;
+                Assert.Equal(count + 1, dictionary.Count);
+                Assert.Equal(newValue, dictionary[existingKey]);
+            }
         }
 
         #endregion
@@ -342,17 +367,20 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            ICollection keys = dictionary.Keys;
-            int previousCount = keys.Count;
-            dictionary.Clear();
-            if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+            if (!IsReadOnly)
             {
-                Assert.Empty(keys);
-            }
-            else
-            {
-                Assert.Equal(previousCount, keys.Count);
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                ICollection keys = dictionary.Keys;
+                int previousCount = keys.Count;
+                dictionary.Clear();
+                if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+                {
+                    Assert.Empty(keys);
+                }
+                else
+                {
+                    Assert.Equal(previousCount, keys.Count);
+                }
             }
         }
 
@@ -360,23 +388,26 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Keys_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            ICollection keys = dictionary.Keys;
-            IEnumerator keysEnum = keys.GetEnumerator();
-            dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
-            if (IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
+            if (!IsReadOnly)
             {
-                Assert.Throws<InvalidOperationException>(() => keysEnum.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => keysEnum.Reset());
-            }
-            else
-            {
-                keysEnum.MoveNext();
-                if (count > 0)
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                ICollection keys = dictionary.Keys;
+                IEnumerator keysEnum = keys.GetEnumerator();
+                dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
+                if (count == 0 ? Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException : IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
                 {
-                    var cur = keysEnum.Current;
+                    Assert.Throws<InvalidOperationException>(() => keysEnum.MoveNext());
+                    Assert.Throws<InvalidOperationException>(() => keysEnum.Reset());
                 }
-                keysEnum.Reset();
+                else
+                {
+                    keysEnum.MoveNext();
+                    if (count > 0)
+                    {
+                        _ = keysEnum.Current;
+                    }
+                    keysEnum.Reset();
+                }
             }
         }
 
@@ -411,34 +442,40 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_IncludeDuplicatesMultipleTimes(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            List<DictionaryEntry> entries = new List<DictionaryEntry>();
-
-            foreach (DictionaryEntry pair in dictionary)
-                entries.Add(pair);
-            foreach (DictionaryEntry pair in entries)
+            if (!IsReadOnly)
             {
-                object missingKey = GetNewKey(dictionary);
-                dictionary.Add(missingKey, (pair.Value));
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                List<DictionaryEntry> entries = new List<DictionaryEntry>();
+
+                foreach (DictionaryEntry pair in dictionary)
+                    entries.Add(pair);
+                foreach (DictionaryEntry pair in entries)
+                {
+                    object missingKey = GetNewKey(dictionary);
+                    dictionary.Add(missingKey, (pair.Value));
+                }
+                Assert.Equal(count * 2, dictionary.Values.Count);
             }
-            Assert.Equal(count * 2, dictionary.Values.Count);
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void IDictionary_NonGeneric_Values_ModifyingTheDictionaryUpdatesTheCollection(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            ICollection values = dictionary.Values;
-            int previousCount = values.Count;
-            dictionary.Clear();
-            if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+            if (!IsReadOnly)
             {
-                Assert.Empty(values);
-            }
-            else
-            {
-                Assert.Equal(previousCount, values.Count);
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                ICollection values = dictionary.Values;
+                int previousCount = values.Count;
+                dictionary.Clear();
+                if (IDictionary_NonGeneric_Keys_Values_ModifyingTheDictionaryUpdatesTheCollection)
+                {
+                    Assert.Empty(values);
+                }
+                else
+                {
+                    Assert.Equal(previousCount, values.Count);
+                }
             }
         }
 
@@ -446,24 +483,27 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public virtual void IDictionary_NonGeneric_Values_Enumeration_ParentDictionaryModifiedInvalidatesEnumerator(int count)
         {
-            IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            ICollection values = dictionary.Values;
-            IEnumerator valuesEnum = values.GetEnumerator();
-            dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
-            if (IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
+            if (!IsReadOnly)
             {
-                Assert.Throws<InvalidOperationException>(() => valuesEnum.MoveNext());
-                Assert.Throws<InvalidOperationException>(() => valuesEnum.Reset());
-                Assert.Throws<InvalidOperationException>(() => valuesEnum.Current);
-            }
-            else
-            {
-                valuesEnum.MoveNext();
-                if (count > 0)
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                ICollection values = dictionary.Values;
+                IEnumerator valuesEnum = values.GetEnumerator();
+                dictionary.Add(GetNewKey(dictionary), CreateTValue(3432));
+                if (count == 0 ? Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException : IDictionary_NonGeneric_Keys_Values_ParentDictionaryModifiedInvalidates)
                 {
-                    var cur = valuesEnum.Current;
+                    Assert.Throws<InvalidOperationException>(() => valuesEnum.MoveNext());
+                    Assert.Throws<InvalidOperationException>(() => valuesEnum.Reset());
+                    Assert.Throws<InvalidOperationException>(() => valuesEnum.Current);
                 }
-                valuesEnum.Reset();
+                else
+                {
+                    valuesEnum.MoveNext();
+                    if (count > 0)
+                    {
+                        _ = valuesEnum.Current;
+                    }
+                    valuesEnum.Reset();
+                }
             }
         }
 
@@ -583,16 +623,34 @@ namespace J2N.Collections.Tests
         public void IDictionary_NonGeneric_Remove_NullKey(int count)
         {
             IDictionary dictionary = NonGenericIDictionaryFactory(count);
-            if (!NullAllowed)
+            if (!IsReadOnly)
             {
-                Assert.Throws<ArgumentNullException>(() => dictionary.Remove(null));
+                if (!NullAllowed)
+                {
+                    Assert.Throws<ArgumentNullException>(() => dictionary.Remove(null));
+                }
+                else
+                {
+                    object value = CreateTValue(3452);
+                    dictionary.Add(null, value);
+                    dictionary.Remove(null);
+                    Assert.Null(dictionary[null]);
+                }
             }
-            else
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCollectionSizes))]
+        public void IDictionary_NonGeneric_Remove_ThrowsWhenNotSupported(int count)
+        {
+            if (IsReadOnly)
             {
-                object value = CreateTValue(3452);
-                dictionary.Add(null, value);
-                dictionary.Remove(null);
-                Assert.Null(dictionary[null]);
+                IDictionary dictionary = NonGenericIDictionaryFactory(count);
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    Assert.Throws<NotSupportedException>(() => dictionary.Remove(entry.Key));
+                    break;
+                }
             }
         }
 

--- a/tests/J2N.Tests.xUnit/Collections/IDictionaryTest.cs
+++ b/tests/J2N.Tests.xUnit/Collections/IDictionaryTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using J2N;
 using System;

--- a/tests/J2N.Tests.xUnit/Collections/IEnumerableTest.cs
+++ b/tests/J2N.Tests.xUnit/Collections/IEnumerableTest.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
@@ -101,7 +100,7 @@ namespace Tests.Collections
             if (IsGenericCompatibility)
             {
                 return;
-                // apparently it is okay if enumerator.Current doesn't throw when the collection is generic.
+                    // apparently it is okay if enumerator.Current doesn't throw when the collection is generic.
             }
 
             RepeatTest(

--- a/tests/J2N.Tests.xUnit/Collections/ISet.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ISet.Generic.Tests.cs
@@ -50,7 +50,7 @@ namespace J2N.Collections.Tests
             while (set.Count < numberOfItemsToAdd)
             {
                 T toAdd = CreateT(seed++);
-                while (set.Contains(toAdd) || (InvalidValues != ArrayEmpty && InvalidValues.Contains(toAdd, GetIEqualityComparer())))
+                while (set.Contains(toAdd) || (InvalidValues != Arrays.Empty<T>() && InvalidValues.Contains(toAdd, GetIEqualityComparer())))
                     toAdd = CreateT(seed++);
                 set.Add(toAdd);
             }

--- a/tests/J2N.Tests.xUnit/Collections/TestBase.Generic.cs
+++ b/tests/J2N.Tests.xUnit/Collections/TestBase.Generic.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -41,42 +40,49 @@ namespace J2N.Collections.Tests
         /// MemberData to be passed to tests that take an IEnumerable{T}. This method returns every permutation of
         /// EnumerableType to test on (e.g. HashSet, Queue), and size of set to test with (e.g. 0, 1, etc.).
         /// </summary>
-        public static IEnumerable<object[]> EnumerableTestData()
+        public static IEnumerable<object[]> EnumerableTestData() =>
+            ((IEnumerable<EnumerableType>)Enum.GetValues(typeof(EnumerableType))).SelectMany(GetEnumerableTestData);
+
+        /// <summary>
+        /// MemberData to be passed to tests that take an IEnumerable{T}. This method returns results for various
+        /// sizes of sets to test with (e.g. 0, 1, etc.) but only for List.
+        /// </summary>
+        public static IEnumerable<object[]> ListTestData() =>
+            GetEnumerableTestData(EnumerableType.List);
+
+        protected static IEnumerable<object[]> GetEnumerableTestData(EnumerableType enumerableType)
         {
             foreach (object[] collectionSizeArray in ValidCollectionSizes())
             {
-                foreach (EnumerableType enumerableType in Enum.GetValues(typeof(EnumerableType)))
+                int count = (int)collectionSizeArray[0];
+                yield return new object[] { enumerableType, count, 0, 0, 0 };                       // Empty Enumerable
+                yield return new object[] { enumerableType, count, count + 1, 0, 0 };               // Enumerable that is 1 larger
+
+                if (count >= 1)
                 {
-                    int count = (int)collectionSizeArray[0];
-                    yield return new object[] { enumerableType, count, 0, 0, 0 };                       // Empty Enumerable
-                    yield return new object[] { enumerableType, count, count + 1, 0, 0 };               // Enumerable that is 1 larger
+                    yield return new object[] { enumerableType, count, count, 0, 0 };               // Enumerable of the same size
+                    yield return new object[] { enumerableType, count, count - 1, 0, 0 };           // Enumerable that is 1 smaller
+                    yield return new object[] { enumerableType, count, count, 1, 0 };               // Enumerable of the same size with 1 matching element
+                    yield return new object[] { enumerableType, count, count + 1, 1, 0 };           // Enumerable that is 1 longer with 1 matching element
+                    yield return new object[] { enumerableType, count, count, count, 0 };           // Enumerable with all elements matching
+                    yield return new object[] { enumerableType, count, count + 1, count, 0 };       // Enumerable with all elements matching plus one extra
+                }
 
-                    if (count >= 1)
-                    {
-                        yield return new object[] { enumerableType, count, count, 0, 0 };               // Enumerable of the same size
-                        yield return new object[] { enumerableType, count, count - 1, 0, 0 };           // Enumerable that is 1 smaller
-                        yield return new object[] { enumerableType, count, count, 1, 0 };               // Enumerable of the same size with 1 matching element
-                        yield return new object[] { enumerableType, count, count + 1, 1, 0 };           // Enumerable that is 1 longer with 1 matching element
-                        yield return new object[] { enumerableType, count, count, count, 0 };           // Enumerable with all elements matching
-                        yield return new object[] { enumerableType, count, count + 1, count, 0 };       // Enumerable with all elements matching plus one extra
-                    }
+                if (count >= 2)
+                {
+                    yield return new object[] { enumerableType, count, count - 1, 1, 0 };           // Enumerable that is 1 smaller with 1 matching element
+                    yield return new object[] { enumerableType, count, count + 2, 2, 0 };           // Enumerable that is 2 longer with 2 matching element
+                    yield return new object[] { enumerableType, count, count - 1, count - 1, 0 };   // Enumerable with all elements matching minus one
+                    yield return new object[] { enumerableType, count, count, 2, 0 };               // Enumerable of the same size with 2 matching element
+                    if ((enumerableType == EnumerableType.List || enumerableType == EnumerableType.Queue))
+                        yield return new object[] { enumerableType, count, count, 0, 1 };           // Enumerable with 1 element duplicated
+                }
 
-                    if (count >= 2)
-                    {
-                        yield return new object[] { enumerableType, count, count - 1, 1, 0 };           // Enumerable that is 1 smaller with 1 matching element
-                        yield return new object[] { enumerableType, count, count + 2, 2, 0 };           // Enumerable that is 2 longer with 2 matching element
-                        yield return new object[] { enumerableType, count, count - 1, count - 1, 0 };   // Enumerable with all elements matching minus one
-                        yield return new object[] { enumerableType, count, count, 2, 0 };               // Enumerable of the same size with 2 matching element
-                        if ((enumerableType == EnumerableType.List || enumerableType == EnumerableType.Queue))
-                            yield return new object[] { enumerableType, count, count, 0, 1 };           // Enumerable with 1 element duplicated
-                    }
-
-                    if (count >= 3)
-                    {
-                        if ((enumerableType == EnumerableType.List || enumerableType == EnumerableType.Queue))
-                            yield return new object[] { enumerableType, count, count, 0, 1 };           // Enumerable with all elements duplicated
-                        yield return new object[] { enumerableType, count, count - 1, 2, 0 };           // Enumerable that is 1 smaller with 2 matching elements
-                    }
+                if (count >= 3)
+                {
+                    if ((enumerableType == EnumerableType.List || enumerableType == EnumerableType.Queue))
+                        yield return new object[] { enumerableType, count, count, 0, 1 };           // Enumerable with all elements duplicated
+                    yield return new object[] { enumerableType, count, count - 1, 2, 0 };           // Enumerable that is 1 smaller with 2 matching elements
                 }
             }
         }

--- a/tests/J2N.Tests.xUnit/Collections/TestBase.NonGeneric.cs
+++ b/tests/J2N.Tests.xUnit/Collections/TestBase.NonGeneric.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
@@ -43,8 +42,9 @@ namespace J2N.Collections.Tests
             None = 0,
             Add = 1,
             Insert = 2,
-            Remove = 4,
-            Clear = 8
+            Overwrite = 4,
+            Remove = 8,
+            Clear = 16
         }
 
         #endregion

--- a/tests/J2N.Tests.xUnit/Collections/TestingTypes.cs
+++ b/tests/J2N.Tests.xUnit/Collections/TestingTypes.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;
@@ -413,6 +412,17 @@ namespace J2N.Collections.Tests
             GetHashCodeCalls++;
             return EqualityComparer<T>.Default.GetHashCode(obj);
         }
+    }
+
+    public sealed class EqualityComparerConstantHashCode<T> : IEqualityComparer<T>
+    {
+        private readonly IEqualityComparer<T> _comparer;
+
+        public EqualityComparerConstantHashCode(IEqualityComparer<T> comparer) => _comparer = comparer;
+
+        public bool Equals(T x, T y) => _comparer.Equals(x, y);
+
+        public int GetHashCode(T obj) => 42;
     }
 
     #endregion

--- a/tests/J2N.Tests.xUnit/PlatformDetection.cs
+++ b/tests/J2N.Tests.xUnit/PlatformDetection.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -7,12 +10,76 @@ namespace J2N
 {
     public static class PlatformDetection
     {
-        public static bool IsFullFramework =>
+
+        public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
+        public static bool IsNotMonoRuntime => !IsMonoRuntime;
+
+        public static bool IsNativeAot => IsNotMonoRuntime && !IsReflectionEmitSupported;
+        public static bool IsBrowser =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+#else
+            false;
+#endif
+        public static bool IsWasi =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI"));
+#else
+            false;
+#endif
+        public static bool IsAndroid =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
+#else
+            false;
+#endif
+        public static bool IsNotAndroid => !IsAndroid;
+
+        public static bool IsiOS =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
+#else
+            false;
+#endif
+        public static bool IstvOS =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
+#else
+            false;
+#endif
+        public static bool IsMacCatalyst =>
+#if FEATURE_RUNTIMEINFORMATION
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACCATALYST"));
+#else
+            false;
+#endif
+        public static bool IsNotMacCatalyst => !IsMacCatalyst;
+
+        public static bool IsMobile => IsBrowser || IsWasi || IsAppleMobile || IsAndroid;
+        public static bool IsNotMobile => !IsMobile;
+
+        public static bool IsAppleMobile => IsMacCatalyst || IsiOS || IstvOS;
+
+        public static bool IsNetFramework =>
 #if FEATURE_RUNTIMEINFORMATION
             RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 #else
             true;
 #endif
+
+        public static bool IsBinaryFormatterSupported => IsNotMobile && !IsNativeAot;
+
+        public static bool IsPreciseGcSupported => !IsMonoRuntime;
+
+        public static bool IsThreadingSupported => (!IsWasi && !IsBrowser) || IsWasmThreadingSupported;
+        public static bool IsWasmThreadingSupported => IsBrowser && IsEnvironmentVariableTrue("IsBrowserThreadingSupported");
+
+#if NETCOREAPP
+        public static bool IsReflectionEmitSupported => RuntimeFeature.IsDynamicCodeSupported;
+#else
+        public static bool IsReflectionEmitSupported => true;
+#endif
+        public static bool IsNotReflectionEmitSupported => !IsReflectionEmitSupported;
 
         private static volatile Tuple<bool> s_lazyNonZeroLowerBoundArraySupported;
         public static bool IsNonZeroLowerBoundArraySupported
@@ -34,6 +101,20 @@ namespace J2N
                 }
                 return s_lazyNonZeroLowerBoundArraySupported.Item1;
             }
+        }
+
+        private static readonly Lazy<bool> m_isInvariant = new Lazy<bool>(()
+            => (bool?)Type.GetType("System.Globalization.GlobalizationMode")?.GetProperty("Invariant", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null) == true);
+
+        public static bool IsInvariantGlobalization => m_isInvariant.Value;
+        public static bool IsNotInvariantGlobalization => !IsInvariantGlobalization;
+
+        private static bool IsEnvironmentVariableTrue(string variableName)
+        {
+            if (!IsBrowser)
+                return false;
+
+            return Environment.GetEnvironmentVariable(variableName) is "true";
         }
     }
 }

--- a/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
+++ b/tests/J2N.Tests.xUnit/Runtime/InteropServices/CollectionMarshalTests.cs
@@ -1,8 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using J2N.Collections.Generic;
+using J2N.Runtime.CompilerServices;
+using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -147,355 +148,355 @@ namespace J2N.Runtime.InteropServices.Tests
             }
         }
 
-        //[Fact]
-        //public void GetValueRefOrNullRefValueType()
-        //{
-        //    var dict = new Dictionary<int, Struct>
-        //    {
-        //        {  1, default },
-        //        {  2, default }
-        //    };
+        [Fact]
+        public void GetValueRefOrNullRefValueType()
+        {
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, default },
+                {  2, default }
+            };
 
-        //    Assert.Equal(2, dict.Count);
+            Assert.Equal(2, dict.Count);
 
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    Struct itemVal = dict[1];
-        //    itemVal.Value = 1;
-        //    itemVal.Property = 2;
+            Struct itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
 
-        //    // Does not change values in dictionary
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            // Does not change values in dictionary
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
-        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
+            CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
+            CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
 
-        //    Assert.Equal(3, dict[1].Value);
-        //    Assert.Equal(4, dict[1].Property);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
 
-        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
+            ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
 
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 5;
-        //    itemRef.Property = 6;
+            itemRef.Value = 5;
+            itemRef.Property = 6;
 
-        //    Assert.Equal(5, itemRef.Value);
-        //    Assert.Equal(6, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    itemRef = new Struct() { Value = 7, Property = 8 };
+            itemRef = new Struct() { Value = 7, Property = 8 };
 
-        //    Assert.Equal(7, itemRef.Value);
-        //    Assert.Equal(8, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    // Check for null refs
+            // Check for null refs
 
-        //    Assert.True(Unsafe.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
-        //    Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
+            Assert.True(UnsafeHelpers.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
+            Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
 
-        //    Assert.Equal(2, dict.Count);
-        //}
+            Assert.Equal(2, dict.Count);
+        }
 
-        //[Fact]
-        //public void GetValueRefOrNullRefClass()
-        //{
-        //    var dict = new Dictionary<int, IntAsObject>
-        //    {
-        //        {  1, new IntAsObject() },
-        //        {  2, new IntAsObject() }
-        //    };
+        [Fact]
+        public void GetValueRefOrNullRefClass()
+        {
+            var dict = new Dictionary<int, IntAsObject>
+            {
+                {  1, new IntAsObject() },
+                {  2, new IntAsObject() }
+            };
 
-        //    Assert.Equal(2, dict.Count);
+            Assert.Equal(2, dict.Count);
 
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    IntAsObject itemVal = dict[1];
-        //    itemVal.Value = 1;
-        //    itemVal.Property = 2;
+            IntAsObject itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
 
-        //    // Does change values in dictionary
-        //    Assert.Equal(1, dict[1].Value);
-        //    Assert.Equal(2, dict[1].Property);
+            // Does change values in dictionary
+            Assert.Equal(1, dict[1].Value);
+            Assert.Equal(2, dict[1].Property);
 
-        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
-        //    CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
+            CollectionMarshal.GetValueRefOrNullRef(dict, 1).Value = 3;
+            CollectionMarshal.GetValueRefOrNullRef(dict, 1).Property = 4;
 
-        //    Assert.Equal(3, dict[1].Value);
-        //    Assert.Equal(4, dict[1].Property);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
 
-        //    ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
+            ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 2);
 
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 5;
-        //    itemRef.Property = 6;
+            itemRef.Value = 5;
+            itemRef.Property = 6;
 
-        //    Assert.Equal(5, itemRef.Value);
-        //    Assert.Equal(6, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    itemRef = new IntAsObject() { Value = 7, Property = 8 };
+            itemRef = new IntAsObject() { Value = 7, Property = 8 };
 
-        //    Assert.Equal(7, itemRef.Value);
-        //    Assert.Equal(8, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    // Check for null refs
+            // Check for null refs
 
-        //    Assert.True(Unsafe.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
-        //    Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
+            Assert.True(UnsafeHelpers.IsNullRef(ref CollectionMarshal.GetValueRefOrNullRef(dict, 3)));
+            Assert.Throws<NullReferenceException>(() => CollectionMarshal.GetValueRefOrNullRef(dict, 3).Value = 9);
 
-        //    Assert.Equal(2, dict.Count);
-        //}
+            Assert.Equal(2, dict.Count);
+        }
 
-        //[Fact]
-        //public void GetValueRefOrNullRefLinkBreaksOnResize()
-        //{
-        //    var dict = new Dictionary<int, Struct>
-        //    {
-        //        {  1, new Struct() }
-        //    };
+        [Fact]
+        public void GetValueRefOrNullRefLinkBreaksOnResize()
+        {
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, new Struct() }
+            };
 
-        //    Assert.Equal(1, dict.Count);
+            Assert.Equal(1, dict.Count);
 
-        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 1);
+            ref Struct itemRef = ref CollectionMarshal.GetValueRefOrNullRef(dict, 1);
 
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 1;
-        //    itemRef.Property = 2;
+            itemRef.Value = 1;
+            itemRef.Property = 2;
 
-        //    Assert.Equal(1, itemRef.Value);
-        //    Assert.Equal(2, itemRef.Property);
-        //    Assert.Equal(dict[1].Value, itemRef.Value);
-        //    Assert.Equal(dict[1].Property, itemRef.Property);
+            Assert.Equal(1, itemRef.Value);
+            Assert.Equal(2, itemRef.Property);
+            Assert.Equal(dict[1].Value, itemRef.Value);
+            Assert.Equal(dict[1].Property, itemRef.Property);
 
-        //    // Resize
-        //    dict.EnsureCapacity(100);
-        //    for (int i = 2; i <= 50; i++)
-        //    {
-        //        dict.Add(i, new Struct());
-        //    }
+            // Resize
+            dict.EnsureCapacity(100);
+            for (int i = 2; i <= 50; i++)
+            {
+                dict.Add(i, new Struct());
+            }
 
-        //    itemRef.Value = 3;
-        //    itemRef.Property = 4;
+            itemRef.Value = 3;
+            itemRef.Property = 4;
 
-        //    Assert.Equal(3, itemRef.Value);
-        //    Assert.Equal(4, itemRef.Property);
+            Assert.Equal(3, itemRef.Value);
+            Assert.Equal(4, itemRef.Property);
 
-        //    // Check connection broken
-        //    Assert.NotEqual(dict[1].Value, itemRef.Value);
-        //    Assert.NotEqual(dict[1].Property, itemRef.Property);
+            // Check connection broken
+            Assert.NotEqual(dict[1].Value, itemRef.Value);
+            Assert.NotEqual(dict[1].Property, itemRef.Property);
 
-        //    Assert.Equal(50, dict.Count);
-        //}
+            Assert.Equal(50, dict.Count);
+        }
 
-        //[Fact]
-        //public void GetValueRefOrAddDefaultValueType()
-        //{
-        //    // This test is the same as the one for GetValueRefOrNullRef, but it uses
-        //    // GetValueRefOrAddDefault instead, and also checks for incorrect additions.
-        //    // The two APIs should behave the same when values already exist.
-        //    var dict = new Dictionary<int, Struct>
-        //    {
-        //        {  1, default },
-        //        {  2, default }
-        //    };
+        [Fact]
+        public void GetValueRefOrAddDefaultValueType()
+        {
+            // This test is the same as the one for GetValueRefOrNullRef, but it uses
+            // GetValueRefOrAddDefault instead, and also checks for incorrect additions.
+            // The two APIs should behave the same when values already exist.
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, default },
+                {  2, default }
+            };
 
-        //    Assert.Equal(2, dict.Count);
+            Assert.Equal(2, dict.Count);
 
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    Struct itemVal = dict[1];
-        //    itemVal.Value = 1;
-        //    itemVal.Property = 2;
+            Struct itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
 
-        //    // Does not change values in dictionary
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            // Does not change values in dictionary
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+            CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
 
-        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+            CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
-        //    Assert.Equal(3, dict[1].Value);
-        //    Assert.Equal(4, dict[1].Property);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
 
-        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+            ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 5;
-        //    itemRef.Property = 6;
+            itemRef.Value = 5;
+            itemRef.Property = 6;
 
-        //    Assert.Equal(5, itemRef.Value);
-        //    Assert.Equal(6, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    itemRef = new Struct() { Value = 7, Property = 8 };
+            itemRef = new Struct() { Value = 7, Property = 8 };
 
-        //    Assert.Equal(7, itemRef.Value);
-        //    Assert.Equal(8, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    // Check for correct additions
+            // Check for correct additions
 
-        //    ref Struct entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+            ref Struct entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
 
-        //    Assert.False(exists);
-        //    Assert.Equal(3, dict.Count);
-        //    Assert.False(Unsafe.IsNullRef(ref entry3Ref));
-        //    Assert.True(EqualityComparer<Struct>.Default.Equals(entry3Ref, default));
+            Assert.False(exists);
+            Assert.Equal(3, dict.Count);
+            Assert.False(UnsafeHelpers.IsNullRef(ref entry3Ref));
+            Assert.True(EqualityComparer<Struct>.Default.Equals(entry3Ref, default));
 
-        //    entry3Ref.Property = 42;
-        //    entry3Ref.Value = 12345;
+            entry3Ref.Property = 42;
+            entry3Ref.Value = 12345;
 
-        //    Struct value3 = dict[3];
+            Struct value3 = dict[3];
 
-        //    Assert.Equal(42, value3.Property);
-        //    Assert.Equal(12345, value3.Value);
-        //}
+            Assert.Equal(42, value3.Property);
+            Assert.Equal(12345, value3.Value);
+        }
 
-        //[Fact]
-        //public void GetValueRefOrAddDefaultClass()
-        //{
-        //    var dict = new Dictionary<int, IntAsObject>
-        //    {
-        //        {  1, new IntAsObject() },
-        //        {  2, new IntAsObject() }
-        //    };
+        [Fact]
+        public void GetValueRefOrAddDefaultClass()
+        {
+            var dict = new Dictionary<int, IntAsObject>
+            {
+                {  1, new IntAsObject() },
+                {  2, new IntAsObject() }
+            };
 
-        //    Assert.Equal(2, dict.Count);
+            Assert.Equal(2, dict.Count);
 
-        //    Assert.Equal(0, dict[1].Value);
-        //    Assert.Equal(0, dict[1].Property);
+            Assert.Equal(0, dict[1].Value);
+            Assert.Equal(0, dict[1].Property);
 
-        //    IntAsObject itemVal = dict[1];
-        //    itemVal.Value = 1;
-        //    itemVal.Property = 2;
+            IntAsObject itemVal = dict[1];
+            itemVal.Value = 1;
+            itemVal.Property = 2;
 
-        //    // Does change values in dictionary
-        //    Assert.Equal(1, dict[1].Value);
-        //    Assert.Equal(2, dict[1].Property);
+            // Does change values in dictionary
+            Assert.Equal(1, dict[1].Value);
+            Assert.Equal(2, dict[1].Property);
 
-        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
+            CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists).Value = 3;
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
 
-        //    CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
+            CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out exists).Property = 4;
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
-        //    Assert.Equal(3, dict[1].Value);
-        //    Assert.Equal(4, dict[1].Property);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(3, dict[1].Value);
+            Assert.Equal(4, dict[1].Property);
 
-        //    ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
+            ref IntAsObject itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 2, out exists);
 
-        //    Assert.True(exists);
-        //    Assert.Equal(2, dict.Count);
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.True(exists);
+            Assert.Equal(2, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 5;
-        //    itemRef.Property = 6;
+            itemRef.Value = 5;
+            itemRef.Property = 6;
 
-        //    Assert.Equal(5, itemRef.Value);
-        //    Assert.Equal(6, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(5, itemRef.Value);
+            Assert.Equal(6, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    itemRef = new IntAsObject() { Value = 7, Property = 8 };
+            itemRef = new IntAsObject() { Value = 7, Property = 8 };
 
-        //    Assert.Equal(7, itemRef.Value);
-        //    Assert.Equal(8, itemRef.Property);
-        //    Assert.Equal(dict[2].Value, itemRef.Value);
-        //    Assert.Equal(dict[2].Property, itemRef.Property);
+            Assert.Equal(7, itemRef.Value);
+            Assert.Equal(8, itemRef.Property);
+            Assert.Equal(dict[2].Value, itemRef.Value);
+            Assert.Equal(dict[2].Property, itemRef.Property);
 
-        //    // Check for correct additions
+            // Check for correct additions
 
-        //    ref IntAsObject entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
+            ref IntAsObject entry3Ref = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 3, out exists);
 
-        //    Assert.False(exists);
-        //    Assert.Equal(3, dict.Count);
-        //    Assert.False(Unsafe.IsNullRef(ref entry3Ref));
-        //    Assert.Null(entry3Ref);
+            Assert.False(exists);
+            Assert.Equal(3, dict.Count);
+            Assert.False(UnsafeHelpers.IsNullRef(ref entry3Ref));
+            Assert.Null(entry3Ref);
 
-        //    entry3Ref = new IntAsObject() { Value = 12345, Property = 42 };
+            entry3Ref = new IntAsObject() { Value = 12345, Property = 42 };
 
-        //    IntAsObject value3 = dict[3];
+            IntAsObject value3 = dict[3];
 
-        //    Assert.Equal(42, value3.Property);
-        //    Assert.Equal(12345, value3.Value);
-        //}
+            Assert.Equal(42, value3.Property);
+            Assert.Equal(12345, value3.Value);
+        }
 
-        //[Fact]
-        //public void GetValueRefOrAddDefaultLinkBreaksOnResize()
-        //{
-        //    var dict = new Dictionary<int, Struct>
-        //    {
-        //        {  1, new Struct() }
-        //    };
+        [Fact]
+        public void GetValueRefOrAddDefaultLinkBreaksOnResize()
+        {
+            var dict = new Dictionary<int, Struct>
+            {
+                {  1, new Struct() }
+            };
 
-        //    Assert.Equal(1, dict.Count);
+            Assert.Equal(1, dict.Count);
 
-        //    ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists);
+            ref Struct itemRef = ref CollectionMarshal.GetValueRefOrAddDefault(dict, 1, out bool exists);
 
-        //    Assert.True(exists);
-        //    Assert.Equal(1, dict.Count);
-        //    Assert.Equal(0, itemRef.Value);
-        //    Assert.Equal(0, itemRef.Property);
+            Assert.True(exists);
+            Assert.Equal(1, dict.Count);
+            Assert.Equal(0, itemRef.Value);
+            Assert.Equal(0, itemRef.Property);
 
-        //    itemRef.Value = 1;
-        //    itemRef.Property = 2;
+            itemRef.Value = 1;
+            itemRef.Property = 2;
 
-        //    Assert.Equal(1, itemRef.Value);
-        //    Assert.Equal(2, itemRef.Property);
-        //    Assert.Equal(dict[1].Value, itemRef.Value);
-        //    Assert.Equal(dict[1].Property, itemRef.Property);
+            Assert.Equal(1, itemRef.Value);
+            Assert.Equal(2, itemRef.Property);
+            Assert.Equal(dict[1].Value, itemRef.Value);
+            Assert.Equal(dict[1].Property, itemRef.Property);
 
-        //    // Resize
-        //    dict.EnsureCapacity(100);
-        //    for (int i = 2; i <= 50; i++)
-        //    {
-        //        dict.Add(i, new Struct());
-        //    }
+            // Resize
+            dict.EnsureCapacity(100);
+            for (int i = 2; i <= 50; i++)
+            {
+                dict.Add(i, new Struct());
+            }
 
-        //    itemRef.Value = 3;
-        //    itemRef.Property = 4;
+            itemRef.Value = 3;
+            itemRef.Property = 4;
 
-        //    Assert.Equal(3, itemRef.Value);
-        //    Assert.Equal(4, itemRef.Property);
+            Assert.Equal(3, itemRef.Value);
+            Assert.Equal(4, itemRef.Property);
 
-        //    // Check connection broken
-        //    Assert.NotEqual(dict[1].Value, itemRef.Value);
-        //    Assert.NotEqual(dict[1].Property, itemRef.Property);
+            // Check connection broken
+            Assert.NotEqual(dict[1].Value, itemRef.Value);
+            Assert.NotEqual(dict[1].Property, itemRef.Property);
 
-        //    Assert.Equal(50, dict.Count);
-        //}
+            Assert.Equal(50, dict.Count);
+        }
 
         private struct Struct
         {

--- a/tests/J2N.Tests.xUnit/Xunit/Attributes/ConditionalFactAttribute.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/Attributes/ConditionalFactAttribute.cs
@@ -1,13 +1,15 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// From https://github.com/dotnet/arcade
+
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using System;
+using Xunit;
 using Xunit.Sdk;
 
 namespace Xunit
 {
-    [XunitTestCaseDiscoverer("Microsoft.DotNet.XUnitExtensions.ConditionalFactDiscoverer", "Microsoft.DotNet.XUnitExtensions")]
+    [XunitTestCaseDiscoverer("Xunit.ConditionalFactDiscoverer", "J2N.Tests.xUnit")]
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public sealed class ConditionalFactAttribute : FactAttribute
     {

--- a/tests/J2N.Tests.xUnit/Xunit/Attributes/ConditionalTheoryAttribute.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/Attributes/ConditionalTheoryAttribute.cs
@@ -1,0 +1,36 @@
+﻿// From https://github.com/dotnet/arcade
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+
+    [XunitTestCaseDiscoverer("Xunit.ConditionalTheoryDiscoverer", "J2N.Tests.xUnit")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class ConditionalTheoryAttribute : TheoryAttribute
+    {
+        [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
+        public Type CalleeType { get; private set; }
+        public string[] ConditionMemberNames { get; private set; }
+
+        public ConditionalTheoryAttribute(
+            [DynamicallyAccessedMembers(StaticReflectionConstants.ConditionalMemberKinds)]
+            Type calleeType,
+            params string[] conditionMemberNames)
+        {
+            CalleeType = calleeType;
+            ConditionMemberNames = conditionMemberNames;
+        }
+
+        public ConditionalTheoryAttribute(params string[] conditionMemberNames)
+        {
+            ConditionMemberNames = conditionMemberNames;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/ConditionalDiscovererException.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/ConditionalDiscovererException.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Xunit
+{
+    internal class ConditionalDiscovererException : Exception
+    {
+        public ConditionalDiscovererException(string message) : base(message) { }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalFactDiscoverer.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalFactDiscoverer.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    public class ConditionalFactDiscoverer : FactDiscoverer
+    {
+        public ConditionalFactDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink) { }
+
+        protected override IXunitTestCase CreateTestCase(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo factAttribute)
+        {
+            if (ConditionalTestDiscoverer.TryEvaluateSkipConditions(discoveryOptions, DiagnosticMessageSink, testMethod, factAttribute.GetConstructorArguments().ToArray(), out string skipReason, out ExecutionErrorTestCase errorTestCase))
+            {
+                return skipReason != null
+                    ? (IXunitTestCase)new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod)
+                    : new SkippedFactTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod); // Test case skippable at runtime.
+            }
+
+            return errorTestCase;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalTestDiscoverer.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalTestDiscoverer.cs
@@ -1,0 +1,179 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    // Internal helper class for code common to conditional test discovery through
+    // [ConditionalFact] and [ConditionalTheory]
+    internal static class ConditionalTestDiscoverer
+    {
+        // This helper method evaluates the given condition member names for a given set of test cases.
+        // If any condition member evaluates to 'false', the test cases are marked to be skipped.
+        // The skip reason is the collection of all the condition members that evaluated to 'false'.
+        internal static string EvaluateSkipConditions(ITestMethod testMethod, object[] conditionArguments)
+        {
+            Type calleeType = null;
+            string[] conditionMemberNames = null;
+
+            if (CheckInputToSkipExecution(conditionArguments, ref calleeType, ref conditionMemberNames, testMethod)) return null;
+
+            MethodInfo testMethodInfo = testMethod.Method.ToRuntimeMethod();
+            Type testMethodDeclaringType = testMethodInfo.DeclaringType;
+            List<string> falseConditions = new List<string>(conditionMemberNames.Count());
+
+            foreach (string entry in conditionMemberNames)
+            {
+                string conditionMemberName = entry;
+
+                // Null condition member names are silently tolerated
+                if (string.IsNullOrWhiteSpace(conditionMemberName))
+                {
+                    continue;
+                }
+
+                Type declaringType;
+
+                if (calleeType != null)
+                {
+                    declaringType = calleeType;
+                }
+                else
+                {
+                    declaringType = testMethodDeclaringType;
+
+                    string[] symbols = conditionMemberName.Split('.');
+                    if (symbols.Length == 2)
+                    {
+                        conditionMemberName = symbols[1];
+                        ITypeInfo type = testMethod.TestClass.Class.Assembly.GetTypes(false).Where(t => t.Name.Contains(symbols[0])).FirstOrDefault();
+                        if (type != null)
+                        {
+                            declaringType = type.ToRuntimeType();
+                        }
+                    }
+                }
+
+                Func<bool> conditionFunc;
+                if ((conditionFunc = LookupConditionalMember(declaringType, conditionMemberName)) == null)
+                {
+                    throw new ConditionalDiscovererException(GetFailedLookupString(conditionMemberName, declaringType));
+                }
+
+                // In the case of multiple conditions, collect the results of all
+                // of them to produce a summary skip reason.
+                try
+                {
+                    if (!conditionFunc())
+                    {
+                        falseConditions.Add(conditionMemberName);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    falseConditions.Add($"{conditionMemberName} ({exc.GetType().Name})");
+                }
+            }
+
+            // Compose a summary of all conditions that returned false.
+            if (falseConditions.Count > 0)
+            {
+                return string.Format("Condition(s) not met: \"{0}\"", string.Join("\", \"", falseConditions));
+            }
+
+            // No conditions returned false (including the absence of any conditions).
+            return null;
+        }
+
+        internal static bool TryEvaluateSkipConditions(ITestFrameworkDiscoveryOptions discoveryOptions, IMessageSink diagnosticMessageSink, ITestMethod testMethod, object[] conditionArguments, out string skipReason, out ExecutionErrorTestCase errorTestCase)
+        {
+            skipReason = null;
+            errorTestCase = null;
+            try
+            {
+                skipReason = EvaluateSkipConditions(testMethod, conditionArguments);
+                return true;
+            }
+            catch (ConditionalDiscovererException e)
+            {
+                errorTestCase = new ExecutionErrorTestCase(
+                    diagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    e.Message);
+                return false;
+            }
+        }
+
+        internal static string GetFailedLookupString(string name, Type type)
+        {
+            return
+                $"An appropriate member '{name}' could not be found. " +
+                $"The conditional method needs to be a static method, property, or field on the type {type} or any ancestor, " +
+                "of any visibility, accepting zero arguments, and having a return type of Boolean.";
+        }
+
+        internal static Func<bool> LookupConditionalMember(Type t, string name)
+        {
+            if (t == null || name == null)
+                return null;
+
+            TypeInfo ti = t.GetTypeInfo();
+
+            MethodInfo mi = ti.GetDeclaredMethod(name);
+            if (mi != null && mi.IsStatic && mi.GetParameters().Length == 0 && mi.ReturnType == typeof(bool))
+                return () => (bool)mi.Invoke(null, null);
+
+            PropertyInfo pi = ti.GetDeclaredProperty(name);
+            if (pi != null && pi.PropertyType == typeof(bool) && pi.GetMethod != null && pi.GetMethod.IsStatic && pi.GetMethod.GetParameters().Length == 0)
+                return () => (bool)pi.GetValue(null);
+
+            FieldInfo fi = ti.GetDeclaredField(name);
+            if (fi != null && fi.FieldType == typeof(bool) && fi.IsStatic)
+                return () => (bool)fi.GetValue(null);
+
+            return LookupConditionalMember(ti.BaseType, name);
+        }
+
+        internal static bool CheckInputToSkipExecution(object[] conditionArguments, ref Type calleeType, ref string[] conditionMemberNames, ITestMethod testMethod = null)
+        {
+            // A null or empty list of conditionArguments is treated as "no conditions".
+            // and the test cases will be executed.
+            // Example: [ConditionalClass()]
+            if (conditionArguments == null || conditionArguments.Length == 0) return true;
+
+            calleeType = conditionArguments[0] as Type;
+            if (calleeType != null)
+            {
+                if (conditionArguments.Length < 2)
+                {
+                    // [ConditionalFact(typeof(x))] no provided methods.
+                    return true;
+                }
+
+                // [ConditionalFact(typeof(x), "MethodName")]
+                conditionMemberNames = conditionArguments[1] as string[];
+            }
+            else
+            {
+                // For [ConditionalClass], unable to get the Type info. All test cases will be executed.
+                if (testMethod == null) return true;
+
+                // [ConditionalFact("MethodName")]
+                conditionMemberNames = conditionArguments[0] as string[];
+            }
+
+            // [ConditionalFact((string[]) null)]
+            if (conditionMemberNames == null || conditionMemberNames.Count() == 0) return true;
+
+            return false;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalTheoryDiscoverer.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/Discoverers/ConditionalTheoryDiscoverer.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    public class ConditionalTheoryDiscoverer : TheoryDiscoverer
+    {
+        private readonly Dictionary<IMethodInfo, string> _conditionCache;
+
+        public ConditionalTheoryDiscoverer(IMessageSink diagnosticMessageSink) : base(diagnosticMessageSink)
+        {
+            _conditionCache = new Dictionary<IMethodInfo, string>();
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            if (ConditionalTestDiscoverer.TryEvaluateSkipConditions(discoveryOptions, DiagnosticMessageSink, testMethod, theoryAttribute.GetConstructorArguments().ToArray(), out string skipReason, out ExecutionErrorTestCase errorTestCase))
+            {
+                return skipReason != null
+                   ? new[] { new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) }
+                   : new IXunitTestCase[] { new SkippedTheoryTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod) }; // Theory skippable at runtime.
+            }
+
+            return new IXunitTestCase[] { errorTestCase };
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute, object[] dataRow)
+        {
+            IMethodInfo methodInfo = testMethod.Method;
+            List<IXunitTestCase> skippedTestCase = new List<IXunitTestCase>();
+
+            if (!_conditionCache.TryGetValue(methodInfo, out string skipReason))
+            {
+                if (!ConditionalTestDiscoverer.TryEvaluateSkipConditions(discoveryOptions, DiagnosticMessageSink, testMethod, theoryAttribute.GetConstructorArguments().ToArray(), out skipReason, out ExecutionErrorTestCase errorTestCase))
+                {
+                    return new IXunitTestCase[] { errorTestCase };
+                }
+
+                _conditionCache.Add(methodInfo, skipReason);
+
+                if (skipReason != null)
+                {
+                    // If this is the first time we evalute the condition we return a SkippedTestCase to avoid printing a skip for every inline-data.
+                    skippedTestCase.Add(new SkippedTestCase(skipReason, DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod));
+                }
+            }
+
+            return skipReason != null ?
+                        (IEnumerable<IXunitTestCase>)skippedTestCase
+                        : new[] { new SkippedFactTestCase(DiagnosticMessageSink, discoveryOptions.MethodDisplayOrDefault(), discoveryOptions.MethodDisplayOptionsOrDefault(), testMethod, dataRow) }; // Test case skippable at runtime.
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/SkippedFactTestCase.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/SkippedFactTestCase.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>Wraps RunAsync for ConditionalFact.</summary>
+    public class SkippedFactTestCase : XunitTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", error: true)]
+        public SkippedFactTestCase() { }
+
+        public SkippedFactTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            SkippedTestMessageBus skipMessageBus = new SkippedTestMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.SkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.SkippedTestCount;
+                result.Skipped += skipMessageBus.SkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/SkippedTestCase.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/SkippedTestCase.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>Wraps another test case that should be skipped.</summary>
+    internal sealed class SkippedTestCase : XunitTestCase
+    {
+        private string _skipReason;
+
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public SkippedTestCase() : base()
+        {
+        }
+
+        public SkippedTestCase(
+            string skipReason,
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            _skipReason = skipReason;
+        }
+
+        protected override string GetSkipReason(IAttributeInfo factAttribute)
+            => _skipReason ?? base.GetSkipReason(factAttribute);
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+            _skipReason = data.GetValue<string>(nameof(_skipReason));
+        }
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+            data.AddValue(nameof(_skipReason), _skipReason);
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/SkippedTestMessageBus.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/SkippedTestMessageBus.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    public class SkipTestException : Exception
+    {
+        public SkipTestException(string reason)
+            : base(reason) { }
+    }
+
+    /// <summary>Implements message bus to communicate tests skipped via SkipTestException.</summary>
+    public class SkippedTestMessageBus : IMessageBus
+    {
+        readonly IMessageBus innerBus;
+
+        public SkippedTestMessageBus(IMessageBus innerBus)
+        {
+            this.innerBus = innerBus;
+        }
+
+        public int SkippedTestCount { get; private set; }
+
+        public void Dispose() { }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            var testFailed = message as ITestFailed;
+
+            if (testFailed != null)
+            {
+                var exceptionType = testFailed.ExceptionTypes.FirstOrDefault();
+                if (exceptionType == typeof(SkipTestException).FullName)
+                {
+                    SkippedTestCount++;
+                    return innerBus.QueueMessage(new TestSkipped(testFailed.Test, testFailed.Messages.FirstOrDefault()));
+                }
+            }
+
+            // Nothing we care about, send it on its way
+            return innerBus.QueueMessage(message);
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/SkippedTheoryTestCase.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/SkippedTheoryTestCase.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>Wraps RunAsync for ConditionalTheory.</summary>
+    public class SkippedTheoryTestCase : XunitTheoryTestCase
+    {
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", error: true)]
+        public SkippedTheoryTestCase() { }
+
+        public SkippedTheoryTestCase(IMessageSink diagnosticMessageSink, TestMethodDisplay defaultMethodDisplay, TestMethodDisplayOptions defaultMethodDisplayOptions, ITestMethod testMethod)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod) { }
+
+        public override async Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink,
+                                                        IMessageBus messageBus,
+                                                        object[] constructorArguments,
+                                                        ExceptionAggregator aggregator,
+                                                        CancellationTokenSource cancellationTokenSource)
+        {
+            SkippedTestMessageBus skipMessageBus = new SkippedTestMessageBus(messageBus);
+            var result = await base.RunAsync(diagnosticMessageSink, skipMessageBus, constructorArguments, aggregator, cancellationTokenSource);
+            if (skipMessageBus.SkippedTestCount > 0)
+            {
+                result.Failed -= skipMessageBus.SkippedTestCount;
+                result.Skipped += skipMessageBus.SkippedTestCount;
+            }
+
+            return result;
+        }
+    }
+}

--- a/tests/J2N.Tests.xUnit/Xunit/StaticReflectionConstants.cs
+++ b/tests/J2N.Tests.xUnit/Xunit/StaticReflectionConstants.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Xunit
+{
+    internal static class StaticReflectionConstants
+    {
+        // ConditionalTestDiscoverer looks at all fields/methods/properties, recursively.
+        internal const DynamicallyAccessedMemberTypes ConditionalMemberKinds = DynamicallyAccessedMemberTypes.All;
+    }
+}
+
+#if !NET
+namespace System.Diagnostics.CodeAnalysis
+{
+    // This is a copy of the attribute from CoreLib. The attribute shipped in .NET 5.
+    // The tooling looks for the attribute by name, so we can define a local copy.
+    // This copy can be deleted once we stop supporting anything below .NET 5.
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) => MemberTypes = memberTypes;
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        PublicParameterlessConstructor = 0x0001,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        NonPublicConstructors = 0x0004,
+        PublicMethods = 0x0008,
+        NonPublicMethods = 0x0010,
+        PublicFields = 0x0020,
+        NonPublicFields = 0x0040,
+        PublicNestedTypes = 0x0080,
+        NonPublicNestedTypes = 0x0100,
+        PublicProperties = 0x0200,
+        NonPublicProperties = 0x0400,
+        PublicEvents = 0x0800,
+        NonPublicEvents = 0x1000,
+        Interfaces = 0x2000,
+        All = ~None
+    }
+}
+#endif


### PR DESCRIPTION
This brings over the `Dictionary<TKey, TValue>` implementation from .NET 8.0.8 and also upgrades the test framework to account for the new features (throwing exceptions in fewer cases) introduced in .NET 8. This provides the following benefits:

1. A consistent implementation across all .NET versions. This is especially important for the ability to delete while iterating forward, which wasn't introduced until .NET Core 3.
2. Less branching logic. We now store the null key and value in the hash table with the rest of the collection items.

We are still missing the `RandomizedStringComparer`/`NonRandomizedStringComparer` support for `OrdinalIgnoreCase`, as this depends on both ICU and some branching logic for invariant/NLS/ICU mode. There is some work started on the ICU bit here: https://github.com/NightOwl888/J2N/tree/feature/randomizedstringcomparer-ordinalignorecase. Lucene.NET and ICU4N don't rely on `StringComparer.OrdinalIgnoreCase` (except in tests) so we can probably do without it for a release.
