### PR TITLE
CA2265: Do not use a `default(ReadOnlySpan<char>)` to compare against `null`

### DIFF
--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -265,10 +265,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this char[]? str, ReadOnlySpan<char> value)
         {
-#pragma warning disable CA2265 // Do not compare Span<T> to null or default
-            if (str is null) return (value == default) ? 0 : -1;
-            if (value == default) return 1;
-#pragma warning restore CA2265 // Do not compare Span<T> to null or default
+            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (str is null) return -1;
 
             unsafe
             {

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -19,6 +19,7 @@
 using J2N.Buffers;
 using System;
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -277,6 +278,7 @@ namespace J2N.Text
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe static int CompareToOrdinalCore(char[] str, char* value, int valueLength)
         {
             int length = Math.Min(str.Length, valueLength);

--- a/src/J2N/Text/CharArrayExtensions.cs
+++ b/src/J2N/Text/CharArrayExtensions.cs
@@ -265,8 +265,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this char[]? str, ReadOnlySpan<char> value)
         {
-            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
-            if (str is null) return -1;
+            // J2N: Only consider whether the right side is empty if the left side is null. This is the equivalent of calling str.AsSpan() and then doing the comparison. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (str is null) return value.IsEmpty ? 0 : -1;
 
             unsafe
             {

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -697,10 +697,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this StringBuilder? text, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-#pragma warning disable CA2265 // Do not compare Span<T> to null or default
-            if (text is null) return (value == default) ? 0 : -1;
-            if (value == default) return 1;
-#pragma warning restore CA2265 // Do not compare Span<T> to null or default
+            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (text is null) return -1;
 
             unsafe
             {

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -709,6 +709,7 @@ namespace J2N.Text
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe static int CompareToOrdinalCore(StringBuilder text, char* value, int valueLength)
         {
             int length = Math.Min(text.Length, valueLength);

--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -697,8 +697,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this StringBuilder? text, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
-            if (text is null) return -1;
+            // J2N: Only consider whether the right side is empty if the left side is null. This is the equivalent of calling text.AsSpan() and then doing the comparison. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (text is null) return value.IsEmpty ? 0 : -1;
 
             unsafe
             {

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -232,6 +232,7 @@ namespace J2N.Text
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe static int CompareToOrdinalCore(string str, char* value, int valueLength)
         {
             int length = Math.Min(str.Length, valueLength);

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -220,8 +220,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this string? str, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
-            if (str is null) return -1;
+            // J2N: Only consider whether the right side is empty if the left side is null. This is the equivalent of calling str.AsSpan() and then doing the comparison. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (str is null) return value.IsEmpty ? 0 : -1;
 
             unsafe
             {
@@ -398,8 +398,10 @@ namespace J2N.Text
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
-            if (text is null) return false;
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
+            if (text is null)
+                return charSequence == default;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             int len = charSequence.Length;
             if (len != text.Length)
@@ -551,8 +553,10 @@ namespace J2N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
-            if (text is null) return false;
+#pragma warning disable CA2265 // Do not compare Span<T> to null or default
+            if (text is null)
+                return charSequence == default;
+#pragma warning restore CA2265 // Do not compare Span<T> to null or default
 
             int len = charSequence.Length;
             if (len != text.Length)

--- a/src/J2N/Text/StringExtensions.cs
+++ b/src/J2N/Text/StringExtensions.cs
@@ -220,10 +220,8 @@ namespace J2N.Text
         /// </returns>
         public static int CompareToOrdinal(this string? str, ReadOnlySpan<char> value) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-#pragma warning disable CA2265 // Do not compare Span<T> to null or default
-            if (str is null) return (value == default) ? 0 : -1;
-            if (value == default) return 1;
-#pragma warning restore CA2265 // Do not compare Span<T> to null or default
+            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (str is null) return -1;
 
             unsafe
             {
@@ -400,10 +398,8 @@ namespace J2N.Text
         /// sequence of characters as the specified <paramref name="charSequence"/>; otherwise, <c>false</c>.</returns>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-#pragma warning disable CA2265 // Do not compare Span<T> to null or default
-            if (text is null)
-                return charSequence == default;
-#pragma warning restore CA2265 // Do not compare Span<T> to null or default
+            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (text is null) return false;
 
             int len = charSequence.Length;
             if (len != text.Length)
@@ -555,10 +551,8 @@ namespace J2N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="comparisonType"/> is not a <see cref="StringComparison"/> value.</exception>
         public static bool ContentEquals(this string? text, ReadOnlySpan<char> charSequence, StringComparison comparisonType) // KEEP OVERLOADS FOR ReadOnlySpan<char>, ICharSequence, char[], StringBuilder, and string IN SYNC
         {
-#pragma warning disable CA2265 // Do not compare Span<T> to null or default
-            if (text is null)
-                return charSequence == default;
-#pragma warning restore CA2265 // Do not compare Span<T> to null or default
+            // J2N: Compare null only on the left side. When value == default, we treat it as empty. See: https://github.com/NightOwl888/J2N/pull/122#discussion_r1850836158
+            if (text is null) return false;
 
             int len = charSequence.Length;
             if (len != text.Length)


### PR DESCRIPTION
Do not use a default(ReadOnlySpan<char>) to compare against null. Instead, treat default(ReadOnlySpan<char>) as if it were empty. (fixes #123)

NOTE: We may need to change this to target a release branch for 3.0.