### PR TITLE
Added net9.0 target + tests

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -20,16 +20,16 @@
     <!-- Test Client to DLL target works as follows:
 
       Test Client       | Target Under Test
+      net9.0            | net9.0
       net8.0            | net8.0
-      net6.0            | net6.0
-      net5.0            | netstandard2.1
+      net6.0            | netstandard2.1
       net48             | net462
       net472            | net45
       net471            | netstandard2.0
       net47             | net40
 
     -->
-    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net8.0;net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' ">net9.0;net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(TestAllTargetFrameworks)' == 'true' AND $([MSBuild]::IsOsPlatform('Windows')) ">$(TargetFrameworks);net48;net472;net471;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
   </PropertyGroup>

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -153,7 +153,7 @@ steps:
     function RunTests([string]$framework, [string]$fileRegexPattern) {
         if (!(IsSupportedFramework($framework))) { return }
         
-        $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework"} | Where-Object {$_.FullName -match "$fileRegexPattern"} | Select -ExpandProperty FullName | Sort-Object -Descending
+        $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework"} | Where-Object {$_.FullName -match "$fileRegexPattern"} | Sort-Object @{ Expression = { $_.Name }; Descending = $true } | Select -ExpandProperty FullName
         foreach ($testBinary in $testBinaries) {
             $testName = [System.IO.Path]::GetFileNameWithoutExtension($testBinary)
             

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -58,7 +58,7 @@ steps:
     sdkVersion: '$(DotNetSdkVersion)'
     performMultiLevelLookup: '$(PerformMultiLevelLookup)'
 
-    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
     # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
     # This code only works on Windows.
@@ -73,22 +73,47 @@ steps:
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
   displayName: 'Use .NET SDK $(DotNetSdkVersion) (x86)'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net9.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 8.0.404'
+  inputs:
+    packageType: 'sdk'
+    version: '8.0.404'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net8.'))
+
+    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '8.0.404'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK 8.0.404 (x86)'
   condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK 6.0.421'
+  displayName: 'Use .NET SDK 6.0.428'
   inputs:
     packageType: 'sdk'
-    version: '6.0.421'
+    version: '6.0.428'
     performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net6.'))
 
-    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
     # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
     # This code only works on Windows.
 - pwsh: |
-    $sdkVersion = '6.0.421'
+    $sdkVersion = '6.0.428'
     $architecture = '${{ parameters.vsTestPlatform }}'
     $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
     $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
@@ -97,33 +122,8 @@ steps:
     $installPath = "${env:ProgramFiles(x86)}/dotnet"
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
-  displayName: 'Use .NET SDK 6.0.421 (x86)'
+  displayName: 'Use .NET SDK 6.0.428 (x86)'
   condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net6.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
-
-- task: UseDotNet@2
-  displayName: 'Use .NET SDK 5.0.408'
-  inputs:
-    packageType: 'sdk'
-    version: '5.0.408'
-    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
-  condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net5.'))
-
-    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
-    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
-    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
-    # This code only works on Windows.
-- pwsh: |
-    $sdkVersion = '5.0.408'
-    $architecture = '${{ parameters.vsTestPlatform }}'
-    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
-    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
-    $installPath = "${env:ProgramFiles(x86)}/dotnet"
-    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
-    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
-  displayName: 'Use .NET SDK 5.0.408 (x86)'
-  condition: and(succeeded(), contains('${{ parameters.testTargetFramework }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: DownloadPipelineArtifact@2
   displayName: 'Download Pipeline Artifacts: ${{ parameters.binaryArtifactName }}'
@@ -151,7 +151,7 @@ steps:
     }
     
     function RunTests([string]$framework, [string]$fileRegexPattern) {
-        if (!(IsSupportedFramework($framework))) { continue }
+        if (!(IsSupportedFramework($framework))) { return }
         
         $testBinaries = Get-ChildItem -Path "$testBinaryRootDirectory" -File -Recurse | Where-Object {$_.FullName -match "$framework"} | Where-Object {$_.FullName -match "$fileRegexPattern"} | Select -ExpandProperty FullName | Sort-Object -Descending
         foreach ($testBinary in $testBinaries) {

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -17,7 +17,7 @@ properties {
     [string]$configuration         = "Release"
     [string]$platform              = "Any CPU"
     [bool]$backupFiles             = $true
-    [string]$minimumSdkVersion     = "8.0.100"
+    [string]$minimumSdkVersion     = "9.0.100"
 
     #test parameters
     [string]$testPlatforms         = Get-DefaultPlatform # Pass a parameter (not a property) to override

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,8 +12,8 @@
     <PublishDir Condition="'$(AlternatePublishRootDirectory)' != ''">$(AlternatePublishRootDirectory)/$(TargetFramework)/$(MSBuildProjectName)/</PublishDir>
   </PropertyGroup>
 
-  <!-- Features in .NET Standard, .NET Core, .NET 5.x, .NET 6.x, and .NET 8.x only (no .NET Framework support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Standard, .NET Core, .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x only (no .NET Framework support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
@@ -27,27 +27,27 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <!-- Features in .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET 8.x and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x9FFF</DefineConstants>
+    <!-- J2N NOTE: This is technically supported in .NET 6.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
+    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_GETCHUNKS</DefineConstants>
     
   </PropertyGroup>
 
-  <!-- Features in .NET 6.x and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET 6.x, .NET 8.x and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_ARRAY_CLEAR_ARRAY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTINT64</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOM_NEXTSINGLE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_READONLYSET</DefineConstants>
-    <!-- J2N NOTE: This is technically supported in .NET 5.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
-    <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_GETCHUNKS</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET 5.x, .NET 6.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_PREDEFINEDONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_HASHSET_MODIFY_CONTINUEENUMERATION</DefineConstants>
@@ -56,16 +56,16 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_COLLECTIONSMARSHAL_ASSPAN_LIST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMERICBITOPERATIONS</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Standard 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x only -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <!-- Features in .NET Standard 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x only -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_CTOR_READONLYSPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
@@ -91,20 +91,25 @@
     <DefineConstants>$(DefineConstants);FEATURE_UNSAFE_NULLREF</DefineConstants>
 
   </PropertyGroup>
-
-  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 8.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
-
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
+  
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
     
-    <!-- serializable exeptions were added back in .NET Core 2.0.4: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#net-core -->
-    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
-
     <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
         To add it to the build, just add /p:IncludeICloneable to the command line. -->
     <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
+    
   </PropertyGroup>
 
+  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x (No .NET 9+ support) -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
+    <!-- serializable exeptions were added back in .NET Core 2.0.4: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#net-core -->
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>
+    
+  </PropertyGroup>
+  
   <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, and .NET 6.x (No .NET 8+ support) -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">
 
@@ -170,7 +175,7 @@
 
   <PropertyGroup>
     <!-- Disable warnings for out of support frameworks that we use for testing .NET Standard -->
-    <CheckEolTargetFramework Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) ">false</CheckEolTargetFramework>
+    <CheckEolTargetFramework Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) ">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <Target Name="AddInternalsVisibleTo" BeforeTargets="BeforeCompile" Label="Adds InternalsVisibleTo Attribute and PublicKey (if supplied)">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,9 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net8.0;net6.0;net5.0;net48;net472;net471;net47'
+  value: 'net9.0;net8.0;net6.0;net48;net472;net471;net47'
 - name: DotNetSDKVersion
-  value: '8.0.401'
+  value: '9.0.100'
 - name: BinaryArtifactName
   value: 'testbinaries'
 - name: NuGetArtifactName
@@ -233,6 +233,56 @@ stages:
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
+  - job: Test_net9_0_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net9.0,x64 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFramework: 'net9.0'
+        vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net9_0_x86 # Only run if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net9.0,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFramework: 'net9.0'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
   - job: Test_net8_0_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
     strategy:
@@ -328,56 +378,6 @@ stages:
       parameters:
         osName: $(osName)
         testTargetFramework: 'net6.0'
-        vsTestPlatform: 'x86'
-        testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumAllowedFailures: $(maximumAllowedFailures)
-        dotNetSdkVersion: '$(DotNetSDKVersion)'
-
-  - job: Test_net5_0_x64
-    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    strategy:
-      matrix:
-        Windows:
-          osName: 'Windows'
-          imageName: 'windows-latest'
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        Linux:
-          osName: 'Linux'
-          imageName: 'ubuntu-22.04' # 24.04 now fails for net5.0 because of OpenSLL version issue, so we have to pin this.
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-        macOS:
-          osName: 'macOS'
-          imageName: 'macOS-latest'
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net5.0,x64 on'
-    pool:
-      vmImage: $(imageName)
-    steps:
-    - template: '.build/azure-templates/run-tests-on-os.yml'
-      parameters:
-        osName: $(osName)
-        testTargetFramework: 'net5.0'
-        vsTestPlatform: 'x64'
-        testResultsArtifactName: '$(TestResultsArtifactName)'
-        maximumAllowedFailures: $(maximumAllowedFailures)
-        dotNetSdkVersion: '$(DotNetSDKVersion)'
-
-  - job: Test_net5_0_x86 # Only run if explicitly enabled with RunX86Tests
-    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
-    strategy:
-      matrix:
-        Windows:
-          osName: 'Windows'
-          imageName: 'windows-latest'
-          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net5.0,x86 on'
-    pool:
-      vmImage: $(imageName)
-    steps:
-    - template: '.build/azure-templates/run-tests-on-os.yml'
-      parameters:
-        osName: $(osName)
-        testTargetFramework: 'net5.0'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: $(maximumAllowedFailures)

--- a/src/J2N/J2N.csproj
+++ b/src/J2N/J2N.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -265,8 +265,10 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this char[]? str, ReadOnlySpan<char> value)
         {
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
             if (str is null) return (value == default) ? 0 : -1;
             if (value == default) return 1;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             unsafe
             {

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -697,8 +697,10 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this StringBuilder? text, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
             if (text is null) return (value == default) ? 0 : -1;
             if (value == default) return 1;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             unsafe
             {

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -220,8 +220,10 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this string? str, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
             if (str is null) return (value == default) ? 0 : -1;
             if (value == default) return 1;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             unsafe
             {
@@ -398,8 +400,10 @@ namespace J2N.Text
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
             if (text is null)
                 return charSequence == default;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             int len = charSequence.Length;
             if (len != text.Length)
@@ -551,8 +555,10 @@ namespace J2N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
             if (text is null)
                 return charSequence == default;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             int len = charSequence.Length;
             if (len != text.Length)

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -101,16 +101,13 @@
   <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
     <PropertyGroup>
       <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
-      <DotNet_8_0_OrGreater>false</DotNet_8_0_OrGreater>
-      <DotNet_8_0_OrGreater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ($(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or ($(TargetFramework.StartsWith('net')) And $(TargetFramework.IndexOf('.')) > 4))">true</DotNet_8_0_OrGreater>
     </PropertyGroup>
 
-    <!-- Example usage -->
     <UpdateRuntimeConfigProperty 
         RuntimeConfigFile="$(RuntimeConfigFile)" 
         PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" 
         PropertyValue="true" 
-        Condition="Exists('$(RuntimeConfigFile)') And '$(DotNet_8_0_OrGreater)' == 'true'" />
+        Condition="Exists('$(RuntimeConfigFile)') And '$(TargetFramework)' == 'net8.0'" />
   </Target>
   
 </Project>

--- a/tests/NUnit/J2N.TestFramework/J2N.TestFramework.csproj
+++ b/tests/NUnit/J2N.TestFramework/J2N.TestFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.1;netstandard2.0;net462;net45;net40</TargetFrameworks>
     <RootNamespace>J2N</RootNamespace>
 
     <IsTestProject>false</IsTestProject>

--- a/tests/NUnit/J2N.Tests/J2N.Tests.csproj
+++ b/tests/NUnit/J2N.Tests/J2N.Tests.csproj
@@ -15,7 +15,7 @@
 
   <Import Project="..\..\SystemMemoryReferenceOverride.targets" />
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageReferenceVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #119.

- Added target and tests for `net9.0`
- Removed target for `net6.0`
- Changed to use `net6.0` as the target to test `netstandard2.1`
- Fixed sort order for tests so `J2N.Tests.dll` runs first
- Removed support for binary serialization in `net9.0` (it is deprecated in `net8.0` and lower)
- Suppressed CA2265 build warnings, since we intend to compare against a default `ReadOnlySpan<char>` instance rather than empty.
- Changed publish output to publish each project to an individual directory