### PR TITLE
Fixed issue with non-hyphen negative signs in exp notation, #128

### DIFF
--- a/src/J2N/Numerics/RyuDouble.cs
+++ b/src/J2N/Numerics/RyuDouble.cs
@@ -1216,7 +1216,11 @@ namespace J2N.Numerics
                 result[index++] = upperCase ? 'E' : 'e';
                 if (exp < 0)
                 {
-                    result[index++] = '-';
+                    foreach (var nc in negSign)
+                    {
+                        result[index++] = nc;
+                    }
+
                     exp = -exp;
                 }
                 if (exp >= 100)

--- a/src/J2N/Numerics/RyuSingle.cs
+++ b/src/J2N/Numerics/RyuSingle.cs
@@ -491,7 +491,10 @@ namespace J2N.Numerics
                 result[index++] = upperCase ? 'E' : 'e';
                 if (exp < 0)
                 {
-                    result[index++] = '-';
+                    foreach (var nc in negSign)
+                    {
+                        result[index++] = nc;
+                    }
                     exp = -exp;
                 }
                 if (exp >= 10)

--- a/tests/NUnit/J2N.Tests/Numerics/TestDouble.cs
+++ b/tests/NUnit/J2N.Tests/Numerics/TestDouble.cs
@@ -4583,5 +4583,26 @@ namespace J2N.Numerics
             #endregion TryParse_CharSequence_Double
 
         }
+
+        // J2N specific - GitHub issue #128
+        [Test]
+        public void Issue128_UnicodeMinusSignExponentialNotation()
+        {
+            // Some cultures (such as sv-FI) use a Unicode minus sign (U+2212) instead of the ASCII hyphen-minus (U+002D) as the negative sign.
+            // Previously, the formatter was using a hyphen as the negative sign, which caused parsing to fail when the culture used a different character.
+            // This test verifies that the parser can handle Unicode minus signs in exponential notation, as well as i.e. decimal commas.
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                double d = 6.815791e-4d; // small value that gets formatted as exponential notation
+
+                string formatted = Double.ToString(d, culture);
+
+                assertEquals($"6{culture.NumberFormat.NumberDecimalSeparator}815791E{culture.NumberFormat.NegativeSign}4", formatted);
+
+                double parsed = Double.Parse(formatted, culture);
+
+                assertEquals(d, parsed, 0.1e-10d);
+            }
+        }
     }
 }

--- a/tests/NUnit/J2N.Tests/Numerics/TestSingle.cs
+++ b/tests/NUnit/J2N.Tests/Numerics/TestSingle.cs
@@ -3212,5 +3212,26 @@ namespace J2N.Numerics
 
             #endregion TryParse_CharSequence_Single
         }
+
+        // J2N specific - GitHub issue #128
+        [Test]
+        public void Issue128_UnicodeMinusSignExponentialNotation()
+        {
+            // Some cultures (such as sv-FI) use a Unicode minus sign (U+2212) instead of the ASCII hyphen-minus (U+002D) as the negative sign.
+            // Previously, the formatter was using a hyphen as the negative sign, which caused parsing to fail when the culture used a different character.
+            // This test verifies that the parser can handle Unicode minus signs in exponential notation, as well as i.e. decimal commas.
+            foreach (var culture in CultureInfo.GetCultures(CultureTypes.SpecificCultures))
+            {
+                float f = 6.815791e-4f; // small value that gets formatted as exponential notation
+
+                string formatted = Single.ToString(f, culture);
+
+                assertEquals($"6{culture.NumberFormat.NumberDecimalSeparator}815791E{culture.NumberFormat.NegativeSign}4", formatted);
+
+                double parsed = Single.Parse(formatted, culture);
+
+                assertEquals(f, parsed, 0.1e-10f);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #128