### PR TITLE
Fix tests on macOS/arm64

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -29,7 +29,8 @@
       net47             | net40
 
     -->
-    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0;net48;net472;net471;net47</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48;net472;net471;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>
 

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -20,7 +20,7 @@ properties {
     [string]$minimumSdkVersion     = "8.0.100"
 
     #test parameters
-    [string]$testPlatforms         = ""
+    [string]$testPlatforms         = Get-DefaultPlatform # Pass a parameter (not a property) to override
 }
 
 $backedUpFiles = New-Object System.Collections.ArrayList
@@ -122,15 +122,6 @@ task Test -depends Pack -description "This task runs the tests" {
     $testProjects = $testProjects | Sort-Object -Property FullName
     Ensure-Directory-Exists $testResultsDirectory
 
-    if ([String]::IsNullOrWhiteSpace($testPlatforms)) {
-        $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-        $testPlatforms = switch ($architecture) {
-            "X64"  { "x64" }
-            "Arm64" { "arm64" }
-            Default { "x64" }
-        }
-    }
-
     foreach ($testProject in $testProjects) {
         $testName = $testProject.Directory.Name
     
@@ -210,4 +201,14 @@ function New-TemporaryDirectory {
 function Normalize-FileSystemSlashes([string]$path) {
     $sep = [System.IO.Path]::DirectorySeparatorChar
     return $($path -replace '/',$sep -replace '\\',$sep)
+}
+
+function Get-DefaultPlatform {
+    $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    $platform = switch ($architecture) {
+        "X64" { "x64"; break }
+        "Arm64" { "arm64"; break }
+        default { "x64" }
+    }
+    return $platform
 }

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -141,8 +141,8 @@ task Test -depends Pack -description "This task runs the tests" {
             foreach ($testPlatform in $testPlatformArray) {
 
                 if ([System.Runtime.InteropServices.RuntimeInformation]::OSDescription -match "Darwin" -and $testPlatform -eq "arm64" -and $framework -eq "net5.0") {
-                    Write-Host "Using x64 test platform on macOS for .NET 5" -ForegroundColor DarkYellow
-                    $testPlatform = "x64"
+                    Write-Host "Skipping '$framework' because it is not supportd on ARM64"
+                    continue
                 }
 
                 $testResultDirectory = "$testResultsDirectory/$framework/$testPlatform/$testName"
@@ -159,7 +159,7 @@ task Test -depends Pack -description "This task runs the tests" {
                     --results-directory "$testResultDirectory" `
                     --logger:"trx;LogFileName=$testResultsFileName" `
                     -- RunConfiguration.TargetPlatform=$testPlatform
-                #	--logger:"console;verbosity=normal"
+                #   --logger:"console;verbosity=normal"
             }
             Write-Host ""
             Write-Host "See the .trx logs in $(Normalize-FileSystemSlashes "$testResultsDirectory/$framework") for more details." -ForegroundColor DarkCyan

--- a/docs/building-and-testing.md
+++ b/docs/building-and-testing.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 3.0 or higher (see [this question](http://stackoverflow.com/questions/1825585/determine-installed-powershell-version) to check your PowerShell version)
+- [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 6.0 or higher (see [this question](http://stackoverflow.com/questions/1825585/determine-installed-powershell-version) to check your PowerShell version)
 - [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 
 ### Execution


### PR DESCRIPTION
Fixes test run issues:

- Only run .NET Framework tests on Windows
- Detect current architecture as default argument to build script
- Use x64 always on macOS .NET 5 tests, as there is no arm64 release of .NET 5 for macOS