### PR TITLE
Added net8.0 target and tests (Fixes #94)

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -4,12 +4,13 @@
     <!-- Changing this setting will allow testing on all target frameworks within Visual Studio 2017.
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
-    <!--<TargetFramework>net452</TargetFramework>-->
-    <!--<TargetFramework>net461</TargetFramework>-->
+    <!--<TargetFramework>net47</TargetFramework>-->
+    <!--<TargetFramework>net471</TargetFramework>-->
     <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->
+    <!--<TargetFramework>net8.0</TargetFramework>-->
     <TestAllTargetFrameworks>true</TestAllTargetFrameworks>
 
     <!-- Allow the build script to pass in the test frameworks to build for.
@@ -17,23 +18,25 @@
       TODO: Due to a parsing bug, we cannot pass a string with a ; to dotnet msbuild, so passing true as a workaround -->
     
     <!-- Test Client to DLL target works as follows:
+
       Test Client       | Target Under Test
+      net8.0            | net8.0
       net6.0            | net6.0
       net5.0            | netstandard2.1
       net48             | net462
       net472            | net45
-      net461            | netstandard2.0
-      net452            | net40
-      
+      net471            | netstandard2.0
+      net47             | net40
+
     -->
-    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0;net48;net472;net461;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0;net48;net472;net471;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Mismatched Target Framework (to override the target framework under test)">
     <SetTargetFramework></SetTargetFramework>
-    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net452' ">TargetFramework=net40</SetTargetFramework>
-    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net461' ">TargetFramework=netstandard2.0</SetTargetFramework>
+    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net47' ">TargetFramework=net40</SetTargetFramework>
+    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net471' ">TargetFramework=netstandard2.0</SetTargetFramework>
     <SetTargetFramework Condition=" '$(TargetFramework)' == 'net472' ">TargetFramework=net45</SetTargetFramework>
   </PropertyGroup>
   

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -26,7 +26,7 @@
       net452            | net40
       
     -->
-    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net6.0;net5.0;net48;net472;net461;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0;net48;net472;net461;net452</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 

--- a/.build/azure-templates/build-pack-and-publish-libraries.yml
+++ b/.build/azure-templates/build-pack-and-publish-libraries.yml
@@ -72,11 +72,12 @@ steps:
     Contents: '**/bin/${{ parameters.buildConfiguration }}/**/*.pdb'
     TargetFolder: '$(Build.ArtifactStagingDirectory)/${{ parameters.nugetArtifactName }}'
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   displayName: 'Publish Artifact: ${{ parameters.nugetArtifactName }}'
   inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/${{ parameters.nugetArtifactName }}'
-    ArtifactName: '${{ parameters.nugetArtifactName }}'
+    targetPath: '$(Build.ArtifactStagingDirectory)/${{ parameters.nugetArtifactName }}'
+    artifact: '${{ parameters.nugetArtifactName }}'
+    publishLocation: 'pipeline'
   condition: succeededOrFailed()
 
   # Loops through each framework in the TestTargetFrameworks variable and

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -26,6 +26,16 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
+    framework: 'net8.0'
+    testProjectName: '${{ parameters.testProjectName }}'
+    osName: '${{ parameters.osName }}'
+    testPlatform: '${{ parameters.testPlatform }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
     framework: 'net6.0'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -76,7 +76,7 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
-    framework: 'net461'
+    framework: 'net471'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'
     testPlatform: '${{ parameters.testPlatform }}'
@@ -84,11 +84,11 @@ steps:
     testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
     testResultsFileName: '${{ parameters.testResultsFileName }}'
 
-# Special Case: Using lowest supported version of .NET Framework (4.5.2) in xUnit to test .NET Framework 4.0.
+# Special Case: Using a supported version of .NET Framework (4.7) in xUnit to test .NET Framework 4.0.
 # This only works because we are using the SetTargetFramework attribute to set the target framework of the project reference.
 - template: publish-test-results.yml
   parameters:
-    framework: 'net452'
+    framework: 'net47'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'
     testPlatform: '${{ parameters.testPlatform }}'

--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -67,12 +67,20 @@ steps:
                         if ($reader.Name -eq 'RunInfos') {
                             $inRunInfos = $true
                         }
-                        if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text' -and $reader.ReadInnerXml().Contains('Test host process crashed')) {
-                            Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
-                            # Report all of the test projects that crashed
-                            $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
-                            Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
-                            $crashed = $true
+                        if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text') {
+                            $innerXml = $reader.ReadInnerXml()
+                            # Test for specific error messages - we may need to adjust this, as needed
+                            if ($innerXml -and ($innerXml.Contains('Test host process crashed') `
+                                -or $innerXml.Contains('Could not load file or assembly') `
+                                -or $innerXml.Contains("Could not find `'dotnet.exe`' host") `
+                                -or $innerXml.Contains('No test is available') `
+                                -or $innerXml.Contains('exited with error'))) {
+                                Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
+                                # Report all of the test projects that crashed
+                                $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
+                                Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
+                                $crashed = $true
+                            }
                         }
                     }
                     if ($reader.NodeType -eq [System.Xml.XmlNodeType]::EndElement -and $reader.Name -eq 'RunInfos') {

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -34,26 +34,35 @@ steps:
   displayName: 'Validate Template Parameters'
 
 - pwsh: |
+    $testTargetFrameworks = '${{ parameters.testTargetFrameworks }}'
     $testPlatform = '${{ parameters.vsTestPlatform }}'
+    $dotnetSdkVersion = '${{ parameters.dotNetSdkVersion }}'
     if ($IsWindows -eq $null) {
         $IsWindows = $env:OS.StartsWith('Win')
     }
+    # .NET Framework tests are SLOW when using the .NET 8 SDK (especially those for net47 targeting net40).
+    # So, we use .NET 6 SDK instead.
+    if ($testTargetFrameworks.StartsWith('net4')) {
+        $dotnetSdkVersion = '6.0.421'
+    }
+    Write-Host "Using SDK Version: $dotnetSdkVersion"
     $performMulitLevelLookup = if ($IsWindows -and $testPlatform.Equals('x86')) { 'true' } else { 'false' }
     Write-Host "##vso[task.setvariable variable=PerformMultiLevelLookup;]$performMulitLevelLookup"
+    Write-Host "##vso[task.setvariable variable=DotNetSdkVersion;]$dotnetSdkVersion"
 
 #- template: 'show-all-environment-variables.yml' # Uncomment for debugging
 
 - template: 'install-dotnet-sdk.yml'
   parameters:
-    sdkVersion: '${{ parameters.dotNetSdkVersion }}'
-    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+    sdkVersion: '$(DotNetSdkVersion)'
+    performMultiLevelLookup: '$(PerformMultiLevelLookup)'
 
     # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
     # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
     # This code only works on Windows.
 - pwsh: |
-    $sdkVersion = '${{ parameters.dotNetSdkVersion }}'
+    $sdkVersion = '$(DotNetSdkVersion)'
     $architecture = '${{ parameters.vsTestPlatform }}'
     $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
     $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
@@ -62,7 +71,7 @@ steps:
     $installPath = "${env:ProgramFiles(x86)}/dotnet"
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
-  displayName: 'Use .NET SDK ${{ parameters.dotNetSdkVersion }} (x86)'
+  displayName: 'Use .NET SDK $(DotNetSdkVersion) (x86)'
   condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -115,11 +115,11 @@ steps:
   displayName: 'Use .NET SDK 5.0.408 (x86)'
   condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download Build Artifacts: ${{ parameters.binaryArtifactName }}'
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Pipeline Artifacts: ${{ parameters.binaryArtifactName }}'
   inputs:
     artifactName: ${{ parameters.binaryArtifactName }}
-    downloadPath: '$(System.DefaultWorkingDirectory)'
+    targetPath: '$(System.DefaultWorkingDirectory)'
 
 - pwsh: |
     $testTargetFrameworksString = '${{ parameters.testTargetFrameworks }}'

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -63,7 +63,7 @@ steps:
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
   displayName: 'Use .NET SDK ${{ parameters.dotNetSdkVersion }} (x86)'
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
   displayName: 'Use .NET SDK 6.0.421'
@@ -71,7 +71,7 @@ steps:
     packageType: 'sdk'
     version: '6.0.421'
     performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net6.'))
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net6.'))
 
     # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
@@ -88,7 +88,7 @@ steps:
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
   displayName: 'Use .NET SDK 6.0.421 (x86)'
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net6.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net6.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
   displayName: 'Use .NET SDK 5.0.408'
@@ -96,7 +96,7 @@ steps:
     packageType: 'sdk'
     version: '5.0.408'
     performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'))
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net5.'))
 
     # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
@@ -113,7 +113,7 @@ steps:
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
   displayName: 'Use .NET SDK 5.0.408 (x86)'
-  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: DownloadPipelineArtifact@2
   displayName: 'Download Pipeline Artifacts: ${{ parameters.binaryArtifactName }}'

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -33,21 +33,87 @@ steps:
     EnsureNotNullOrEmpty('${{ parameters.dotNetSdkVersion }}', 'dotNetSdkVersion')
   displayName: 'Validate Template Parameters'
 
+- pwsh: |
+    $testPlatform = '${{ parameters.vsTestPlatform }}'
+    if ($IsWindows -eq $null) {
+        $IsWindows = $env:OS.StartsWith('Win')
+    }
+    $performMulitLevelLookup = if ($IsWindows -and $testPlatform.Equals('x86')) { 'true' } else { 'false' }
+    Write-Host "##vso[task.setvariable variable=PerformMultiLevelLookup;]$performMulitLevelLookup"
+
+#- template: 'show-all-environment-variables.yml' # Uncomment for debugging
+
 - template: 'install-dotnet-sdk.yml'
   parameters:
     sdkVersion: '${{ parameters.dotNetSdkVersion }}'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '${{ parameters.dotNetSdkVersion }}'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK ${{ parameters.dotNetSdkVersion }} (x86)'
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 3.1.416'
+  displayName: 'Use .NET SDK 6.0.421'
   inputs:
-    version: 3.1.416
-  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'netcoreapp3.'))
+    packageType: 'sdk'
+    version: '6.0.421'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net6.'))
+
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '6.0.421'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK 6.0.421 (x86)'
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net6.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET sdk 5.0.404'
+  displayName: 'Use .NET SDK 5.0.408'
   inputs:
-    version: 5.0.404
-  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net5.'))
+    packageType: 'sdk'
+    version: '5.0.408'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'))
+
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '5.0.408'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK 5.0.408 (x86)'
+  condition: and(succeeded(), contains('${{ parameters.framework }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: DownloadBuildArtifacts@0
   displayName: 'Download Build Artifacts: ${{ parameters.binaryArtifactName }}'

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -143,38 +143,43 @@ steps:
     
     function RunTests([string]$framework, [string]$fileRegexPattern) {
         if (!(IsSupportedFramework($framework))) { continue }
-    
+        
         $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework"} | Where-Object {$_.FullName -match "$fileRegexPattern"} | Select -ExpandProperty FullName
         foreach ($testBinary in $testBinaries) {
             $testName = [System.IO.Path]::GetFileNameWithoutExtension($testBinary)
-    
-            # Pause if we have queued too many parallel jobs
-            #$running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-            #if ($running.Count -ge $maximumParalellJobs) {
-            #    Write-Host ""
-            #    Write-Host "  Running tests in parallel on $($running.Count) projects." -ForegroundColor Cyan
-            #    Write-Host "  Next in queue is $projectName on $framework. This will take a bit, please wait..." -ForegroundColor Cyan
-            #    $running | Wait-Job -Any | Out-Null
-            #}
-              
+            
+            if ($maximumParalellJobs -gt 1) {
+                # Pause if we have queued too many parallel jobs
+                $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+                if ($running.Count -ge $maximumParalellJobs) {
+                    Write-Host ""
+                    Write-Host "  Running tests in parallel on $($running.Count) projects." -ForegroundColor Cyan
+                    Write-Host "  Next in queue is $projectName on $framework. This will take a bit, please wait..." -ForegroundColor Cyan
+                    $running | Wait-Job -Any | Out-Null
+                }
+            }
+            
             $testResultDirectory = "$testResultsArtifactDirectory/$testOSName/$framework/$testPlatform/$testName"
             if (!(Test-Path "$testResultDirectory")) {
                 New-Item "$testResultDirectory" -ItemType Directory -Force
             }
-    
+            
             Write-Host "Testing '$testBinary' on framework '$framework' and outputting test results to '$testResultDirectory/${{ parameters.testResultsFileName }}'..."
-            dotnet test "$testBinary" --framework "$framework" --blame --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{ parameters.testResultsFileName }}" --results-directory:"$testResultDirectory" --blame-hang-timeout 10minutes --blame-hang-dump-type mini -- RunConfiguration.TargetPlatform=$testPlatform
-    
-
-            $testExpression = "$testExpression -- RunConfiguration.TargetPlatform=$testPlatform"
-
-            #$scriptBlock = {
-            #    param([string]$testBinary, [string]$fwork, [string]$testPlatform, [string]$testResultDirectory)
-            #    dotnet test "$testBinary" --framework "$framework" --blame --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{ parameters.testResultsFileName }}" --results-directory:"$testResultDirectory" --blame-hang-timeout 10minutes --blame-hang-dump-type mini -- RunConfiguration.TargetPlatform=$testPlatform > "$testResultDirectory/dotnet-vstest.log" 2> "$testResultDirectory/dotnet-vstest-error.log"
-            #}
-    
-            # Execute the jobs in parallel
-            #Start-Job $scriptBlock -ArgumentList $testBinary,$fwork,$testPlatform,$testResultDirectory
+            if ($maximumParalellJobs -le 1) {
+                dotnet test "$testBinary" --framework "$framework" --blame --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{ parameters.testResultsFileName }}" --results-directory:"$testResultDirectory" --blame-hang-timeout 10minutes --blame-hang-dump-type mini -- RunConfiguration.TargetPlatform=$testPlatform
+            } else {
+            
+                $scriptBlock = {
+                    param([string]$testName, [string]$testBinary, [string]$framework, [string]$testPlatform, [string]$testResultDirectory)
+                    dotnet test "$testBinary" --framework "$framework" --blame --no-build --no-restore --logger:"console;verbosity=normal" --logger:"trx;LogFileName=${{ parameters.testResultsFileName }}" --results-directory:"$testResultDirectory" --blame-hang-timeout 10minutes --blame-hang-dump-type mini -- RunConfiguration.TargetPlatform=$testPlatform > "$testResultDirectory/dotnet-vstest.log" 2> "$testResultDirectory/dotnet-vstest-error.log"
+                }
+                
+                # Avoid dotnet test collisions by delaying for 500ms
+                Start-Sleep -Milliseconds 500
+                
+                # Execute the jobs in parallel
+                Start-Job -Name "$testName,$framework,$testPlatform" -ScriptBlock $scriptBlock -ArgumentList $testName,$testBinary,$framework,$testPlatform,$testResultDirectory
+            }
         }
     }
     
@@ -182,15 +187,23 @@ steps:
         RunTests -Framework "$framework" -FileRegexPattern "$testBinaryFilesPattern"
     }
     
-    # Wait for it all to complete
-    #do {
-    #    $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
-    #    if ($running.Count -gt 0) {
-    #        Write-Host ""
-    #        Write-Host "  Almost finished, only $($running.Count) projects left..." -ForegroundColor Cyan
-    #        $running | Wait-Job -Any
-    #    }
-    #} until ($running.Count -eq 0)
+    if ($maximumParalellJobs -gt 1) {
+        # Wait for it all to complete
+        do {
+            $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
+            if ($running.Count -gt 0) {
+                Write-Host ""
+                Write-Host "  Almost finished, only $($running.Count) projects left..." -ForegroundColor Cyan
+                [int]$number = 0
+                foreach ($runningJob in $running) {
+                    $number++
+                    $jobName = $runningJob | Select -ExpandProperty Name
+                    Write-Host "$number. $jobName"
+                }
+                $running | Wait-Job -Any
+            }
+        } until ($running.Count -eq 0)
+    }
     
     $global:LASTEXITCODE = 0 # Force the script to continue on error
   displayName: 'dotnet test ${{ parameters.testTargetFrameworks }}'
@@ -210,7 +223,7 @@ steps:
 # Publish Test Results task or the (deprecated) TfsPublisher
 # our only other option is to make a task for every supported
 # platform and project and update it whenever a new platform 
-# is targeted or test project is created in ICU4N.
+# is targeted or test project is created in J2N.
 
 - template: 'publish-test-results-for-test-projects.yml'
   parameters:

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -3,14 +3,14 @@
     <ICU4NPackageReferenceVersion>60.1.0-alpha.354</ICU4NPackageReferenceVersion>
     <MicrosoftCSharpPackageReferenceVersion>4.4.0</MicrosoftCSharpPackageReferenceVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>
-    <MicrosoftNETTestSdkPackageReferenceVersion>16.1.1</MicrosoftNETTestSdkPackageReferenceVersion>
+    <MicrosoftNETTestSdkPackageReferenceVersion>17.11.0</MicrosoftNETTestSdkPackageReferenceVersion>
     <MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>1.1.1</MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
     <NetFxSystemMemoryPackageReferenceVersion>4.0.0</NetFxSystemMemoryPackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.10.1</NUnitPackageReferenceVersion>
-    <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
+    <NUnit3TestAdapterPackageReferenceVersion>4.6.0</NUnit3TestAdapterPackageReferenceVersion>
     <RandomizedTestingGeneratorsPackageReferenceVersion>2.7.8</RandomizedTestingGeneratorsPackageReferenceVersion>
     <SystemBuffersPackageReferenceVersion>4.5.1</SystemBuffersPackageReferenceVersion>
     <SystemMemoryPackageReferenceVersion>4.5.5</SystemMemoryPackageReferenceVersion>

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -17,7 +17,7 @@ properties {
     [string]$configuration         = "Release"
     [string]$platform              = "Any CPU"
     [bool]$backupFiles             = $true
-    [string]$minimumSdkVersion     = "6.0.100"
+    [string]$minimumSdkVersion     = "8.0.100"
 
     #test parameters
     [string]$testPlatforms         = "x64"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -25,7 +25,7 @@
 
   <!-- Features in .NET 8.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
-    
+
     <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x9FFF</DefineConstants>
     
   </PropertyGroup>
@@ -36,6 +36,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_ARRAY_CLEAR_ARRAY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTSINGLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYSET</DefineConstants>
     <!-- J2N NOTE: This is technically supported in .NET 5.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_GETCHUNKS</DefineConstants>
 
@@ -72,6 +73,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_NUMBER_TRYFORMAT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RUNTIMEHELPERS_ISREFERENCETYPEORCONTAINSREFERENCES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STACK_TRYPOP</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CONTAINS_CHAR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CREATE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_READONLYSPAN</DefineConstants>
@@ -97,6 +99,17 @@
     <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
         To add it to the build, just add /p:IncludeICloneable to the command line. -->
     <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x (No .NET 8+ support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+
+    <!-- JCG.ReadOnlyList subclasses SCG.ReadOnlyCollection. SCG.ReadOnlyCollection has differing exception behaviors when calling .Current
+         depending on .NET version. Unfortunately, SCG.ReadOnlyCollection.GetEnumerator() is not virtual and removing this superclass would
+         constitute a breaking API change, so there is no way to normalize this behavior until a major J2N version bump. Ideally, we would
+         remove this superclass and provide our own implementation that doesn't drift across .NET versions. -->
+    <DefineConstants>$(DefineConstants);FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW</DefineConstants>
+    
   </PropertyGroup>
 
   <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, and .NET Core 3.x (No .NET 5+ support) -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,8 +8,8 @@
     <NoWarn Label="Use range operator">$(NoWarn);IDE0057</NoWarn>
   </PropertyGroup>
 
-  <!-- Features in .NET Standard, .NET Core, .NET 5.x, and .NET 6.x only (no .NET Framework support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+  <!-- Features in .NET Standard, .NET Core, .NET 5.x, .NET 6.x, and .NET 8.x only (no .NET Framework support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
@@ -23,8 +23,8 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Features in .NET 6.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) ">
+  <!-- Features in .NET 6.x and .NET 8.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARRAY_CLEAR_ARRAY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64</DefineConstants>
@@ -34,8 +34,8 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET 5.x and .NET 6.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+  <!-- Features in .NET 5.x, .NET 6.x, and .NET 8.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_PREDEFINEDONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HASHSET_MODIFY_CONTINUEENUMERATION</DefineConstants>
@@ -44,16 +44,16 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Core 3.x, .NET 5.x, and .NET 6.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_COLLECTIONSMARSHAL_ASSPAN_LIST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMERICBITOPERATIONS</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.1, .NET Core 3.x, .NET 5.x, and .NET 6.x only -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+  <!-- Features in .NET Standard 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x only -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_CTOR_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
@@ -79,7 +79,15 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x -->
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+
+    <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
+        To add it to the build, just add /p:IncludeICloneable to the command line. -->
+    <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x (No .NET 8+ support) -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
@@ -87,12 +95,9 @@
     <!-- serializable exeptions were added back in .NET Core 2.0.4: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#net-core -->
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
 
-    <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
-        To add it to the build, just add /p:IncludeICloneable to the command line. -->
-    <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, and .NET Core 3.x (No .NET 5 or .NET 6 support) -->
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, and .NET Core 3.x (No .NET 5+ support) -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_THREADABORT</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -89,19 +89,14 @@
   <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
-    <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
-        To add it to the build, just add /p:IncludeICloneable to the command line. -->
-    <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
-  </PropertyGroup>
-
-  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x (No .NET 8+ support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
-
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
-
+    
     <!-- serializable exeptions were added back in .NET Core 2.0.4: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#net-core -->
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
 
+    <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
+        To add it to the build, just add /p:IncludeICloneable to the command line. -->
+    <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
   </PropertyGroup>
 
   <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, and .NET Core 3.x (No .NET 5+ support) -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -130,8 +130,8 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+ only (excluding .NET Framework 4.6.1, the target framework we use for testing .NET Standard 2.0)  -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) And '$(TargetFramework)' != 'net461'">
+  <!-- Features in .NET Framework 4.5+ only (excluding .NET Framework 4.7.1, the target framework we use for testing .NET Standard 2.0)  -->
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net4')) And '$(TargetFramework)' != 'net471'">
 
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_RANDOM</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_STRINGS</DefineConstants>
@@ -146,8 +146,8 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
 
-  <!-- Features not in .NET Framework 4.0 and .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452'">
+  <!-- Features not in .NET Framework 4.0 and .NET Framework 4.7 (the target framework we use for testing .NET Framework 4.0) -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net47'">
 
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTIONDISPATCHINFO</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -146,6 +146,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_METHODIMPLOPTIONS_AGRESSIVEINLINING</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_THREAD_ISENTERED</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEINFO</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_VOLATILE</DefineConstants>
 
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,6 +23,13 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
+  <!-- Features in .NET 8.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
+    
+    <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x9FFF</DefineConstants>
+    
+  </PropertyGroup>
+
   <!-- Features in .NET 6.x and .NET 8.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
@@ -39,8 +46,8 @@
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_PREDEFINEDONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HASHSET_MODIFY_CONTINUEENUMERATION</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_ICU</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYMARSHAL_GETARRAYDATAREFERENCE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x30000</DefineConstants>
 
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,9 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net6.0;net5.0;net48;net472;net461;net452'
+  value: 'net8.0;net6.0;net5.0;net48;net472;net461;net452'
 - name: DotNetSDKVersion
-  value: '6.0.101'
+  value: '8.0.401'
 - name: BinaryArtifactName
   value: 'testbinaries'
 - name: NuGetArtifactName
@@ -111,6 +111,56 @@ stages:
 - stage: Test_Stage
   displayName: 'Test Stage:'
   jobs:
+
+  - job: Test_net8_0_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net8.0,x64 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFrameworks: 'net8.0'
+        vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net8_0_x86 # Only run if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net8.0,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFrameworks: 'net8.0'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
 
   - job: Test_net6_0_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net8.0;net6.0;net5.0;net48;net472;net461;net452'
+  value: 'net8.0;net6.0;net5.0;net48;net472;net471;net47'
 - name: DotNetSDKVersion
   value: '8.0.401'
 - name: BinaryArtifactName
@@ -323,61 +323,61 @@ stages:
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net461_x64
+  - job: Test_net471_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    displayName: 'Test net461,x64 on Windows'
+    displayName: 'Test net4671,x64 on Windows'
     pool:
       vmImage: 'windows-latest'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net461'
+        testTargetFrameworks: 'net471'
         vsTestPlatform: 'x64'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net461_x86 # Only run if explicitly enabled with RunX86Tests
+  - job: Test_net471_x86 # Only run if explicitly enabled with RunX86Tests
     condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
-    displayName: 'Test net461,x86 on Windows'
+    displayName: 'Test net471,x86 on Windows'
     pool:
       vmImage: 'windows-latest'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net461'
+        testTargetFrameworks: 'net471'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net452_x64
+  - job: Test_net47_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    displayName: 'Test net452,x64 on Windows'
+    displayName: 'Test net47,x64 on Windows'
     pool:
       vmImage: 'windows-latest'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net452'
+        testTargetFrameworks: 'net47'
         vsTestPlatform: 'x64'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net452_x86 # Only run if explicitly enabled with RunX86Tests
+  - job: Test_net47_x86 # Only run if explicitly enabled with RunX86Tests
     condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
-    displayName: 'Test net452,x86 on Windows'
+    displayName: 'Test net47,x86 on Windows'
     pool:
       vmImage: 'windows-latest'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net452'
+        testTargetFrameworks: 'net47'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -325,7 +325,7 @@ stages:
 
   - job: Test_net471_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    displayName: 'Test net4671,x64 on Windows'
+    displayName: 'Test net471,x64 on Windows'
     pool:
       vmImage: 'windows-latest'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,11 +101,12 @@ stages:
         nugetArtifactName: '$(NuGetArtifactName)'
         binaryArtifactName: '$(BinaryArtifactName)'
 
-    - task: PublishBuildArtifacts@1
+    - task: PublishPipelineArtifact@1
       displayName: 'Publish Artifact: $(BinaryArtifactName)'
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)/$(BinaryArtifactName)'
-        ArtifactName: '$(BinaryArtifactName)'
+        targetPath: '$(Build.ArtifactStagingDirectory)/$(BinaryArtifactName)'
+        artifact: '$(BinaryArtifactName)'
+        publishLocation: 'pipeline'
       condition: succeededOrFailed()
 
 - stage: Test_Stage

--- a/src/J2N.TestFramework/J2N.TestFramework.csproj
+++ b/src/J2N.TestFramework/J2N.TestFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
     <RootNamespace>J2N</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/src/J2N.TestFramework/J2N.TestFramework.csproj
+++ b/src/J2N.TestFramework/J2N.TestFramework.csproj
@@ -18,6 +18,8 @@
     <NoWarn Label="Naming rule violation: Must begin with upper case characters">$(NoWarn);IDE1006</NoWarn>
     
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
+    <NoWarn Label="FormatterConverter serialization is obsolete">$(NoWarn);SYSLIB0050</NoWarn>
+    <NoWarn Label=".ctor(SerializationInfo, StreamingContext) is obsolete">$(NoWarn);SYSLIB0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/J2N/Collections/Concurrent/LurchTable.cs
+++ b/src/J2N/Collections/Concurrent/LurchTable.cs
@@ -18,6 +18,7 @@ using J2N.Collections.ObjectModel;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -2927,15 +2928,17 @@ namespace J2N.Collections.Concurrent
     /// Exception class: LurchTableCorruptionException
     /// The LurchTable internal datastructure appears to be corrupted.
     /// </summary>
-#if FEATURE_SERIALIZABLE
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
     [Serializable]
 #endif
     public class LurchTableCorruptionException : Exception
     {
-#if FEATURE_SERIALIZABLE
+#if FEATURE_SERIALIZABLE_EXCEPTIONS
         /// <summary>
         /// Serialization constructor
         /// </summary>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LurchTableCorruptionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
         }

--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -8,6 +8,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -454,6 +455,8 @@ namespace J2N.Collections.Generic
         /// For more information, see
         /// <a href="https://docs.microsoft.com/en-us/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</a>.
         /// </remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected Dictionary(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been deserialized
@@ -659,6 +662,8 @@ namespace J2N.Collections.Generic
         /// <exception cref="ArgumentNullException"><paramref name="info"/> is <c>null</c>.</exception>
         /// <remarks>This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.</remarks>
         [System.Security.SecurityCritical]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // Customized serialization for Dictionary.

--- a/src/J2N/Collections/Generic/EnumerableHelpers.cs
+++ b/src/J2N/Collections/Generic/EnumerableHelpers.cs
@@ -16,6 +16,10 @@ namespace J2N.Collections.Generic
     [SuppressMessage("Style", "IDE0063:Use simple 'using' statement", Justification = "Using Microsoft's code styles")]
     internal static partial class EnumerableHelpers
     {
+        /// <summary>Gets an enumerator singleton for an empty collection.</summary>
+        internal static IEnumerator<T> GetEmptyEnumerator<T>() =>
+            ((IEnumerable<T>)Arrays.Empty<T>()).GetEnumerator();
+
         /// <summary>Converts an enumerable to an array using the same logic as <see cref="List{T}"/>.</summary>
         /// <param name="source">The enumerable to convert.</param>
         /// <param name="length">The number of items stored in the resulting array, 0-indexed.</param>

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -7,6 +7,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -285,6 +286,8 @@ namespace J2N.Collections.Generic
         /// the information required to serialize the <see cref="HashSet{T}"/> object.</param>
         /// <param name="context">A <see cref="System.Runtime.Serialization.StreamingContext"/> structure that contains
         /// the source and destination of the serialized stream associated with the <see cref="HashSet{T}"/> object.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected HashSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // We can't do anything with the keys and values until the entire graph has been
@@ -699,6 +702,8 @@ namespace J2N.Collections.Generic
         /// Associated enumeration: <see cref="System.Security.Permissions.SecurityPermissionFlag.SerializationFormatter"/>
         /// </permission>
         [System.Security.SecurityCritical]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             if (info == null)

--- a/src/J2N/Collections/Generic/HashSet.cs
+++ b/src/J2N/Collections/Generic/HashSet.cs
@@ -56,6 +56,9 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyCollection<T>,
 #endif
+#if FEATURE_READONLYSET
+        IReadOnlySet<T>,
+#endif
         IStructuralEquatable, IStructuralFormattable
 #if FEATURE_SERIALIZABLE
         , System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable

--- a/src/J2N/Collections/Generic/LinkedDictionary.cs
+++ b/src/J2N/Collections/Generic/LinkedDictionary.cs
@@ -30,6 +30,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -189,6 +190,8 @@ namespace J2N.Collections.Generic
         /// For more information, see
         /// <a href="https://docs.microsoft.com/en-us/dotnet/standard/serialization/xml-and-soap-serialization">XML and SOAP Serialization</a>.
         /// </remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LinkedDictionary(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             siInfo = info;
@@ -340,6 +343,8 @@ namespace J2N.Collections.Generic
         /// <exception cref="ArgumentNullException"><paramref name="info"/> is <c>null</c>.</exception>
         /// <remarks>This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.</remarks>
         [System.Security.SecurityCritical]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             // Customized serialization for LinkedDictionary

--- a/src/J2N/Collections/Generic/LinkedHashSet.cs
+++ b/src/J2N/Collections/Generic/LinkedHashSet.cs
@@ -21,6 +21,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using SCG = System.Collections.Generic;
@@ -174,6 +175,8 @@ namespace J2N.Collections.Generic
         /// the information required to serialize the <see cref="HashSet{T}"/> object.</param>
         /// <param name="context">A <see cref="System.Runtime.Serialization.StreamingContext"/> structure that contains
         /// the source and destination of the serialized stream associated with the <see cref="HashSet{T}"/> object.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected LinkedHashSet(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             hashSet = new HashSetWrapper(info, context);
@@ -206,6 +209,7 @@ namespace J2N.Collections.Generic
         [Serializable]
         private class HashSetWrapper : HashSet<T>
         {
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
             public HashSetWrapper(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
         }
 #endif
@@ -314,6 +318,8 @@ namespace J2N.Collections.Generic
         /// Associated enumeration: <see cref="System.Security.Permissions.SecurityPermissionFlag.SerializationFormatter"/>
         /// </permission>
         [System.Security.SecurityCritical]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             => hashSet.GetObjectData(info, context);
 

--- a/src/J2N/Collections/Generic/LinkedHashSet.cs
+++ b/src/J2N/Collections/Generic/LinkedHashSet.cs
@@ -56,6 +56,9 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyCollection<T>,
 #endif
+#if FEATURE_READONLYSET
+        IReadOnlySet<T>,
+#endif
         IStructuralEquatable, IStructuralFormattable
 #if FEATURE_SERIALIZABLE
         , System.Runtime.Serialization.IDeserializationCallback, System.Runtime.Serialization.ISerializable

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -7,6 +7,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -162,6 +163,8 @@ namespace J2N.Collections.Generic
         /// <remarks>
         /// This constructor is called during deserialization to reconstitute an object that is transmitted over a stream.
         /// </remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected List(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             siInfo = info;
@@ -2378,11 +2381,13 @@ namespace J2N.Collections.Generic
             return true;
         }
 
-#endregion
+        #endregion
 
         #region Custom Serialization
 
 #if FEATURE_SERIALIZABLE
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) => GetObjectData(info, context);
 
         /// <summary>
@@ -2395,6 +2400,8 @@ namespace J2N.Collections.Generic
         /// of the serialized stream associated with the <see cref="List{T}"/> object.</param>
         /// <exception cref="ArgumentNullException"><paramref name="info"/> is <c>null</c>.</exception>
         /// <remarks>Calling this method is an <c>O(n)</c> operation, where <c>n</c> is <see cref="Count"/>.</remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             if (info == null)

--- a/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
+++ b/src/J2N/Collections/Generic/NonRandomizedStringEqualityComparer.cs
@@ -44,7 +44,7 @@ namespace J2N.Collections.Generic
         }
 
         // This is used by the serialization engine.
-        //[Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected NonRandomizedStringEqualityComparer(SerializationInfo information, StreamingContext context)
             : this(EqualityComparer<string?>.Default)

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -7,6 +7,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE
@@ -1946,6 +1947,7 @@ namespace J2N.Collections.Generic
         public TreeSet(IComparer<T> comparer) : base(comparer) { }
 
 #if FEATURE_SERIALIZABLE
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         private TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
 #endif
 

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -153,11 +153,22 @@ namespace J2N.Collections.Generic
                 throw new ArgumentNullException(nameof(dictionary));
             }
 
-            _set = new TreeSet<KeyValuePair<TKey, TValue>>(new KeyValuePairComparer(comparer));
+            var keyValuePairComparer = new KeyValuePairComparer(comparer);
 
-            foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+            if (dictionary is SortedDictionary<TKey, TValue> sortedDictionary &&
+            sortedDictionary._set.Comparer is KeyValuePairComparer kv &&
+                kv.keyComparer.Equals(keyValuePairComparer.keyComparer))
             {
-                _set.Add(pair);
+                _set = new TreeSet<KeyValuePair<TKey, TValue>>(sortedDictionary._set, keyValuePairComparer);
+            }
+            else
+            {
+                _set = new TreeSet<KeyValuePair<TKey, TValue>>(keyValuePairComparer);
+
+                foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+                {
+                    _set.Add(pair);
+                }
             }
         }
 
@@ -273,7 +284,7 @@ namespace J2N.Collections.Generic
         /// Getting the value of this property is an O(log <c>n</c>) operation; setting the property is also
         /// an O(log <c>n</c>) operation.
         /// </remarks>
-        public TValue this[TKey key]
+        public TValue this[[AllowNull]TKey key]
         {
             get
             {
@@ -285,7 +296,7 @@ namespace J2N.Collections.Generic
                 TreeSet<KeyValuePair<TKey, TValue>>.Node? node = _set.FindNode(new KeyValuePair<TKey, TValue>(key, default!));
                 if (node == null)
                 {
-                    throw new KeyNotFoundException(J2N.SR.Format(SR.Arg_KeyNotFoundWithKey, key));
+                    throw new KeyNotFoundException(J2N.SR.Format(SR.Arg_KeyNotFoundWithKey, key?.ToString() ?? "null"));
                 }
 
                 return node.Item.Value;
@@ -349,14 +360,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public ICollection<TKey> Keys
-        {
-            get
-            {
-                if (_keys == null) _keys = new KeyCollection(this);
-                return _keys;
-            }
-        }
+        public KeyCollection Keys => _keys ??= new KeyCollection(this);
 
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
@@ -380,14 +384,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public ICollection<TValue> Values
-        {
-            get
-            {
-                if (_values == null) _values = new ValueCollection(this);
-                return _values;
-            }
-        }
+        public ValueCollection Values => _values ??= new ValueCollection(this);
 
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
@@ -415,13 +412,13 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-        public void Add(TKey key, TValue value)
+        public void Add([AllowNull] TKey key, [AllowNull]TValue value)
         {
             //if (key == null) // J2N: Making key nullable
             //{
             //    throw new ArgumentNullException(nameof(key));
             //}
-            _set.Add(new KeyValuePair<TKey, TValue>(key, value));
+            _set.Add(new KeyValuePair<TKey, TValue>(key!, value!));
         }
 
         /// <summary>
@@ -447,14 +444,14 @@ namespace J2N.Collections.Generic
         /// <returns><c>true</c> if the <see cref="SortedDictionary{TKey, TValue}"/> contains an element
         /// with the specified key; otherwise, <c>false</c>.</returns>
         /// <remarks>This method is an O(log <c>n</c>) operation.</remarks>
-        public bool ContainsKey(TKey key)
+        public bool ContainsKey([AllowNull] TKey key)
         {
             //if (key == null) // J2N: Making key nullable
             //{
             //    throw new ArgumentNullException(nameof(key));
             //}
 
-            return _set.Contains(new KeyValuePair<TKey, TValue>(key, default!));
+            return _set.Contains(new KeyValuePair<TKey, TValue>(key!, default!));
         }
 
         /// <summary>
@@ -475,7 +472,7 @@ namespace J2N.Collections.Generic
         {
             // NOTE: We do this check here to override the .NET default equality comparer
             // with J2N's version
-            return ContainsValue(value, EqualityComparer<TValue>.Default);
+            return ContainsValue(value, null);
         }
 
         /// <summary>
@@ -493,14 +490,14 @@ namespace J2N.Collections.Generic
         /// is proportional to <see cref="Count"/>. That is, this method is an O(<c>n</c>) operation,
         /// where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
-        public bool ContainsValue(TValue value, IEqualityComparer<TValue> valueComparer) // Overload added so end user can override J2N's equality comparer
+        public bool ContainsValue([AllowNull] TValue value, IEqualityComparer<TValue>? valueComparer) // Overload added so end user can override J2N's equality comparer
         {
             bool found = false;
-            if (value == null)
+            if (value is null)
             {
                 _set.InOrderTreeWalk(delegate (TreeSet<KeyValuePair<TKey, TValue>>.Node node)
                 {
-                    if (node.Item.Value == null)
+                    if (node.Item.Value is null)
                     {
                         found = true;
                         return false;  // stop the walk
@@ -510,6 +507,7 @@ namespace J2N.Collections.Generic
             }
             else
             {
+				valueComparer ??= EqualityComparer<TValue>.Default;
                 _set.InOrderTreeWalk(delegate (TreeSet<KeyValuePair<TKey, TValue>>.Node node)
                 {
                     if (valueComparer.Equals(node.Item.Value, value))
@@ -588,15 +586,11 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-        public Enumerator GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+        public Enumerator GetEnumerator() => new Enumerator(this, Enumerator.KeyValuePair);
 
-        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() =>
+            Count == 0 ? EnumerableHelpers.GetEmptyEnumerator<KeyValuePair<TKey, TValue>>() :
+            GetEnumerator();
 
         /// <summary>
         /// Removes the element with the specified key from the <see cref="SortedDictionary{TKey, TValue}"/>.
@@ -610,14 +604,14 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(log <c>n</c>) operation.
         /// </remarks>
-        public bool Remove(TKey key)
+        public bool Remove([AllowNull] TKey key)
         {
             //if (key == null) // J2N: Making key nullable
             //{
             //    throw new ArgumentNullException(nameof(key));
             //}
 
-            return _set.Remove(new KeyValuePair<TKey, TValue>(key, default!));
+            return _set.Remove(new KeyValuePair<TKey, TValue>(key!, default!));
         }
 
         /// <summary>
@@ -634,11 +628,11 @@ namespace J2N.Collections.Generic
         /// </remarks>
         // J2N: This is an extension method on IDictionary<TKey, TValue>, but only for .NET Standard 2.1+.
         // It is redefined here to ensure we have it in prior platforms.
-        public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool Remove([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
         {
             if (TryGetValue(key, out value))
             {
-                _set.Remove(new KeyValuePair<TKey, TValue>(key, default!));
+                _set.Remove(new KeyValuePair<TKey, TValue>(key!, default!));
                 return true;
             }
 
@@ -658,7 +652,7 @@ namespace J2N.Collections.Generic
         /// <see cref="TryAdd(TKey, TValue)"/> does nothing and returns <c>false</c>.</remarks>
         // J2N: This is an extension method on IDictionary<TKey, TValue>, but only for .NET Standard 2.1+.
         // It is redefined here to ensure we have it in prior platforms.
-        public bool TryAdd(TKey key, TValue value)
+        public bool TryAdd([AllowNull] TKey key, TValue value)
         {
             if (!ContainsKey(key))
             {
@@ -695,7 +689,7 @@ namespace J2N.Collections.Generic
 
 
 #pragma warning disable CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
-        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
         {
             //if (key == null) // J2N: Making key nullable
@@ -730,21 +724,21 @@ namespace J2N.Collections.Generic
 
         ICollection IDictionary.Keys
         {
-            get { return (ICollection)Keys; }
+            get { return Keys; }
         }
 
         ICollection IDictionary.Values
         {
-            get { return (ICollection)Values; }
+            get { return Values; }
         }
 
-        object? IDictionary.this[object key]
+        object? IDictionary.this[object? key]
         {
             get
             {
                 if (IsCompatibleKey(key))
                 {
-                    if (TryGetValue((TKey)key, out TValue? value))
+                    if (TryGetValue((TKey)key!, out TValue? value))
                     {
                         return value;
                     }
@@ -770,7 +764,7 @@ namespace J2N.Collections.Generic
                     TKey tempKey = (TKey)key!;
                     try
                     {
-                        this[tempKey!] = (TValue)value!;
+                        this[tempKey] = (TValue)value!;
                     }
                     catch (InvalidCastException)
                     {
@@ -803,7 +797,7 @@ namespace J2N.Collections.Generic
 
                 try
                 {
-                    Add(tempKey!, (TValue)value!);
+                    Add(tempKey, (TValue)value!);
                 }
                 catch (InvalidCastException)
                 {
@@ -837,10 +831,7 @@ namespace J2N.Collections.Generic
             return (key is TKey);
         }
 
-        IDictionaryEnumerator IDictionary.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.DictEntry);
-        }
+        IDictionaryEnumerator IDictionary.GetEnumerator() => new Enumerator(this, Enumerator.DictEntry);
 
         void IDictionary.Remove(object? key)
         {
@@ -854,10 +845,7 @@ namespace J2N.Collections.Generic
 
         object ICollection.SyncRoot => ((ICollection)_set).SyncRoot;
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<KeyValuePair<TKey, TValue>>)this).GetEnumerator();
 
         #endregion
 
@@ -1042,8 +1030,8 @@ namespace J2N.Collections.Generic
         [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Collection design requires this to be public")]
         public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>, IDictionaryEnumerator
         {
-            private readonly IEnumerator<KeyValuePair<TKey, TValue>> _treeEnum;
-            private readonly int _getEnumeratorRetType;  // What should Enumerator.Current return?
+            private /*readonly*/ TreeSet<KeyValuePair<TKey, TValue>>.Enumerator _treeEnum;
+            private /*readonly*/ int _getEnumeratorRetType;  // What should Enumerator.Current return?
 
             internal const int KeyValuePair = 1;
             internal const int DictEntry = 2;
@@ -1123,7 +1111,7 @@ namespace J2N.Collections.Generic
             {
                 get
                 {
-                    return ((SortedSet<KeyValuePair<TKey, TValue>>.Enumerator)_treeEnum).NotStartedOrEnded;
+                    return _treeEnum.NotStartedOrEnded;
                 }
             }
 
@@ -1138,7 +1126,7 @@ namespace J2N.Collections.Generic
                 _treeEnum.Reset();
             }
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -1225,7 +1213,7 @@ namespace J2N.Collections.Generic
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
         [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Collection design requires this to be public")]
-        internal sealed class KeyCollection : ICollection<TKey>, ICollection
+        public sealed class KeyCollection : ICollection<TKey>, ICollection
 #if FEATURE_IREADONLYCOLLECTIONS
             , IReadOnlyCollection<TKey>
 #endif
@@ -1290,20 +1278,13 @@ namespace J2N.Collections.Generic
             /// <para/>
             /// Default implementations of collections in the <see cref="J2N.Collections.Generic"/> namespace are not synchronized.
             /// </remarks>
-            public IEnumerator<TKey> GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            public Enumerator GetEnumerator() => new Enumerator(_dictionary);
 
-            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() =>
+                Count == 0 ? EnumerableHelpers.GetEmptyEnumerator<TKey>() :
+                GetEnumerator();
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<TKey>)this).GetEnumerator();
 
             /// <summary>
             /// Copies the <see cref="KeyCollection"/> elements to an existing one-dimensional array,
@@ -1349,17 +1330,12 @@ namespace J2N.Collections.Generic
                 if (array.Length - index < _dictionary.Count)
                     throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
 
-                TKey[]? keys = array as TKey[];
-                if (keys != null)
+                if (array is TKey[] keys)
                 {
                     CopyTo(keys, index);
                 }
                 else
                 {
-                    if (!(array is object?[]))
-                    {
-                        throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
-                    }
                     try
                     {
                         object?[] objects = (object?[])array;
@@ -1396,7 +1372,12 @@ namespace J2N.Collections.Generic
                 throw new NotSupportedException(SR.NotSupported_KeyCollectionSet);
             }
 
-            bool ICollection<TKey>.Contains(TKey item)
+            /// <summary>
+            /// Determines whether the <see cref="ICollection{T}"/> contains a specific value.
+            /// </summary>
+            /// <param name="item">The object to locate in the <see cref="ICollection{T}"/>.</param>
+            /// <returns><c>true</c> if item is found in the <see cref="ICollection{T}"/>; otherwise, <c>false</c>.</returns>
+            public bool Contains([AllowNull] TKey item)
             {
                 return _dictionary.ContainsKey(item);
             }
@@ -1449,7 +1430,7 @@ namespace J2N.Collections.Generic
             /// </remarks>
             [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
             [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Collection design requires this to be public")]
-            internal struct Enumerator : IEnumerator<TKey>, IEnumerator
+            public struct Enumerator : IEnumerator<TKey>, IEnumerator
             {
                 [SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "Following Microsoft's code style")]
                 private SortedDictionary<TKey, TValue>.Enumerator _dictEnum;
@@ -1562,7 +1543,7 @@ namespace J2N.Collections.Generic
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
         [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Collection design requires this to be public")]
-        internal sealed class ValueCollection : ICollection<TValue>, ICollection
+        public sealed class ValueCollection : ICollection<TValue>, ICollection
 #if FEATURE_IREADONLYCOLLECTIONS
             , IReadOnlyCollection<TValue>
 #endif
@@ -1627,20 +1608,13 @@ namespace J2N.Collections.Generic
             /// <para/>
             /// This method is an O(1) operation.
             /// </remarks>
-            public IEnumerator<TValue> GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            public Enumerator GetEnumerator() => new Enumerator(_dictionary);
 
-            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() =>
+                Count == 0 ? EnumerableHelpers.GetEmptyEnumerator<TValue>() :
+                GetEnumerator();
 
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return new Enumerator(_dictionary);
-            }
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<TValue>)this).GetEnumerator();
 
             /// <summary>
             /// Copies the <see cref="ValueCollection"/> elements to an existing one-dimensional
@@ -1699,17 +1673,12 @@ namespace J2N.Collections.Generic
                     throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
                 }
 
-                TValue[]? values = array as TValue[];
-                if (values != null)
+                if (array is TValue[] values)
                 {
                     CopyTo(values, index);
                 }
                 else
                 {
-                    if (!(array is object?[]))
-                    {
-                        throw new ArgumentException(SR.Argument_InvalidArrayType, nameof(array));
-                    }
                     try
                     {
                         object?[] objects = (object?[])array;
@@ -1803,9 +1772,9 @@ namespace J2N.Collections.Generic
             /// </remarks>
             [SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes", Justification = "not an expected scenario")]
             [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Collection design requires this to be public")]
-            internal struct Enumerator : IEnumerator<TValue>, IEnumerator
+            public struct Enumerator : IEnumerator<TValue>, IEnumerator
             {
-                private readonly SortedDictionary<TKey, TValue>.Enumerator _dictEnum;
+                private SortedDictionary<TKey, TValue>.Enumerator _dictEnum;
 
                 internal Enumerator(SortedDictionary<TKey, TValue> dictionary)
                 {
@@ -1900,7 +1869,7 @@ namespace J2N.Collections.Generic
 #if FEATURE_SERIALIZABLE
         [Serializable]
 #endif
-        internal sealed class KeyValuePairComparer : SCG.Comparer<KeyValuePair<TKey, TValue>>
+        internal sealed class KeyValuePairComparer : SCG.Comparer<KeyValuePair<TKey, TValue>> // J2N TODO: API - This is public in .NET, but I cannot find any docs for it.
         {
             internal IComparer<TKey> keyComparer; // Do not rename (binary serialization)
 
@@ -1920,6 +1889,21 @@ namespace J2N.Collections.Generic
             {
                 return keyComparer.Compare(x.Key, y.Key);
             }
+
+            public override bool Equals(object? obj)
+            {
+                if (obj is KeyValuePairComparer other)
+                {
+                    // Commonly, both comparers will be the default comparer (and reference-equal). Avoid a virtual method call to Equals() in that case.
+                    return this.keyComparer == other.keyComparer || this.keyComparer.Equals(other.keyComparer);
+                }
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return this.keyComparer.GetHashCode();
+            }
         }
 
         #endregion
@@ -1938,17 +1922,19 @@ namespace J2N.Collections.Generic
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
-    internal sealed class TreeSet<T> : SortedSet<T>
+    internal sealed class TreeSet<T> : SortedSet<T> // J2N TODO: API - This is public in .NET, but I cannot find any docs for it.
     {
         public TreeSet()
             : base()
-        { }
+        { /* Intentionally blank */ }
 
-        public TreeSet(IComparer<T> comparer) : base(comparer) { }
+        public TreeSet(IComparer<T> comparer) : base(comparer) { /* Intentionally blank */ }
+
+        internal TreeSet(TreeSet<T> set, IComparer<T>? comparer) : base(set, comparer) { /* Intentionally blank */ }
 
 #if FEATURE_SERIALIZABLE
         [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
-        private TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { }
+        private TreeSet(SerializationInfo siInfo, StreamingContext context) : base(siInfo, context) { /* Intentionally blank */ }
 #endif
 
         internal override bool AddIfNotPresent(T item)

--- a/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE
@@ -76,6 +77,7 @@ namespace J2N.Collections.Generic
 #if FEATURE_SERIALIZABLE
             [SuppressMessage("Microsoft.Usage", "CA2236:CallBaseClassMethodsOnISerializableTypes", Justification = "special case TreeSubSet serialization")]
             [SuppressMessage("CodeQuality", "IDE0079:Remove unnecessary suppression", Justification = "CA2236 doesn't fire on all target frameworks")]
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
             private TreeSubSet(SerializationInfo info, StreamingContext context)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -446,8 +448,12 @@ namespace J2N.Collections.Generic
 
 #if FEATURE_SERIALIZABLE
 
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => GetObjectData(info, context);
 
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             protected override void GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 if (info == null)

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.ObjectModel;
+using J2N.Numerics;
 using J2N.Text;
 using System;
 using System.Collections;
@@ -92,6 +93,9 @@ namespace J2N.Collections.Generic
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyCollection<T>,
 #endif
+#if FEATURE_READONLYSET
+        IReadOnlySet<T>,
+#endif
         IStructuralEquatable, IStructuralFormattable
 #if FEATURE_SERIALIZABLE
         , ISerializable, IDeserializationCallback
@@ -167,7 +171,7 @@ namespace J2N.Collections.Generic
         /// This constructor is an <c>O(n log n)</c> operation, where <c>n</c> is the number of elements
         /// in the <paramref name="collection"/> parameter.
         /// </remarks>
-        public SortedSet(IEnumerable<T> collection) : this(collection, Comparer<T>.Default) { }
+        public SortedSet(IEnumerable<T> collection) : this(collection, Comparer<T>.Default) { /* Intentionally empty */ }
 
 
         /// <summary>
@@ -731,7 +735,6 @@ namespace J2N.Collections.Generic
                             {
                                 parentOfMatch = newGrandParent;
                             }
-                            grandParent = newGrandParent;
                         }
                     }
                 }
@@ -911,7 +914,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an <c>O(log n)</c> operation.
         /// </remarks>
-        public IEnumerator<T> GetEnumerator() => new Enumerator(this);
+        public Enumerator GetEnumerator() => new Enumerator(this);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
@@ -1061,9 +1064,9 @@ namespace J2N.Collections.Generic
             return -1;
         }
 
-        internal Node? FindRange([AllowNull] T from, [AllowNull]  T to) => FindRange(from, to, lowerBoundInclusive: true, upperBoundInclusive: true, lowerBoundActive: true, upperBoundActive: true);
+        internal Node? FindRange(T? from, T? to) => FindRange(from, to, lowerBoundInclusive: true, upperBoundInclusive: true, lowerBoundActive: true, upperBoundActive: true);
 
-        internal Node? FindRange([AllowNull] T from, [AllowNull] T to, bool lowerBoundInclusive, bool upperBoundInclusive, bool lowerBoundActive, bool upperBoundActive)
+        internal Node? FindRange(T? from, T? to, bool lowerBoundInclusive, bool upperBoundInclusive, bool lowerBoundActive, bool upperBoundActive)
         {
             Node? current = root;
             while (current != null)
@@ -1200,8 +1203,8 @@ namespace J2N.Collections.Generic
                 // First do a merge sort to an array.
                 T[] merged = new T[asSorted.Count + this.Count];
                 int c = 0;
-                IEnumerator<T> mine = this.GetEnumerator();
-                IEnumerator<T> theirs = asSorted.GetEnumerator();
+                Enumerator mine = this.GetEnumerator();
+                Enumerator theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
                 while (!mineEnded && !theirsEnded)
                 {
@@ -1356,8 +1359,8 @@ namespace J2N.Collections.Generic
                 // First do a merge sort to an array.
                 T[] merged = new T[this.Count];
                 int c = 0;
-                IEnumerator<T> mine = this.GetEnumerator();
-                IEnumerator<T> theirs = asSorted.GetEnumerator();
+                Enumerator mine = this.GetEnumerator();
+                Enumerator theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
                 T? max = Max;
 
@@ -1779,8 +1782,8 @@ namespace J2N.Collections.Generic
             SortedSet<T>? asSorted = other as SortedSet<T>;
             if (asSorted != null && HasEqualComparer(asSorted))
             {
-                IEnumerator<T> mine = GetEnumerator();
-                IEnumerator<T> theirs = asSorted.GetEnumerator();
+                Enumerator mine = GetEnumerator();
+                Enumerator theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext();
                 bool theirsEnded = !theirs.MoveNext();
                 while (!mineEnded && !theirsEnded)
@@ -1967,11 +1970,9 @@ namespace J2N.Collections.Generic
         /// If the <see cref="SortedSet{T}"/> has no elements, then the <see cref="Min"/> property returns
         /// the default value of <typeparamref name="T"/>.
         /// </remarks>
-        [MaybeNull]
-        public T Min => MinInternal;
+        public T? Min => MinInternal;
 
-        [MaybeNull]
-        internal virtual T MinInternal
+        internal virtual T? MinInternal
         {
             get
             {
@@ -1997,11 +1998,9 @@ namespace J2N.Collections.Generic
         /// If the <see cref="SortedSet{T}"/> has no elements, then the <see cref="Max"/> property returns
         /// the default value of <typeparamref name="T"/>.
         /// </remarks>
-        [MaybeNull]
-        public T Max => MaxInternal;
+        public T? Max => MaxInternal;
 
-        [MaybeNull]
-        internal virtual T MaxInternal
+        internal virtual T? MaxInternal
         {
             get
             {
@@ -2054,7 +2053,7 @@ namespace J2N.Collections.Generic
         /// <see cref="SortedSet{T}"/>, but provides a window into the underlying <see cref="SortedSet{T}"/> itself.
         /// You can make changes in both the view and in the underlying <see cref="SortedSet{T}"/>.
         /// </remarks>
-        public virtual SortedSet<T> GetViewBetween([AllowNull] T lowerValue, [AllowNull] T upperValue)
+        public virtual SortedSet<T> GetViewBetween(T? lowerValue, T? upperValue)
         {
             if (Comparer.Compare(lowerValue!, upperValue!) > 0)
             {
@@ -2088,7 +2087,7 @@ namespace J2N.Collections.Generic
         /// <see cref="SortedSet{T}"/>, but provides a window into the underlying <see cref="SortedSet{T}"/> itself.
         /// You can make changes in both the view and in the underlying <see cref="SortedSet{T}"/>.
         /// </remarks>
-        public virtual SortedSet<T> GetViewBetween([AllowNull] T lowerValue, bool lowerValueInclusive, [AllowNull] T upperValue, bool upperValueInclusive)
+        public virtual SortedSet<T> GetViewBetween(T? lowerValue, bool lowerValueInclusive, T? upperValue, bool upperValueInclusive)
         {
             if (Comparer.Compare(lowerValue!, upperValue!) > 0)
             {
@@ -2240,6 +2239,32 @@ namespace J2N.Collections.Generic
                 Debug.Assert(count == GetCount());
 #endif
 
+#if FEATURE_STACK_TRYPOP
+                Node newRoot = ShallowClone();
+
+                var pendingNodes = new Stack<(Node source, Node target)>(2 * Log2(count) + 2);
+                pendingNodes.Push((this, newRoot));
+
+                while (pendingNodes.TryPop(out var next))
+                {
+                    Node clonedNode;
+
+                    if (next.source.Left is Node left)
+                    {
+                        clonedNode = left.ShallowClone();
+                        next.target.Left = clonedNode;
+                        pendingNodes.Push((left, clonedNode));
+                    }
+
+                    if (next.source.Right is Node right)
+                    {
+                        clonedNode = right.ShallowClone();
+                        next.target.Right = clonedNode;
+                        pendingNodes.Push((right, clonedNode));
+                    }
+                }
+#else
+                // J2N: This was code from .NET 5
                 // Breadth-first traversal to recreate nodes, preorder traversal to replicate nodes.
 
                 var originalNodes = new Stack<Node>(2 * Log2(count) + 2);
@@ -2276,7 +2301,7 @@ namespace J2N.Collections.Generic
                         newRight = newRight.Left;
                     }
                 }
-
+#endif
                 return newRoot;
             }
 
@@ -2494,19 +2519,19 @@ namespace J2N.Collections.Generic
 #if FEATURE_SERIALIZABLE
         [Serializable]
 #endif
-        internal struct Enumerator : IEnumerator<T>, IEnumerator
+        public struct Enumerator : IEnumerator<T>, IEnumerator
 #if FEATURE_SERIALIZABLE
             , ISerializable, IDeserializationCallback
 #endif
         {
-            private SortedSet<T> _tree;
-            private int _version;
+            private /* readonly */ SortedSet<T> _tree;
+            private /* readonly */ int _version;
 
-            private Stack<Node> _stack;
+            private /* readonly */ Stack<Node> _stack;
             private Node? _current;
             static readonly Node dummyNode = new Node(default!, NodeColor.Red);
 
-            private bool _reverse;
+            private /* readonly */ bool _reverse;
 
 #if FEATURE_SERIALIZABLE
 #pragma warning disable IDE0044 // Add readonly modifier
@@ -2596,7 +2621,7 @@ namespace J2N.Collections.Generic
             {
                 _current = null;
                 Node? node = _tree.root;
-                Node? next = null, other = null;
+                Node? next, other;
                 while (node != null)
                 {
                     next = (_reverse ? node.Right : node.Left);
@@ -2654,7 +2679,7 @@ namespace J2N.Collections.Generic
 
                 _current = _stack.Pop();
                 Node? node = (_reverse ? _current.Left : _current.Right);
-                Node? next = null, other = null;
+                Node? next, other;
                 while (node != null)
                 {
                     next = (_reverse ? node.Right : node.Left);
@@ -2679,7 +2704,7 @@ namespace J2N.Collections.Generic
             /// <summary>
             /// Releases all resources used by the <see cref="SortedSet{T}.Enumerator"/>.
             /// </summary>
-            public void Dispose() { }
+            public void Dispose() { /* Intentionally blank */ }
 
             /// <summary>
             /// Gets the element at the current position of the enumerator.
@@ -2785,16 +2810,7 @@ namespace J2N.Collections.Generic
         }
 
         // Used for set checking operations (using enumerables) that rely on counting
-        private static int Log2(int value)
-        {
-            int result = 0;
-            while (value > 0)
-            {
-                result++;
-                value >>= 1;
-            }
-            return result;
-        }
+        private static int Log2(int value) => BitOperation.Log2((uint)value);
 
         #endregion
 

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -6,6 +6,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 #if FEATURE_SERIALIZABLE
@@ -236,6 +237,8 @@ namespace J2N.Collections.Generic
         /// <remarks>
         /// This constructor is called during deserialization to reconstitute an object that is transmitted over a stream.
         /// </remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected SortedSet(SerializationInfo info, StreamingContext context)
         {
             siInfo = info;
@@ -2107,6 +2110,8 @@ namespace J2N.Collections.Generic
 #endif
 
 #if FEATURE_SERIALIZABLE
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) => GetObjectData(info, context);
 
         /// <summary>
@@ -2119,6 +2124,8 @@ namespace J2N.Collections.Generic
         /// of the serialized stream associated with the <see cref="SortedSet{T}"/> object.</param>
         /// <exception cref="ArgumentNullException"><paramref name="info"/> is <c>null</c>.</exception>
         /// <remarks>Calling this method is an <c>O(n)</c> operation, where <c>n</c> is <see cref="Count"/>.</remarks>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected virtual void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             if (info == null)
@@ -2531,6 +2538,7 @@ namespace J2N.Collections.Generic
 
 #if FEATURE_SERIALIZABLE
 
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
             private Enumerator(SerializationInfo info, StreamingContext context)
             {
                 _tree = null!;
@@ -2541,6 +2549,8 @@ namespace J2N.Collections.Generic
                 _siInfo = info;
             }
 
+            [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
             void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
                 if (info == null)

--- a/src/J2N/Collections/ObjectModel/ReadOnlySet.cs
+++ b/src/J2N/Collections/ObjectModel/ReadOnlySet.cs
@@ -51,6 +51,9 @@ namespace J2N.Collections.ObjectModel
 #if FEATURE_IREADONLYCOLLECTIONS
         IReadOnlyCollection<T>,
 #endif
+#if FEATURE_READONLYSET
+        IReadOnlySet<T>,
+#endif
         IStructuralEquatable, IStructuralFormattable
     {
         private static readonly bool TIsValueTypeOrStringOrStructuralEquatable = typeof(T).IsValueType || typeof(IStructuralEquatable).IsAssignableFrom(typeof(T)) || typeof(string).Equals(typeof(T));
@@ -341,6 +344,27 @@ namespace J2N.Collections.ObjectModel
         }
 
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)set).GetEnumerator();
+
+        #endregion
+
+        #region IReadOnlySet<T> Members
+
+#if FEATURE_READONLYSET
+
+        bool IReadOnlySet<T>.Contains(T item) => set.Contains(item);
+
+        bool IReadOnlySet<T>.IsProperSubsetOf(IEnumerable<T> other) => set.IsProperSubsetOf(other);
+
+        bool IReadOnlySet<T>.IsProperSupersetOf(IEnumerable<T> other) => set.IsProperSupersetOf(other);
+
+        bool IReadOnlySet<T>.IsSubsetOf(IEnumerable<T> other) => set.IsSubsetOf(other);
+
+        bool IReadOnlySet<T>.IsSupersetOf(IEnumerable<T> other) => set.IsSupersetOf(other);
+
+        bool IReadOnlySet<T>.Overlaps(IEnumerable<T> other) => set.Overlaps(other);
+
+        bool IReadOnlySet<T>.SetEquals(IEnumerable<T> other) => set.SetEquals(other);
+#endif
 
         #endregion
 

--- a/src/J2N/IO/BufferOverflowException.cs
+++ b/src/J2N/IO/BufferOverflowException.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.ComponentModel;
 
 
 namespace J2N.IO
@@ -63,6 +64,7 @@ namespace J2N.IO
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         private BufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         { }

--- a/src/J2N/IO/BufferUnderflowException.cs
+++ b/src/J2N/IO/BufferUnderflowException.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.ComponentModel;
 
 
 namespace J2N.IO
@@ -61,6 +62,7 @@ namespace J2N.IO
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         private BufferUnderflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         { }

--- a/src/J2N/IO/InvalidMarkException.cs
+++ b/src/J2N/IO/InvalidMarkException.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.ComponentModel;
 
 
 namespace J2N.IO
@@ -63,6 +64,7 @@ namespace J2N.IO
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         private InvalidMarkException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         { }

--- a/src/J2N/IO/ReadOnlyBufferException.cs
+++ b/src/J2N/IO/ReadOnlyBufferException.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.ComponentModel;
 
 
 namespace J2N.IO
@@ -63,6 +64,7 @@ namespace J2N.IO
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
         private ReadOnlyBufferException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         { }

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -8,7 +8,6 @@
     <WarningsAsErrors Label="Force all public members to have XML doc comments.">NU1605;1591</WarningsAsErrors>
 
     <Nullable>enable</Nullable>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet Package Settings">

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/J2N/Numerics/DotNetNumber.BigInteger.cs
+++ b/src/J2N/Numerics/DotNetNumber.BigInteger.cs
@@ -558,14 +558,18 @@ namespace J2N.Numerics
                         if (digit > 0)
                         {
                             // Now it's time to subtract our current quotient
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                             uint carry = SubtractDivisor(ref rem, n, ref rhs, digit);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
 
                             if (carry != t)
                             {
                                 Debug.Assert(carry == t + 1);
 
                                 // Our guess was still exactly one too high
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                                 carry = AddDivisor(ref rem, n, ref rhs);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                                 digit--;
 
                                 Debug.Assert(carry == 1);
@@ -870,7 +874,9 @@ namespace J2N.Numerics
                         fixed (uint* pBigNumEntry = &s_Pow10BigNumTable[s_Pow10BigNumTableIndices[index]])
                         {
                             ref BigInteger rhs = ref *(BigInteger*)(pBigNumEntry);
+#pragma warning disable CS9082 // Local is returned by reference but was initialized to a value that cannot be returned by reference
                             Multiply(ref lhs, ref rhs, out product);
+#pragma warning restore CS9082 // Local is returned by reference but was initialized to a value that cannot be returned by reference
                         }
 
                         // Swap to the next temporary
@@ -884,7 +890,9 @@ namespace J2N.Numerics
                     exponent >>= 1;
                 }
 
+#pragma warning disable CS9082 // Local is returned by reference but was initialized to a value that cannot be returned by reference
                 SetValue(out result, ref lhs);
+#pragma warning restore CS9082 // Local is returned by reference but was initialized to a value that cannot be returned by reference
             }
 
             private static uint AddDivisor(ref BigInteger lhs, int lhsStartIndex, ref BigInteger rhs)
@@ -1025,19 +1033,25 @@ namespace J2N.Numerics
 
             public void Multiply(uint value)
             {
+#pragma warning disable CS9084 // Struct member returns 'this' or other instance members by reference
                 Multiply(ref this, value, out this);
+#pragma warning restore CS9084 // Struct member returns 'this' or other instance members by reference
             }
 
             public void Multiply(ref BigInteger value)
             {
                 if (value._length <= 1)
                 {
+#pragma warning disable CS9084 // Struct member returns 'this' or other instance members by reference
                     Multiply(ref this, value.ToUInt32(), out this);
+#pragma warning restore CS9084 // Struct member returns 'this' or other instance members by reference
                 }
                 else
                 {
                     SetValue(out BigInteger temp, ref this);
+#pragma warning disable CS9080, CS9091, CS9094
                     Multiply(ref temp, ref value, out this);
+#pragma warning restore CS9080, CS9091, CS9094
                 }
             }
 

--- a/src/J2N/Numerics/DotNetNumber.Dragon4.cs
+++ b/src/J2N/Numerics/DotNetNumber.Dragon4.cs
@@ -254,7 +254,9 @@ namespace J2N.Numerics
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
+#pragma warning disable CS9091 // This returns local by reference but it is not a ref local
                     BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
+#pragma warning restore CS9091 // This returns local by reference but it is not a ref local
                 }
             }
 
@@ -268,7 +270,9 @@ namespace J2N.Numerics
                 // shorter strings for various edge case values like 1.23E+22
 
                 BigInteger.Add(ref scaledValue, ref *pScaledMarginHigh, out BigInteger scaledValueHigh);
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                 int cmpHigh = BigInteger.Compare(ref scaledValueHigh, ref scale);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                 estimateTooLow = isEven ? (cmpHigh >= 0) : (cmpHigh > 0);
             }
             else
@@ -292,7 +296,9 @@ namespace J2N.Numerics
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
+#pragma warning disable CS9091 // This returns local by reference but it is not a ref local
                     BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
+#pragma warning restore CS9091 // This returns local by reference but it is not a ref local
                 }
             }
 
@@ -351,7 +357,9 @@ namespace J2N.Numerics
 
                 if (pScaledMarginHigh != &scaledMarginLow)
                 {
+#pragma warning disable CS9091 // This returns local by reference but it is not a ref local
                     BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
+#pragma warning restore CS9091 // This returns local by reference but it is not a ref local
                 }
             }
 
@@ -379,7 +387,9 @@ namespace J2N.Numerics
 
                     // stop looping if we are far enough away from our neighboring values or if we have reached the cutoff digit
                     int cmpLow = BigInteger.Compare(ref scaledValue, ref scaledMarginLow);
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
                     int cmpHigh = BigInteger.Compare(ref scaledValueHigh, ref scale);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
 
                     if (isEven)
                     {
@@ -407,7 +417,9 @@ namespace J2N.Numerics
 
                     if (pScaledMarginHigh != &scaledMarginLow)
                     {
+#pragma warning disable CS9091 // This returns local by reference but it is not a ref local
                         BigInteger.Multiply(ref scaledMarginLow, 2, out *pScaledMarginHigh);
+#pragma warning restore CS9091 // This returns local by reference but it is not a ref local
                     }
 
                     digitExponent--;

--- a/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
+++ b/src/J2N/Numerics/DotNetNumber.NumberToFloatingPointBits.cs
@@ -634,14 +634,18 @@ namespace J2N.Numerics
             // earlier, or one greater than that shift:
             uint fractionalExponent = fractionalShift;
 
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
             if (BigInteger.Compare(ref fractionalNumerator, ref fractionalDenominator) < 0)
             {
                 fractionalExponent++;
             }
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
 
             fractionalNumerator.ShiftLeft(remainingBitsOfPrecisionRequired);
 
+#pragma warning disable CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
             BigInteger.DivRem(ref fractionalNumerator, ref fractionalDenominator, out BigInteger bigFractionalMantissa, out BigInteger fractionalRemainder);
+#pragma warning restore CS9080 // Use of variable in this context may expose referenced variables outside of their declaration scope
             ulong fractionalMantissa = bigFractionalMantissa.ToUInt64();
             bool hasZeroTail = !number.HasNonZeroTail && fractionalRemainder.IsZero();
 

--- a/src/J2N/Text/ParseException.cs
+++ b/src/J2N/Text/ParseException.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.ComponentModel;
 
 namespace J2N.Text
 {
@@ -82,17 +83,22 @@ namespace J2N.Text
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         protected ParseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         {
             errorOffset = info.GetInt32(ErrorOffsetName);
         }
 
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         /// <summary>
         /// Sets the <see cref="System.Runtime.Serialization.SerializationInfo"/> with information about the exception.
         /// </summary>
         /// <param name="info">The <see cref="System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
         /// <param name="context">The <see cref="System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination.</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         {
             if (info is null)
@@ -102,6 +108,7 @@ namespace J2N.Text
 
             base.GetObjectData(info, context);
         }
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
 #endif
 
         /// <summary>

--- a/src/J2N/Threading/Atomic/AtomicReference.cs
+++ b/src/J2N/Threading/Atomic/AtomicReference.cs
@@ -35,7 +35,9 @@ namespace J2N.Threading.Atomic
     public class AtomicReference<T> where T : class
     {
         private T? value;
+#if !FEATURE_VOLATILE
         private static readonly T Comparand = (T)FormatterServices.GetUninitializedObject(typeof(T)); //does not call ctor
+#endif
 
         /// <summary>
         /// Creates a new <see cref="AtomicReference{T}"/> with the given initial <paramref name="value"/>.
@@ -66,7 +68,11 @@ namespace J2N.Threading.Atomic
         /// </summary>
         public T? Value
         {
+#if FEATURE_VOLATILE
+            get => Volatile.Read(ref value);
+#else
             get => Interlocked.CompareExchange(ref value, Comparand, Comparand);
+#endif
             set => Interlocked.Exchange(ref this.value, value);
         }
 

--- a/src/J2N/Threading/Atomic/AtomicReferenceArray.cs
+++ b/src/J2N/Threading/Atomic/AtomicReferenceArray.cs
@@ -36,7 +36,9 @@ namespace J2N.Threading.Atomic
     public class AtomicReferenceArray<T> : IStructuralFormattable where T : class
     {
         private readonly T?[] array;
+#if !FEATURE_VOLATILE
         private static readonly T Comparand = (T)FormatterServices.GetUninitializedObject(typeof(T)); //does not call ctor
+#endif
 
         /// <summary>
         /// Creates a new <see cref="AtomicReferenceArray{T}"/> of given <paramref name="length"/>.
@@ -78,7 +80,11 @@ namespace J2N.Threading.Atomic
         /// <returns>The current value.</returns>
         public T? this[int index]
         {
+#if FEATURE_VOLATILE
+            get => Volatile.Read(ref array[index]);
+#else
             get => Interlocked.CompareExchange(ref array[index], Comparand, Comparand);
+#endif
             set => Interlocked.Exchange(ref array[index], value);
         }
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   
@@ -32,5 +32,80 @@
     <NoWarn Label="Remove unused parameter">$(NoWarn);IDE0060</NoWarn>
     <NoWarn Label="Naming Styles">$(NoWarn);IDE1006</NoWarn>
   </PropertyGroup>
+  
+  <UsingTask TaskName="UpdateRuntimeConfigProperty" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <RuntimeConfigFile ParameterType="System.String" Required="true" />
+      <PropertyName ParameterType="System.String" Required="true" />
+      <PropertyValue ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        if (File.Exists(RuntimeConfigFile))
+        {
+            // Read the file content
+            string jsonContent = File.ReadAllText(RuntimeConfigFile);
+
+            // Ensure runtimeOptions and configProperties sections exist
+            if (!jsonContent.Contains("\"runtimeOptions\""))
+            {
+                jsonContent = jsonContent.TrimEnd('}', '\n', '\r') + ",\n  \"runtimeOptions\": {\n    \"configProperties\": {\n    }\n  }\n}";
+            }
+            if (!jsonContent.Contains("\"configProperties\""))
+            {
+                int runtimeOptionsIndex = jsonContent.IndexOf("\"runtimeOptions\"");
+                int insertPosition = jsonContent.IndexOf('}', runtimeOptionsIndex);
+                jsonContent = jsonContent.Insert(insertPosition, ",\n    \"configProperties\": {\n    }\n");
+            }
+
+            // Check if the property already exists
+            int configPropertiesIndex = jsonContent.IndexOf("\"configProperties\"");
+            int propertyIndex = jsonContent.IndexOf("\"" + PropertyName + "\"", configPropertiesIndex);
+
+            if (propertyIndex != -1)
+            {
+                // Property exists, update its value
+                int valueStartIndex = jsonContent.IndexOf(':', propertyIndex) + 1;
+                int valueEndIndex = jsonContent.IndexOfAny(new char[] { ',', '}', '\n' }, valueStartIndex);
+                jsonContent = jsonContent.Remove(valueStartIndex, valueEndIndex - valueStartIndex)
+                                         .Insert(valueStartIndex, " " + PropertyValue);
+            }
+            else
+            {
+                // Property does not exist, add it
+                int closingBraceIndex = jsonContent.IndexOf('}', configPropertiesIndex);
+                jsonContent = jsonContent.Insert(closingBraceIndex, "  \"" + PropertyName + "\": " + PropertyValue + ",\n");
+            }
+
+            // Write the updated content back to the file
+            File.WriteAllText(RuntimeConfigFile, jsonContent);
+        }
+        else
+        {
+            Log.LogError("File not found: " + RuntimeConfigFile);
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Target to invoke the task after build -->
+  <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
+    <PropertyGroup>
+      <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
+      <DotNet_8_0_OrGreater>false</DotNet_8_0_OrGreater>
+      <DotNet_8_0_OrGreater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ($(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or ($(TargetFramework.StartsWith('net')) And $(TargetFramework.IndexOf('.')) > 4))">true</DotNet_8_0_OrGreater>
+    </PropertyGroup>
+
+    <!-- Example usage -->
+    <UpdateRuntimeConfigProperty 
+        RuntimeConfigFile="$(RuntimeConfigFile)" 
+        PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" 
+        PropertyValue="true" 
+        Condition="Exists('$(RuntimeConfigFile)') And '$(DotNet_8_0_OrGreater)' == 'true'" />
+  </Target>
   
 </Project>

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.cs
@@ -620,6 +620,7 @@ namespace J2N.Collections.Tests
         #endregion
 
         #region Non-randomized comparers
+
         [Fact]
         public void Dictionary_Comparer_NonRandomizedStringComparers()
         {
@@ -641,14 +642,17 @@ namespace J2N.Collections.Tests
 
                 Assert.Same(expected, dict.EqualityComparer);
 
+#if FEATURE_SERIALIZABLE
                 // Then pretend to serialize the dictionary and check the stored Comparer instance
 
                 SerializationInfo si = new SerializationInfo(typeof(Dictionary<string, object>), new FormatterConverter());
                 dict.GetObjectData(si, new StreamingContext(StreamingContextStates.All));
 
                 Assert.Same(expected, si.GetValue("EqualityComparer", typeof(SCG.IEqualityComparer<string>)));
+#endif
             }
         }
+
         #endregion
     }
 }

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Extensions/SubList/SubList.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Extensions/SubList/SubList.Tests.cs
@@ -93,13 +93,6 @@ namespace J2N.Collections.Tests
 
     public abstract class SubList_Tests<T> : IList_Generic_Tests<T>
     {
-//        // J2N: See the comment in the root Directory.Build.targets file
-//#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
-//        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
-//#else
-//        //protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
-//#endif
-
         private SCG.List<T> OriginalList { get; set; }
 
         #region IList<T> Helper Methods

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Extensions/SubList/SubList.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Extensions/SubList/SubList.Tests.cs
@@ -43,6 +43,11 @@ namespace J2N.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if !FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
+#endif
+
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<string> GenericIListFactory(int setLength)
@@ -66,6 +71,11 @@ namespace J2N.Collections.Tests
             return rand.Next();
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if !FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
+#endif
+
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<int> GenericIListFactory(int setLength)
@@ -83,6 +93,13 @@ namespace J2N.Collections.Tests
 
     public abstract class SubList_Tests<T> : IList_Generic_Tests<T>
     {
+//        // J2N: See the comment in the root Directory.Build.targets file
+//#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+//        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+//#else
+//        //protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
+//#endif
+
         private SCG.List<T> OriginalList { get; set; }
 
         #region IList<T> Helper Methods

--- a/tests/J2N.Tests.xUnit/Collections/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/HashSet/HashSet.Generic.Tests.AsNonGenericIEnumerable.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JCG = J2N.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
@@ -12,7 +13,7 @@ namespace J2N.Collections.Tests
     {
         protected override IEnumerable NonGenericIEnumerableFactory(int count)
         {
-            var set = new HashSet<string>();
+            var set = new JCG.HashSet<string>();
             int seed = 12354;
             while (set.Count < count)
                 set.Add(CreateT(set, seed++));
@@ -35,7 +36,7 @@ namespace J2N.Collections.Tests
             {
                 yield return (IEnumerable enumerable) =>
                 {
-                    HashSet<string> casted = ((HashSet<string>)enumerable);
+                    JCG.HashSet<string> casted = ((JCG.HashSet<string>)enumerable);
                     if (casted.Count > 0)
                     {
                         casted.Clear();
@@ -46,7 +47,7 @@ namespace J2N.Collections.Tests
             }
         }
 
-        protected string CreateT(HashSet<string> set, int seed)
+        protected string CreateT(JCG.HashSet<string> set, int seed)
         {
             int stringLength = seed % 10 + 5;
             Random rand = new Random(seed);

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.Tests.cs
@@ -14,6 +14,9 @@ namespace J2N.Collections.Tests
     public abstract partial class List_Generic_Tests<T> : IList_Generic_Tests<T>
     {
         #region IList<T> Helper Methods
+        //protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
+        //protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
 
         protected override SCG.IList<T> GenericIListFactory()
         {

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.cs
@@ -42,6 +42,11 @@ namespace J2N.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
+
         protected override bool IsReadOnly => true;
 
         protected override IList<string> GenericIListFactory(int setLength)
@@ -65,6 +70,10 @@ namespace J2N.Collections.Tests
             return rand.Next();
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
         protected override bool IsReadOnly => true;
 
         protected override IList<int> GenericIListFactory(int setLength)

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.Generic.cs
@@ -10,6 +10,7 @@ namespace J2N.Collections.Tests
 {
     public class List_Generic_Tests_string : List_Generic_Tests<string>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override string CreateT(int seed)
         {
             int stringLength = seed % 10 + 5;
@@ -22,6 +23,7 @@ namespace J2N.Collections.Tests
 
     public class List_Generic_Tests_int : List_Generic_Tests<int>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override int CreateT(int seed)
         {
             Random rand = new Random(seed);

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Grandchild.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Grandchild.Tests.cs
@@ -7,6 +7,7 @@ namespace J2N.Collections.Tests
 {
     public class List_SubList_Grandchild_Tests_int : List_SubList_Grandchild_Tests<int>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override bool DefaultValueAllowed => true;
 
         protected override int CreateT(int seed)
@@ -18,6 +19,7 @@ namespace J2N.Collections.Tests
 
     public class List_SubList_Grandchild_Tests_string : List_SubList_Grandchild_Tests<string>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override string CreateT(int seed)
         {
             int stringLength = seed % 10 + 5;

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Grandchild.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Grandchild.Tests.cs
@@ -41,6 +41,10 @@ namespace J2N.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<string> GenericIListFactory(int setLength)
@@ -64,6 +68,10 @@ namespace J2N.Collections.Tests
             return rand.Next();
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<int> GenericIListFactory(int setLength)

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Tests.cs
@@ -7,6 +7,7 @@ namespace J2N.Collections.Tests
 {
     public class List_SubList_Tests_int : List_SubList_Tests<int>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override bool DefaultValueAllowed => true;
 
         protected override int CreateT(int seed)
@@ -18,6 +19,7 @@ namespace J2N.Collections.Tests
 
     public class List_SubList_Tests_string : List_SubList_Tests<string>
     {
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
         protected override string CreateT(int seed)
         {
             int stringLength = seed % 10 + 5;

--- a/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/List/List.SubList.Tests.cs
@@ -41,6 +41,10 @@ namespace J2N.Collections.Tests
             return Convert.ToBase64String(bytes);
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<string> GenericIListFactory(int setLength)
@@ -64,6 +68,10 @@ namespace J2N.Collections.Tests
             return rand.Next();
         }
 
+        // J2N: See the comment in the root Directory.Build.targets file
+#if FEATURE_READONLYCOLLECTION_ENUMERATOR_EMPTY_CURRENT_UNDEFINEDOPERATION_DOESNOTTHROW
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => false;
+#endif
         protected override bool IsReadOnly => true;
 
         protected override SCG.IList<int> GenericIListFactory(int setLength)

--- a/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Keys.cs
@@ -1,27 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using J2N.Collections.Generic;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+using SCG = System.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
     public class SortedDictionary_Generic_Tests_Keys : ICollection_Generic_Tests<string>
     {
-        protected override bool DefaultValueAllowed => false;
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
+        protected override bool DefaultValueAllowed => true; // J2N supports null keys
         protected override bool DuplicateValuesAllowed => false;
         protected override bool IsReadOnly => true;
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
-        protected override ICollection<string> GenericICollectionFactory()
+        protected override SCG.IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override SCG.ICollection<string> GenericICollectionFactory()
         {
             return new SortedDictionary<string, string>().Keys;
         }
 
-        protected override ICollection<string> GenericICollectionFactory(int count)
+        protected override SCG.ICollection<string> GenericICollectionFactory(int count)
         {
             SortedDictionary<string, string> list = new SortedDictionary<string, string>();
             int seed = 13453;
@@ -59,11 +61,12 @@ namespace J2N.Collections.Tests
 
     public class SortedDictionary_Generic_Tests_Keys_AsICollection : ICollection_NonGeneric_Tests
     {
-        protected override bool NullAllowed => true;
+        protected override bool NullAllowed => true; // J2N allows null keys
         protected override bool DuplicateValuesAllowed => false;
         protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override SCG.IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
         protected override ICollection NonGenericICollectionFactory()
         {
             return (ICollection)(new SortedDictionary<string, string>().Keys);

--- a/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.Tests.Values.cs
@@ -1,29 +1,31 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using J2N.Collections.Generic;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+using SCG = System.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
     public class SortedDictionary_Generic_Tests_Values : ICollection_Generic_Tests<string>
     {
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
         protected override bool DefaultValueAllowed => true;
         protected override bool DuplicateValuesAllowed => true;
         protected override bool IsReadOnly => true;
 
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override SCG.IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
 
-        protected override ICollection<string> GenericICollectionFactory()
+        protected override SCG.ICollection<string> GenericICollectionFactory()
         {
             return new SortedDictionary<string, string>().Values;
         }
 
-        protected override ICollection<string> GenericICollectionFactory(int count)
+        protected override SCG.ICollection<string> GenericICollectionFactory(int count)
         {
             SortedDictionary<string, string> list = new SortedDictionary<string, string>();
             int seed = 13453;
@@ -64,8 +66,9 @@ namespace J2N.Collections.Tests
         protected override bool NullAllowed => true;
         protected override bool DuplicateValuesAllowed => true;
         protected override bool IsReadOnly => true;
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
         protected override bool Enumerator_Current_UndefinedOperation_Throws => true;
-        protected override IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
+        protected override SCG.IEnumerable<ModifyEnumerable> GetModifyEnumerables(ModifyOperation operations) => new List<ModifyEnumerable>();
         protected override bool SupportsSerialization => false;
 
         protected override ICollection NonGenericICollectionFactory()

--- a/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Generic.cs
@@ -1,18 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using J2N.Collections.Generic;
 using System;
-using System.Collections.Generic;
 using Xunit;
+using SCG = System.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
     public class SortedDictionary_Generic_Tests_string_string : SortedDictionary_Generic_Tests<string, string>
     {
-        protected override KeyValuePair<string, string> CreateT(int seed)
+        protected override SCG.KeyValuePair<string, string> CreateT(int seed)
         {
-            return new KeyValuePair<string, string>(CreateTKey(seed), CreateTKey(seed + 500));
+            return new SCG.KeyValuePair<string, string>(CreateTKey(seed), CreateTKey(seed + 500));
         }
 
         protected override string CreateTKey(int seed)
@@ -33,10 +33,10 @@ namespace J2N.Collections.Tests
     public class SortedDictionary_Generic_Tests_int_int : SortedDictionary_Generic_Tests<int, int>
     {
         protected override bool DefaultValueAllowed { get { return true; } }
-        protected override KeyValuePair<int, int> CreateT(int seed)
+        protected override SCG.KeyValuePair<int, int> CreateT(int seed)
         {
             Random rand = new Random(seed);
-            return new KeyValuePair<int, int>(rand.Next(), rand.Next());
+            return new SCG.KeyValuePair<int, int>(rand.Next(), rand.Next());
         }
 
         protected override int CreateTKey(int seed)
@@ -54,10 +54,10 @@ namespace J2N.Collections.Tests
     //[OuterLoop]
     public class SortedDictionary_Generic_Tests_EquatableBackwardsOrder_int : SortedDictionary_Generic_Tests<EquatableBackwardsOrder, int>
     {
-        protected override KeyValuePair<EquatableBackwardsOrder, int> CreateT(int seed)
+        protected override SCG.KeyValuePair<EquatableBackwardsOrder, int> CreateT(int seed)
         {
             Random rand = new Random(seed);
-            return new KeyValuePair<EquatableBackwardsOrder, int>(new EquatableBackwardsOrder(rand.Next()), rand.Next());
+            return new SCG.KeyValuePair<EquatableBackwardsOrder, int>(new EquatableBackwardsOrder(rand.Next()), rand.Next());
         }
 
         protected override EquatableBackwardsOrder CreateTKey(int seed)
@@ -72,9 +72,9 @@ namespace J2N.Collections.Tests
             return rand.Next();
         }
 
-        protected override IDictionary<EquatableBackwardsOrder, int> GenericIDictionaryFactory()
+        protected override SCG.IDictionary<EquatableBackwardsOrder, int> GenericIDictionaryFactory()
         {
-            return new J2N.Collections.Generic.SortedDictionary<EquatableBackwardsOrder, int>();
+            return new SortedDictionary<EquatableBackwardsOrder, int>();
         }
     }
 }

--- a/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Tests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using Xunit;
+using JCG = J2N.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
@@ -15,7 +16,7 @@ namespace J2N.Collections.Tests
 
         protected override IDictionary NonGenericIDictionaryFactory()
         {
-            return new SortedDictionary<string, string>();
+            return new JCG.SortedDictionary<string, string>();
         }
 
         /// <summary>
@@ -47,7 +48,7 @@ namespace J2N.Collections.Tests
         [Fact]
         public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull()
         {
-            IDictionary dictionary = new SortedDictionary<string, int>();
+            IDictionary dictionary = new JCG.SortedDictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dictionary[GetNewKey(dictionary)] = null);
         }
 
@@ -56,7 +57,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, string>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
                 AssertExtensions.Throws<ArgumentException>("key", () => dictionary[23] = CreateTValue(12345));
                 Assert.Empty(dictionary);
             }
@@ -67,7 +68,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, string>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
                 object missingKey = GetNewKey(dictionary);
                 AssertExtensions.Throws<ArgumentException>("value", () => dictionary[missingKey] = 324);
                 Assert.Empty(dictionary);
@@ -79,7 +80,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, string>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
                 object missingKey = 23;
                 AssertExtensions.Throws<ArgumentException>("key", () => dictionary.Add(missingKey, CreateTValue(12345)));
                 Assert.Empty(dictionary);
@@ -91,7 +92,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, string>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
                 object missingKey = GetNewKey(dictionary);
                 AssertExtensions.Throws<ArgumentException>("value", () => dictionary.Add(missingKey, 324));
                 Assert.Empty(dictionary);
@@ -103,7 +104,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, int>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, int>();
                 object missingKey = GetNewKey(dictionary);
                 Assert.Throws<ArgumentNullException>(() => dictionary.Add(missingKey, null));
                 Assert.Empty(dictionary);
@@ -115,7 +116,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new SortedDictionary<string, int>();
+                IDictionary dictionary = new JCG.SortedDictionary<string, int>();
                 Assert.False(dictionary.Contains(1));
             }
         }
@@ -124,7 +125,7 @@ namespace J2N.Collections.Tests
         public void CantAcceptDuplicateKeysFromSourceDictionary()
         {
             Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };
-            AssertExtensions.Throws<ArgumentException>(null, () => new SortedDictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentException>(null, () => new JCG.SortedDictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
         }
 
         #endregion

--- a/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/SortedDictionary/SortedDictionary.Tests.cs
@@ -1,22 +1,25 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
+using J2N.Collections.Generic;
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using Xunit;
-using JCG = J2N.Collections.Generic;
+using SCG = System.Collections.Generic;
 
 namespace J2N.Collections.Tests
 {
     public class SortedDictionary_IDictionary_NonGeneric_Tests : IDictionary_NonGeneric_Tests
     {
         #region IDictionary Helper Methods
+        protected override bool Enumerator_Empty_UsesSingletonInstance => true;
+        protected override bool Enumerator_Empty_ModifiedDuringEnumeration_ThrowsInvalidOperationException => false;
+
+        protected override bool NullAllowed => true; // J2N allows null keys
 
         protected override IDictionary NonGenericIDictionaryFactory()
         {
-            return new JCG.SortedDictionary<string, string>();
+            return new SortedDictionary<string, string>();
         }
 
         /// <summary>
@@ -48,7 +51,7 @@ namespace J2N.Collections.Tests
         [Fact]
         public void IDictionary_NonGeneric_ItemSet_NullValueWhenDefaultValueIsNonNull()
         {
-            IDictionary dictionary = new JCG.SortedDictionary<string, int>();
+            IDictionary dictionary = new SortedDictionary<string, int>();
             Assert.Throws<ArgumentNullException>(() => dictionary[GetNewKey(dictionary)] = null);
         }
 
@@ -57,7 +60,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
+                IDictionary dictionary = new SortedDictionary<string, string>();
                 AssertExtensions.Throws<ArgumentException>("key", () => dictionary[23] = CreateTValue(12345));
                 Assert.Empty(dictionary);
             }
@@ -68,7 +71,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
+                IDictionary dictionary = new SortedDictionary<string, string>();
                 object missingKey = GetNewKey(dictionary);
                 AssertExtensions.Throws<ArgumentException>("value", () => dictionary[missingKey] = 324);
                 Assert.Empty(dictionary);
@@ -80,7 +83,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
+                IDictionary dictionary = new SortedDictionary<string, string>();
                 object missingKey = 23;
                 AssertExtensions.Throws<ArgumentException>("key", () => dictionary.Add(missingKey, CreateTValue(12345)));
                 Assert.Empty(dictionary);
@@ -92,7 +95,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, string>();
+                IDictionary dictionary = new SortedDictionary<string, string>();
                 object missingKey = GetNewKey(dictionary);
                 AssertExtensions.Throws<ArgumentException>("value", () => dictionary.Add(missingKey, 324));
                 Assert.Empty(dictionary);
@@ -104,7 +107,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, int>();
+                IDictionary dictionary = new SortedDictionary<string, int>();
                 object missingKey = GetNewKey(dictionary);
                 Assert.Throws<ArgumentNullException>(() => dictionary.Add(missingKey, null));
                 Assert.Empty(dictionary);
@@ -116,7 +119,7 @@ namespace J2N.Collections.Tests
         {
             if (!IsReadOnly)
             {
-                IDictionary dictionary = new JCG.SortedDictionary<string, int>();
+                IDictionary dictionary = new SortedDictionary<string, int>();
                 Assert.False(dictionary.Contains(1));
             }
         }
@@ -125,7 +128,7 @@ namespace J2N.Collections.Tests
         public void CantAcceptDuplicateKeysFromSourceDictionary()
         {
             Dictionary<string, int> source = new Dictionary<string, int> { { "a", 1 }, { "A", 1 } };
-            AssertExtensions.Throws<ArgumentException>(null, () => new JCG.SortedDictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentException>(null, () => new SortedDictionary<string, int>(source, StringComparer.OrdinalIgnoreCase));
         }
 
         #endregion
@@ -137,7 +140,7 @@ namespace J2N.Collections.Tests
         public void ICollection_NonGeneric_CopyTo_ArrayOfIncorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
-            KeyValuePair<string, int>[] array = new KeyValuePair<string, int>[count * 3 / 2];
+            SCG.KeyValuePair<string, int>[] array = new SCG.KeyValuePair<string, int>[count * 3 / 2];
             AssertExtensions.Throws<ArgumentException>("array", null, () => collection.CopyTo(array, 0));
         }
 
@@ -146,7 +149,7 @@ namespace J2N.Collections.Tests
         public void ICollection_NonGeneric_CopyTo_ArrayOfCorrectKeyValuePairType(int count)
         {
             ICollection collection = NonGenericICollectionFactory(count);
-            KeyValuePair<string, string>[] array = new KeyValuePair<string, string>[count];
+            SCG.KeyValuePair<string, string>[] array = new SCG.KeyValuePair<string, string>[count];
             collection.CopyTo(array, 0);
             int i = 0;
             foreach (object obj in collection)

--- a/tests/J2N.Tests.xUnit/Collections/ICollection.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ICollection.Generic.Tests.cs
@@ -408,8 +408,10 @@ namespace J2N.Collections.Tests
         public void ICollection_Generic_Contains_DefaultValueOnCollectionNotContainingDefaultValue(int count)
         {
             ICollection<T> collection = GenericICollectionFactory(count);
-            if (DefaultValueAllowed)
+            if (DefaultValueAllowed && default(T) is null) // it's true only for reference types and for Nullable<T>
+            {
                 Assert.False(collection.Contains(default(T)));
+            }
         }
 
         [Theory]
@@ -491,7 +493,7 @@ namespace J2N.Collections.Tests
             ICollection<T> collection = GenericICollectionFactory(count);
             T[] array = new T[count];
             if (count > 0)
-                Assert.Throws<ArgumentException>(() => collection.CopyTo(array, count));
+                Assert.ThrowsAny<ArgumentException>(() => collection.CopyTo(array, count));
             else
                 collection.CopyTo(array, count); // does nothing since the array is empty
         }
@@ -513,7 +515,7 @@ namespace J2N.Collections.Tests
             {
                 ICollection<T> collection = GenericICollectionFactory(count);
                 T[] array = new T[count];
-                Assert.Throws<ArgumentException>(() => collection.CopyTo(array, 1));
+                Assert.ThrowsAny<ArgumentException>(() => collection.CopyTo(array, 1));
             }
         }
 

--- a/tests/J2N.Tests.xUnit/Collections/ISet.Generic.Tests.cs
+++ b/tests/J2N.Tests.xUnit/Collections/ISet.Generic.Tests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
 
 using J2N.Collections.Generic;
 using System;
@@ -305,38 +304,58 @@ namespace J2N.Collections.Tests
         public void ISet_Generic_NullEnumerableArgument(int count)
         {
             ISet<T> set = GenericISetFactory(count);
-            Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null));
-            Assert.Throws<ArgumentNullException>(() => set.IntersectWith(null));
             Assert.Throws<ArgumentNullException>(() => set.IsProperSubsetOf(null));
             Assert.Throws<ArgumentNullException>(() => set.IsProperSupersetOf(null));
             Assert.Throws<ArgumentNullException>(() => set.IsSubsetOf(null));
             Assert.Throws<ArgumentNullException>(() => set.IsSupersetOf(null));
             Assert.Throws<ArgumentNullException>(() => set.Overlaps(null));
             Assert.Throws<ArgumentNullException>(() => set.SetEquals(null));
-            Assert.Throws<ArgumentNullException>(() => set.SymmetricExceptWith(null));
-            Assert.Throws<ArgumentNullException>(() => set.UnionWith(null));
+            if (!IsReadOnly)
+            {
+                Assert.Throws<ArgumentNullException>(() => set.ExceptWith(null));
+                Assert.Throws<ArgumentNullException>(() => set.IntersectWith(null));
+                Assert.Throws<ArgumentNullException>(() => set.SymmetricExceptWith(null));
+                Assert.Throws<ArgumentNullException>(() => set.UnionWith(null));
+            }
+            else
+            {
+                Assert.Throws<NotSupportedException>(() => set.Add(CreateT(0)));
+                Assert.Throws<NotSupportedException>(() => set.ExceptWith(null));
+                Assert.Throws<NotSupportedException>(() => set.IntersectWith(null));
+                Assert.Throws<NotSupportedException>(() => set.SymmetricExceptWith(null));
+                Assert.Throws<NotSupportedException>(() => set.UnionWith(null));
+            }
         }
+
+        public static IEnumerable<object[]> SetTestData() =>
+            new[] { EnumerableType.HashSet, EnumerableType.List }.SelectMany(GetEnumerableTestData);
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_ExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
-            Validate_ExceptWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+                Validate_ExceptWith(set, enumerable);
+            }
         }
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_IntersectWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
-            Validate_IntersectWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+                Validate_IntersectWith(set, enumerable);
+            }
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_IsProperSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -345,7 +364,7 @@ namespace J2N.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_IsProperSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -354,7 +373,7 @@ namespace J2N.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_IsSubsetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -363,7 +382,7 @@ namespace J2N.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_IsSupersetOf(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -372,7 +391,7 @@ namespace J2N.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_Overlaps(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -381,7 +400,7 @@ namespace J2N.Collections.Tests
         }
 
         [Theory]
-        [MemberData(nameof(EnumerableTestData))]
+        [MemberData(nameof(SetTestData))]
         public void ISet_Generic_SetEquals(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
             ISet<T> set = GenericISetFactory(setLength);
@@ -393,18 +412,24 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_SymmetricExceptWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
-            Validate_SymmetricExceptWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+                Validate_SymmetricExceptWith(set, enumerable);
+            }
         }
 
         [Theory]
         [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_UnionWith(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
-            Validate_UnionWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+                Validate_UnionWith(set, enumerable);
+            }
         }
 
         #endregion
@@ -415,8 +440,11 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_ExceptWith_Itself(int setLength)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            Validate_ExceptWith(set, set);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                Validate_ExceptWith(set, set);
+            }
         }
 
         [Theory]
@@ -424,8 +452,11 @@ namespace J2N.Collections.Tests
         //[SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Full framework throws InvalidOperationException")]
         public void ISet_Generic_IntersectWith_Itself(int setLength)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            Validate_IntersectWith(set, set);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                Validate_IntersectWith(set, set);
+            }
         }
 
         [Theory]
@@ -480,16 +511,22 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_SymmetricExceptWith_Itself(int setLength)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            Validate_SymmetricExceptWith(set, set);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                Validate_SymmetricExceptWith(set, set);
+            }
         }
 
         [Theory]
         [MemberData(nameof(ValidCollectionSizes))]
         public void ISet_Generic_UnionWith_Itself(int setLength)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            Validate_UnionWith(set, set);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                Validate_UnionWith(set, set);
+            }
         }
 
         #endregion
@@ -500,18 +537,24 @@ namespace J2N.Collections.Tests
         //[OuterLoop]
         public void ISet_Generic_ExceptWith_LargeSet()
         {
-            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
-            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
-            Validate_ExceptWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+                IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+                Validate_ExceptWith(set, enumerable);
+            }
         }
 
         [Fact]
         //[OuterLoop]
         public void ISet_Generic_IntersectWith_LargeSet()
         {
-            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
-            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
-            Validate_IntersectWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+                IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+                Validate_IntersectWith(set, enumerable);
+            }
         }
 
         [Fact]
@@ -572,18 +615,24 @@ namespace J2N.Collections.Tests
         //[OuterLoop]
         public void ISet_Generic_SymmetricExceptWith_LargeSet()
         {
-            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
-            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
-            Validate_SymmetricExceptWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+                IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+                Validate_SymmetricExceptWith(set, enumerable);
+            }
         }
 
         [Fact]
         //[OuterLoop]
         public void ISet_Generic_UnionWith_LargeSet()
         {
-            ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
-            IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
-            Validate_UnionWith(set, enumerable);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(ISet_Large_Capacity);
+                IEnumerable<T> enumerable = CreateEnumerable(EnumerableType.List, set, 150, 0, 0);
+                Validate_UnionWith(set, enumerable);
+            }
         }
 
         #endregion
@@ -594,25 +643,28 @@ namespace J2N.Collections.Tests
         [MemberData(nameof(EnumerableTestData))]
         public void ISet_Generic_SymmetricExceptWith_AfterRemovingElements(EnumerableType enumerableType, int setLength, int enumerableLength, int numberOfMatchingElements, int numberOfDuplicateElements)
         {
-            ISet<T> set = GenericISetFactory(setLength);
-            T value = CreateT(532);
-            if (!set.Contains(value))
-                set.Add(value);
-            set.Remove(value);
-            IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
-            Debug.Assert(enumerable != null);
+            if (!IsReadOnly)
+            {
+                ISet<T> set = GenericISetFactory(setLength);
+                T value = CreateT(532);
+                if (!set.Contains(value))
+                    set.Add(value);
+                set.Remove(value);
+                IEnumerable<T> enumerable = CreateEnumerable(enumerableType, set, enumerableLength, numberOfMatchingElements, numberOfDuplicateElements);
+                Debug.Assert(enumerable != null);
 
-            IEqualityComparer<T> comparer = GetIEqualityComparer();
-            System.Collections.Generic.HashSet<T> expected = new System.Collections.Generic.HashSet<T>(comparer);
-            foreach (T element in enumerable)
-                if (!set.Contains(element, comparer))
-                    expected.Add(element);
-            foreach (T element in set)
-                if (!enumerable.Contains(element, comparer))
-                    expected.Add(element);
-            set.SymmetricExceptWith(enumerable);
-            Assert.Equal(expected.Count, set.Count);
-            Assert.True(expected.SetEquals(set));
+                IEqualityComparer<T> comparer = GetIEqualityComparer();
+                System.Collections.Generic.HashSet<T> expected = new System.Collections.Generic.HashSet<T>(comparer);
+                foreach (T element in enumerable)
+                    if (!set.Contains(element, comparer))
+                        expected.Add(element);
+                foreach (T element in set)
+                    if (!enumerable.Contains(element, comparer))
+                        expected.Add(element);
+                set.SymmetricExceptWith(enumerable);
+                Assert.Equal(expected.Count, set.Count);
+                Assert.True(expected.SetEquals(set));
+            }
         }
 
         #endregion

--- a/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
+++ b/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
@@ -11,6 +11,8 @@
     <NoWarn Label="Do not use typeof() expression to check the exception type.">$(NoWarn);xUnit2015</NoWarn>
     <NoWarn Label="Do not use Contains() to check if a value exists in a collection.">$(NoWarn);xUnit2017</NoWarn>
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
+    <NoWarn Label="FormatterConverter serialization is obsolete">$(NoWarn);SYSLIB0050</NoWarn>
+    <NoWarn Label=".ctor(SerializationInfo, StreamingContext) is obsolete">$(NoWarn);SYSLIB0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
+++ b/tests/J2N.Tests.xUnit/J2N.Tests.xUnit.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <!-- On net47, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
         ExcludeAssets=compile removes the dependency from being referenced. ExcludeAssets=runtime removes the dependency from the build output. -->
     <PackageReference Include="System.Buffers"
                       Version="$(SystemBuffersPackageReferenceVersion)"

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -25,8 +25,8 @@
   </ItemGroup>
   
   <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <!-- On net47, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
         ExcludeAssets=compile removes the dependency from being referenced. ExcludeAssets=runtime removes the dependency from the build output. -->
     <PackageReference Include="System.Buffers"
                       Version="$(SystemBuffersPackageReferenceVersion)"

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -15,6 +15,8 @@
     <NoWarn Label="Use compound assignment">$(NoWarn);IDE0054</NoWarn>
     
     <NoWarn Label="BinaryFormatter serialization is obsolete">$(NoWarn);SYSLIB0011</NoWarn>
+    <NoWarn Label="FormatterConverter serialization is obsolete">$(NoWarn);SYSLIB0050</NoWarn>
+    <NoWarn Label=".ctor(SerializationInfo, StreamingContext) is obsolete">$(NoWarn);SYSLIB0051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/J2N.Tests/J2N.Tests.csproj
+++ b/tests/J2N.Tests/J2N.Tests.csproj
@@ -39,7 +39,7 @@
                       Version="$(NetFxSystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>
 

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1989,8 +1989,12 @@ namespace J2N
             assertTrue(Character.GetType((int)'$') == UnicodeCategory.CurrencySymbol);
             assertTrue(Character.GetType((int)'\u2029') == UnicodeCategory.ParagraphSeparator);
 
+#if FEATURE_UNICODE_DEFINED_0x9FFF
+            assertTrue(Character.GetType(0x9FFF) == UnicodeCategory.OtherLetter);
+#else
             assertTrue(Character.GetType(0x9FFF) == UnicodeCategory.OtherNotAssigned);
-#if FEATURE_ICU
+#endif
+#if FEATURE_UNICODE_DEFINED_0x30000
             assertTrue(Character.GetType(0x30000) == UnicodeCategory.OtherLetter); // This character is now defined in .NET 5
 #else
             assertTrue(Character.GetType(0x30000) == UnicodeCategory.OtherNotAssigned);
@@ -2114,7 +2118,7 @@ namespace J2N
             assertTrue(Character.IsDefined((int)'\u6039'));
             assertTrue(Character.IsDefined(0x10300));
 
-#if FEATURE_ICU
+#if FEATURE_UNICODE_DEFINED_0x30000
             assertTrue(Character.IsDefined(0x30000)); // This character is now defined in .NET 5
 #else
             assertFalse(Character.IsDefined(0x30000));

--- a/tests/J2N.Tests/TestCharacter.cs
+++ b/tests/J2N.Tests/TestCharacter.cs
@@ -1990,7 +1990,7 @@ namespace J2N
             assertTrue(Character.GetType((int)'\u2029') == UnicodeCategory.ParagraphSeparator);
 
 #if FEATURE_UNICODE_DEFINED_0x9FFF
-            assertTrue(Character.GetType(0x9FFF) == UnicodeCategory.OtherLetter);
+            assertTrue(Character.GetType(0x9FFF) == UnicodeCategory.OtherLetter); // This character is now defined in .NET 8
 #else
             assertTrue(Character.GetType(0x9FFF) == UnicodeCategory.OtherNotAssigned);
 #endif


### PR DESCRIPTION
Fixes #94, Fixes #107, Fixes #108

This adds .NET 8 support and tests. This was a lot more work than previous SDK updates because of several issues:

1. The collection behavior changed in .NET 8, so much work was needed to normalize the behavior between .NET 8 and older .NET versions. `SortedSet<T>` and `SortedDictionary<T>` were updated to match the .NET 8 implementations, while other collections were patched but will still need to be reviewed.
2. The .NET 8 SDK no longer runs installs the bits to run the x86 tests and we needed custom scripts to manually install them because the Azure Pipelines task does not allow you to specify.
3. We had to change the testing targets for older platforms from `net461` > `net471` and `net451` > `net47` because they are no longer supported by the test adapter (which needed upgrading because .NET 8 doesn't support any of the older test adapters).
4. .NET 8 runs too slow to test `net40` (which is now run with `net47`) and it takes more than an hour to complete most of the time, which is longer than a job can run on Azure DevOps. So, the script was changed so that .NET 6 is installed instead of .NET 8 when running .NET Framework tests.
5. Test projects were changed to run in parallel to cut down on testing time.