### PR TITLE
Reverted breaking API changes for 2.1.0 so we don't have to bump to 3.0.0

### DIFF
--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -835,7 +835,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public KeyCollection Keys => _keys ??= new KeyCollection(this);
+        public ICollection<TKey> Keys => _keys ??= new KeyCollection(this);
 
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
@@ -854,7 +854,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public ValueCollection Values => _values ??= new ValueCollection(this);
+        public ICollection<TValue> Values => _values ??= new ValueCollection(this);
 
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
@@ -1404,7 +1404,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an O(1) operation.
         /// </remarks>
-        public Enumerator GetEnumerator() => new Enumerator(this, Enumerator.KeyValuePair);
+        public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => new Enumerator(this, Enumerator.KeyValuePair);
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() =>
             Count == 0 ? GenericEmptyEnumerator<KeyValuePair<TKey, TValue>>.Instance :
@@ -1418,9 +1418,9 @@ namespace J2N.Collections.Generic
 
         bool IDictionary.IsFixedSize => false;
 
-        ICollection IDictionary.Keys => Keys;
+        ICollection IDictionary.Keys => (ICollection)Keys;
 
-        ICollection IDictionary.Values => Values;
+        ICollection IDictionary.Values => (ICollection)Values;
 
         bool IDictionary.IsReadOnly => false;
 

--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -360,7 +360,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public KeyCollection Keys => _keys ??= new KeyCollection(this);
+        public ICollection<TKey> Keys => _keys ??= new KeyCollection(this);
 
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
 
@@ -384,7 +384,7 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// Getting the value of this property is an O(1) operation.
         /// </remarks>
-        public ValueCollection Values => _values ??= new ValueCollection(this);
+        public ICollection<TValue> Values => _values ??= new ValueCollection(this);
 
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
 
@@ -724,12 +724,12 @@ namespace J2N.Collections.Generic
 
         ICollection IDictionary.Keys
         {
-            get { return Keys; }
+            get { return (ICollection)Keys; }
         }
 
         ICollection IDictionary.Values
         {
-            get { return Values; }
+            get { return (ICollection)Values; }
         }
 
         object? IDictionary.this[object? key]
@@ -1038,7 +1038,7 @@ namespace J2N.Collections.Generic
 
             internal Enumerator(SortedDictionary<TKey, TValue> dictionary, int getEnumeratorRetType)
             {
-                _treeEnum = dictionary._set.GetEnumerator();
+                _treeEnum = dictionary._set.GetEnumeratorInternal();
                 _getEnumeratorRetType = getEnumeratorRetType;
             }
 

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -914,7 +914,9 @@ namespace J2N.Collections.Generic
         /// <para/>
         /// This method is an <c>O(log n)</c> operation.
         /// </remarks>
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public IEnumerator<T> GetEnumerator() => new Enumerator(this);
+
+        internal Enumerator GetEnumeratorInternal() => new Enumerator(this);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
@@ -1203,8 +1205,8 @@ namespace J2N.Collections.Generic
                 // First do a merge sort to an array.
                 T[] merged = new T[asSorted.Count + this.Count];
                 int c = 0;
-                Enumerator mine = this.GetEnumerator();
-                Enumerator theirs = asSorted.GetEnumerator();
+                IEnumerator<T> mine = this.GetEnumerator();
+                IEnumerator<T> theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
                 while (!mineEnded && !theirsEnded)
                 {
@@ -1359,8 +1361,8 @@ namespace J2N.Collections.Generic
                 // First do a merge sort to an array.
                 T[] merged = new T[this.Count];
                 int c = 0;
-                Enumerator mine = this.GetEnumerator();
-                Enumerator theirs = asSorted.GetEnumerator();
+                IEnumerator<T> mine = this.GetEnumerator();
+                IEnumerator<T> theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext(), theirsEnded = !theirs.MoveNext();
                 T? max = Max;
 
@@ -1782,8 +1784,8 @@ namespace J2N.Collections.Generic
             SortedSet<T>? asSorted = other as SortedSet<T>;
             if (asSorted != null && HasEqualComparer(asSorted))
             {
-                Enumerator mine = GetEnumerator();
-                Enumerator theirs = asSorted.GetEnumerator();
+                IEnumerator<T> mine = GetEnumerator();
+                IEnumerator<T> theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext();
                 bool theirsEnded = !theirs.MoveNext();
                 while (!mineEnded && !theirsEnded)

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
@@ -75,7 +75,7 @@ namespace J2N.Collections.Tests
 
         protected override ICollection NonGenericICollectionFactory()
         {
-            return new JCG.Dictionary<string, string>().Keys;
+            return (ICollection)new JCG.Dictionary<string, string>().Keys;
         }
 
         protected override ICollection NonGenericICollectionFactory(int count)
@@ -84,7 +84,7 @@ namespace J2N.Collections.Tests
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));
-            return list.Keys;
+            return (ICollection)list.Keys;
         }
 
         private string CreateT(int seed)

--- a/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+++ b/tests/J2N.Tests.xUnit/Collections/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
@@ -79,7 +79,7 @@ namespace J2N.Collections.Tests
 
         protected override ICollection NonGenericICollectionFactory()
         {
-            return new JCG.Dictionary<string, string>().Values;
+            return (ICollection)new JCG.Dictionary<string, string>().Values;
         }
 
         protected override ICollection NonGenericICollectionFactory(int count)
@@ -88,7 +88,7 @@ namespace J2N.Collections.Tests
             int seed = 13453;
             for (int i = 0; i < count; i++)
                 list.Add(CreateT(seed++), CreateT(seed++));
-            return list.Values;
+            return (ICollection)list.Values;
         }
 
         private string CreateT(int seed)


### PR DESCRIPTION
Removed breaking binary API changes for `Dictionary<TKey, TValue>`, `SortedDictionary<TKey, TValue>`, and `SortedSet<T>`. This commit will need to be reverted in a major version bump to match the BCL APIs.