### PR TITLE
Added Span Support to J2N.IO Buffers

### DIFF
--- a/src/J2N/IO/Buffer.cs
+++ b/src/J2N/IO/Buffer.cs
@@ -68,6 +68,8 @@ namespace J2N.IO
     /// </summary>
     public abstract class Buffer
     {
+        internal const int ByteStackBufferSize = 128;
+
         /// <summary>
         /// <c>UnsetMark</c> means the mark has not been set.
         /// </summary>

--- a/src/J2N/IO/CharArrayBuffer.cs
+++ b/src/J2N/IO/CharArrayBuffer.cs
@@ -88,6 +88,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override CharBuffer Get(Span<char> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         //public override sealed bool IsDirect => false;
 
         public override sealed ByteOrder Order => ByteOrder.NativeOrder;

--- a/src/J2N/IO/CharBuffer.cs
+++ b/src/J2N/IO/CharBuffer.cs
@@ -181,7 +181,7 @@ namespace J2N.IO
         {
             if (characterSequence is null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.characterSequence);
-            return new CharSequenceAdapter(characterSequence.AsCharSequence()); // J2N TODO: Create StringBuilderAdapter?
+            return new StringBuilderAdapter(characterSequence);
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace J2N.IO
             if (startIndex > characterSequence.Length - length) // Checks for int overflow
                 ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(startIndex, length);
 
-            return new CharSequenceAdapter(characterSequence.AsCharSequence()) // J2N TODO: Create StringAdapter?
+            return new StringBuilderAdapter(characterSequence)
             {
                 position = startIndex,
                 limit = startIndex + length
@@ -239,8 +239,14 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="characterSequence"/> is <c>null</c>.</exception>
         public static CharBuffer Wrap(ICharSequence characterSequence)
         {
-            if (characterSequence is null)
+            if (characterSequence is null || !characterSequence.HasValue)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.characterSequence);
+
+            if (characterSequence is StringBuilderCharSequence sb)
+            {
+                return new StringBuilderAdapter(sb.Value!);
+            }
+
             return new CharSequenceAdapter(characterSequence);
         }
 
@@ -270,7 +276,7 @@ namespace J2N.IO
         /// <exception cref="ArgumentNullException">If <paramref name="characterSequence"/> is <c>null</c>.</exception>
         public static CharBuffer Wrap(ICharSequence characterSequence, int startIndex, int length)
         {
-            if (characterSequence is null)
+            if (characterSequence is null || !characterSequence.HasValue)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.characterSequence);
             if (startIndex < 0)
                 ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(startIndex, ExceptionArgument.startIndex);
@@ -278,6 +284,11 @@ namespace J2N.IO
                 ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(length, ExceptionArgument.length);
             if (startIndex > characterSequence.Length - length) // Checks for int overflow
                 ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(startIndex, length);
+
+            if (characterSequence is StringBuilderCharSequence sb)
+            {
+                return new StringBuilderAdapter(sb.Value!);
+            }
 
             return new CharSequenceAdapter(characterSequence)
             {

--- a/src/J2N/IO/CharBuffer.cs
+++ b/src/J2N/IO/CharBuffer.cs
@@ -16,8 +16,10 @@
  */
 #endregion
 
+using J2N.Buffers;
 using J2N.Text;
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -364,6 +366,8 @@ namespace J2N.IO
         /// <returns>A negative value if this is less than <paramref name="other"/>; 0 if
         /// this equals to <paramref name="other"/>; a positive valie if this is
         /// greater than <paramref name="other"/>.</returns>
+        /// <remarks>Note to inheritors: This implementation reads chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public virtual int CompareTo(CharBuffer? other)
         {
             if (other is null) return 1; // Using 1 if other is null as specified here: https://stackoverflow.com/a/4852537
@@ -414,6 +418,8 @@ namespace J2N.IO
         /// </summary>
         /// <param name="other">The object to compare with this char buffer.</param>
         /// <returns><c>true</c> if this char buffer is equal to <paramref name="other"/>, <c>false</c> otherwise.</returns>
+        /// <remarks>Note to inheritors: This implementation reads chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public override bool Equals(object? other)
         {
             if (other is null || !(other is CharBuffer otherBuffer))
@@ -472,6 +478,8 @@ namespace J2N.IO
         /// <param name="length">The number of chars to read, must be no less than zero and no
         /// greater than <c>destination.Length - offset</c>.</param>
         /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation reads chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> plus <paramref name="length"/> indicates a position not within this instance.
         /// <para/>
@@ -497,6 +505,33 @@ namespace J2N.IO
                 throw new BufferUnderflowException();
             }
             for (int i = offset; i < offset + length; i++)
+            {
+                destination[i] = Get();
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Reads chars from the current position into the specified span,
+        /// and increases the position by the number of chars read.
+        /// <para/>
+        /// The <see cref="Span{Char}.Length"/> property is used to determine
+        /// how many chars to read.
+        /// </summary>
+        /// <param name="destination">The target span, sliced to the proper position, if necessary.</param>
+        /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation reads chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
+        /// <exception cref="BufferUnderflowException">If <see cref="Span{Char}.Length"/> is greater than
+        /// <see cref="Buffer.Remaining"/>.</exception>
+        public virtual CharBuffer Get(Span<char> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+            {
+                throw new BufferUnderflowException();
+            }
+            for (int i = 0; i < length; i++)
             {
                 destination[i] = Get();
             }
@@ -530,6 +565,8 @@ namespace J2N.IO
         /// position, limit, capacity and mark don't affect the hash code.
         /// </summary>
         /// <returns>The hash code calculated from the remaining chars.</returns>
+        /// <remarks>Note to inheritors: This implementation reads chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public override int GetHashCode()
         {
             int myPosition = position;
@@ -624,6 +661,8 @@ namespace J2N.IO
         /// <param name="length">The number of chars to write, must be no less than zero and no
         /// greater than <c>source.Length - offset</c>.</param>
         /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation writes chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than <paramref name="length"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> plus <paramref name="length"/> indicates a position not within this instance.
@@ -657,6 +696,32 @@ namespace J2N.IO
         }
 
         /// <summary>
+        /// Writes chars in the given span to the current position and increases the
+        /// position by the number of chars written.
+        /// <para/>
+        /// Calling this method has a similar effect as
+        /// <c>Put(source, 0, source.Length)</c>.
+        /// </summary>
+        /// <param name="source">The source span.</param>
+        /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation writes chars one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
+        /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than <c>source.Length</c>.</exception>
+        /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
+        public virtual CharBuffer Put(ReadOnlySpan<char> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            for (int i = 0; i < length; i++)
+            {
+                Put(source[i]);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Writes all the remaining chars of the <paramref name="source"/> char buffer to this
         /// buffer's current position, and increases both buffers' position by the
         /// number of chars copied.
@@ -678,10 +743,21 @@ namespace J2N.IO
             if (IsReadOnly)
                 throw new ReadOnlyBufferException(); // J2N: Harmony has a bug - it shouldn't read the source and change its position unless this buffer is writable
 
-            char[] contents = new char[source.Remaining];
-            source.Get(contents);
-            Put(contents);
-            return this;
+            int length = source.Remaining;
+            char[]? arrayToReturnToPool = null;
+            Span<char> contents = length * sizeof(char) > ByteStackBufferSize
+                ? (arrayToReturnToPool = ArrayPool<char>.Shared.Rent(length)).AsSpan(0, length)
+                : stackalloc char[length];
+            try
+            {
+                source.Get(contents);
+                Put(contents);
+                return this;
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.ReturnIfNotNull(arrayToReturnToPool);
+            }
         }
 
         /// <summary>

--- a/src/J2N/IO/CharSequenceAdapter.cs
+++ b/src/J2N/IO/CharSequenceAdapter.cs
@@ -92,7 +92,19 @@ namespace J2N.IO
                 throw new BufferUnderflowException();
 
             int newPosition = position + length;
-            sequence.ToString().CopyTo(position, destination, offset, length);
+            sequence.ToString().CopyTo(position, destination, offset, length); // J2N TODO: Create specialized adapter for StringBuilder as a separate class and then loop through the indexer here
+            position = newPosition;
+            return this;
+        }
+
+        public override CharBuffer Get(Span<char> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            int newPosition = position + length;
+            sequence.ToString().AsSpan(position, length).CopyTo(destination); // J2N TODO: Create specialized adapter for StringBuilder as a separate class and then loop through the indexer here
             position = newPosition;
             return this;
         }

--- a/src/J2N/IO/CharToByteBufferAdapter.cs
+++ b/src/J2N/IO/CharToByteBufferAdapter.cs
@@ -161,6 +161,8 @@ namespace J2N.IO
             return byteBuffer.GetChar(index << 1);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to chars and override Get(Span<char>)
+
         //public override bool IsDirect => byteBuffer.IsDirect;
 
         public override bool IsReadOnly => byteBuffer.IsReadOnly;
@@ -198,6 +200,8 @@ namespace J2N.IO
             byteBuffer.PutChar(index << 1, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from chars and override Put(ReadOnlySpan<char>)
 
         public override CharBuffer Slice()
         {

--- a/src/J2N/IO/DoubleArrayBuffer.cs
+++ b/src/J2N/IO/DoubleArrayBuffer.cs
@@ -87,6 +87,16 @@ namespace J2N.IO
             return this;
         }
 
+        public override DoubleBuffer Get(Span<double> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
 
         //public override sealed bool IsDirect => false;
 

--- a/src/J2N/IO/DoubleToByteBufferAdapter.cs
+++ b/src/J2N/IO/DoubleToByteBufferAdapter.cs
@@ -153,6 +153,8 @@ namespace J2N.IO
             return byteBuffer.GetDouble(index << 3);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to doubles and override Get(Span<double>)
+
         //public override bool IsDirect => byteBuffer.IsDirect;
 
         public override bool IsReadOnly => byteBuffer.IsReadOnly;
@@ -190,6 +192,8 @@ namespace J2N.IO
             byteBuffer.PutDouble(index << 3, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from doubles and override Put(ReadOnlySpan<double>)
 
         public override DoubleBuffer Slice()
         {

--- a/src/J2N/IO/HeapByteBuffer.cs
+++ b/src/J2N/IO/HeapByteBuffer.cs
@@ -83,6 +83,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override sealed ByteBuffer Get(Span<byte> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         public override sealed byte Get()
         {
             if (position == limit)

--- a/src/J2N/IO/Int16ArrayBuffer.cs
+++ b/src/J2N/IO/Int16ArrayBuffer.cs
@@ -86,6 +86,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override sealed Int16Buffer Get(Span<short> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         //public override sealed bool IsDirect => false;
 
         public override sealed ByteOrder Order => ByteOrder.NativeOrder;

--- a/src/J2N/IO/Int16Buffer.cs
+++ b/src/J2N/IO/Int16Buffer.cs
@@ -16,7 +16,9 @@
  */
 #endregion
 
+using J2N.Buffers;
 using System;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
@@ -162,6 +164,8 @@ namespace J2N.IO
         /// <returns>A negative value if this is less than <paramref name="other"/>; 0 if
         /// this equals to <paramref name="other"/>; a positive value if this is
         /// greater than <paramref name="other"/>.</returns>
+        /// <remarks>Note to inheritors: This implementation reads <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public virtual int CompareTo(Int16Buffer? other)
         {
             if (other is null) return 1; // Using 1 if other is null as specified here: https://stackoverflow.com/a/4852537
@@ -212,6 +216,8 @@ namespace J2N.IO
         /// </summary>
         /// <param name="other">The object to compare with this <see cref="Int16Buffer"/>.</param>
         /// <returns><c>true</c> if this <see cref="Int16Buffer"/> is equal to <paramref name="other"/>, <c>false</c> otherwise.</returns>
+        /// <remarks>Note to inheritors: This implementation reads <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public override bool Equals(object? other)
         {
             if (other is null || !(other is Int16Buffer otherBuffer))
@@ -272,6 +278,8 @@ namespace J2N.IO
         /// <param name="length">The number of <see cref="short"/>s to read, must be no less than zero and
         /// not greater than <c>destination.Length - offset</c>.</param>
         /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation reads <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> plus <paramref name="length"/> indicates a position not within this instance.
         /// <para/>
@@ -302,6 +310,33 @@ namespace J2N.IO
         }
 
         /// <summary>
+        /// Reads <see cref="short"/>s from the current position into the specified span,
+        /// and increases the position by the number of <see cref="short"/>s read.
+        /// <para/>
+        /// The <see cref="Span{Int16}.Length"/> property is used to determine
+        /// how many <see cref="short"/>s to read.
+        /// </summary>
+        /// <param name="destination">The target span, sliced to the proper position, if necessary.</param>
+        /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation reads <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
+        /// <exception cref="BufferUnderflowException">If <see cref="Span{Int16}.Length"/> is greater than
+        /// <see cref="Buffer.Remaining"/>.</exception>
+        public virtual Int16Buffer Get(Span<short> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+            {
+                throw new BufferUnderflowException();
+            }
+            for (int i = 0; i < length; i++)
+            {
+                destination[i] = Get();
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Returns the <see cref="short"/> at the specified <paramref name="index"/>; the position is not changed.
         /// </summary>
         /// <param name="index">The index, must not be negative and less than limit.</param>
@@ -323,6 +358,8 @@ namespace J2N.IO
         /// position, limit, capacity and mark don't affect the hash code.
         /// </summary>
         /// <returns>The hash code calculated from the remaining <see cref="short"/>s.</returns>
+        /// <remarks>Note to inheritors: This implementation reads <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         public override int GetHashCode()
         {
             int myPosition = position;
@@ -414,6 +451,8 @@ namespace J2N.IO
         /// <param name="length">The number of <see cref="short"/>s to write, must be no less than zero and
         /// not greater than <c>source.Length - offset</c>.</param>
         /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation writes <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
         /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/>is less than <paramref name="length"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="offset"/> plus <paramref name="length"/> indicates a position not within this instance.
@@ -445,6 +484,32 @@ namespace J2N.IO
         }
 
         /// <summary>
+        /// Writes <see cref="short"/>s in the given span to the current position and increases the
+        /// position by the number of <see cref="short"/>s written.
+        /// <para/>
+        /// Calling this method has a similar effect as
+        /// <c>Put(source, 0, source.Length)</c>.
+        /// </summary>
+        /// <param name="source">The source span.</param>
+        /// <returns>This buffer.</returns>
+        /// <remarks>Note to inheritors: This implementation writes <see cref="short"/>s one at a time and it is highly
+        /// recommended to override to provide a more optimized implementation.</remarks>
+        /// <exception cref="BufferOverflowException">If <see cref="Buffer.Remaining"/> is less than <c>source.Length</c>.</exception>
+        /// <exception cref="ReadOnlyBufferException">If no changes may be made to the contents of this buffer.</exception>
+        public virtual Int16Buffer Put(ReadOnlySpan<short> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            for (int i = 0; i < length; i++)
+            {
+                Put(source[i]);
+            }
+            return this;
+        }
+
+        /// <summary>
         /// Writes all the remaining <see cref="short"/>s of the <paramref name="source"/> <see cref="Int16Buffer"/> to this
         /// buffer's current position, and increases both buffers' position by the
         /// number of <see cref="short"/>s copied.
@@ -466,10 +531,21 @@ namespace J2N.IO
             if (IsReadOnly)
                 throw new ReadOnlyBufferException(); // J2N: Harmony has a bug - it shouldn't read the source and change its position unless this buffer is writable
 
-            short[] contents = new short[source.Remaining];
-            source.Get(contents);
-            Put(contents);
-            return this;
+            int length = source.Remaining;
+            short[]? arrayToReturnToPool = null;
+            Span<short> contents = length * sizeof(short) > ByteStackBufferSize
+                ? (arrayToReturnToPool = ArrayPool<short>.Shared.Rent(length)).AsSpan(0, length)
+                : stackalloc short[length];
+            try
+            {
+                source.Get(contents);
+                Put(contents);
+                return this;
+            }
+            finally
+            {
+                ArrayPool<short>.Shared.ReturnIfNotNull(arrayToReturnToPool);
+            }
         }
 
         /// <summary>

--- a/src/J2N/IO/Int16ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int16ToByteBufferAdapter.cs
@@ -156,6 +156,8 @@ namespace J2N.IO
             return byteBuffer.GetInt16(index << 1);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to shorts and override Get(Span<short>)
+
         //public override bool IsDirect => byteBuffer.IsDirect;
 
         public override bool IsReadOnly => byteBuffer.IsReadOnly;
@@ -196,6 +198,8 @@ namespace J2N.IO
             byteBuffer.PutInt16(index << 1, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from shorts and override Put(ReadOnlySpan<short>)
 
         public override Int16Buffer Slice()
         {

--- a/src/J2N/IO/Int32ArrayBuffer.cs
+++ b/src/J2N/IO/Int32ArrayBuffer.cs
@@ -86,6 +86,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override sealed Int32Buffer Get(Span<int> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         //public override sealed bool IsDirect => false;
 
         public override sealed ByteOrder Order => ByteOrder.NativeOrder;

--- a/src/J2N/IO/Int32ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int32ToByteBufferAdapter.cs
@@ -163,6 +163,8 @@ namespace J2N.IO
             return byteBuffer.GetInt32(index << 2);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to ints and override Get(Span<int>)
+
         //public override bool IsDirect => byteBuffer.IsDirect;
 
         public override bool IsReadOnly => byteBuffer.IsReadOnly;
@@ -200,6 +202,8 @@ namespace J2N.IO
             byteBuffer.PutInt32(index << 2, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from ints and override Put(ReadOnlySpan<int>)
 
         public override Int32Buffer Slice()
         {

--- a/src/J2N/IO/Int64ArrayBuffer.cs
+++ b/src/J2N/IO/Int64ArrayBuffer.cs
@@ -88,6 +88,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override sealed Int64Buffer Get(Span<long> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         //public override sealed bool IsDirect => false;
 
         public override sealed ByteOrder Order => ByteOrder.NativeOrder;

--- a/src/J2N/IO/Int64ToByteBufferAdapter.cs
+++ b/src/J2N/IO/Int64ToByteBufferAdapter.cs
@@ -155,6 +155,8 @@ namespace J2N.IO
             return byteBuffer.GetInt64(index << 3);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to longs and override Get(Span<long>)
+
         //public override bool IsDirect => byteBuffer.IsDirect;
 
         public override bool IsReadOnly => byteBuffer.IsReadOnly;
@@ -192,6 +194,9 @@ namespace J2N.IO
             byteBuffer.PutInt64(index << 3, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from longs and override Put(ReadOnlySpan<long>)
+
         public override Int64Buffer Slice()
         {
             byteBuffer.SetLimit(limit << 3);

--- a/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyCharArrayBuffer.cs
@@ -79,12 +79,17 @@ namespace J2N.IO
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed CharBuffer Put(char[] source, int offset, int length)
+        public override CharBuffer Put(char[] source, int offset, int length)
         {
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed CharBuffer Put(CharBuffer src)
+        public override CharBuffer Put(ReadOnlySpan<char> source) // J2N specific
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override CharBuffer Put(CharBuffer src)
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlyDoubleArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyDoubleArrayBuffer.cs
@@ -16,6 +16,8 @@
  */
 #endregion
 
+using System;
+
 namespace J2N.IO
 {
     /// <summary>
@@ -82,7 +84,12 @@ namespace J2N.IO
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed DoubleBuffer Put(double[] source, int offset, int length)
+        public override DoubleBuffer Put(double[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override DoubleBuffer Put(ReadOnlySpan<double> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlyHeapByteBuffer.cs
+++ b/src/J2N/IO/ReadOnlyHeapByteBuffer.cs
@@ -16,6 +16,8 @@
  */
 #endregion
 
+using System;
+
 namespace J2N.IO
 {
     /// <summary>
@@ -76,6 +78,11 @@ namespace J2N.IO
         }
 
         public override ByteBuffer Put(byte[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override ByteBuffer Put(ReadOnlySpan<byte> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlyInt16ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt16ArrayBuffer.cs
@@ -16,6 +16,8 @@
  */
 #endregion
 
+using System;
+
 namespace J2N.IO
 {
     /// <summary>
@@ -81,7 +83,12 @@ namespace J2N.IO
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed Int16Buffer Put(short[] source, int offset, int length)
+        public override Int16Buffer Put(short[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override Int16Buffer Put(ReadOnlySpan<short> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlyInt32ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt32ArrayBuffer.cs
@@ -16,7 +16,7 @@
  */
 #endregion
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 
 namespace J2N.IO
@@ -84,7 +84,12 @@ namespace J2N.IO
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed Int32Buffer Put(int[] source, int offset, int length)
+        public override Int32Buffer Put(int[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override Int32Buffer Put(ReadOnlySpan<int> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlyInt64ArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlyInt64ArrayBuffer.cs
@@ -16,6 +16,8 @@
  */
 #endregion
 
+using System;
+
 namespace J2N.IO
 {
     /// <summary>
@@ -81,7 +83,12 @@ namespace J2N.IO
             throw new ReadOnlyBufferException();
         }
 
-        public override sealed Int64Buffer Put(long[] source, int offset, int length)
+        public override Int64Buffer Put(long[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override Int64Buffer Put(ReadOnlySpan<long> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadOnlySingleArrayBuffer.cs
+++ b/src/J2N/IO/ReadOnlySingleArrayBuffer.cs
@@ -16,6 +16,8 @@
  */
 #endregion
 
+using System;
+
 namespace J2N.IO
 {
     /// <summary>
@@ -82,6 +84,11 @@ namespace J2N.IO
         }
 
         public override sealed SingleBuffer Put(float[] source, int offset, int length)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override SingleBuffer Put(ReadOnlySpan<float> source) // J2N specific
         {
             throw new ReadOnlyBufferException();
         }

--- a/src/J2N/IO/ReadWriteCharArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteCharArrayBuffer.cs
@@ -113,6 +113,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override CharBuffer Put(ReadOnlySpan<char> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override CharBuffer Slice()
         {
             return new ReadWriteCharArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteDoubleArrayBuffer.cs
@@ -113,6 +113,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override DoubleBuffer Put(ReadOnlySpan<double> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override DoubleBuffer Slice()
         {
             return new ReadWriteDoubleArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/ReadWriteHeapByteBuffer.cs
+++ b/src/J2N/IO/ReadWriteHeapByteBuffer.cs
@@ -119,10 +119,19 @@ namespace J2N.IO
                 ThrowHelper.ThrowArgumentOutOfRange_IndexLengthArray(offset, ExceptionArgument.offset, length);
             if (length > Remaining)
                 throw new BufferOverflowException();
-            if (IsReadOnly)
-                throw new ReadOnlyBufferException();
 
             System.Array.Copy(source, offset, backingArray, base.offset + position, length);
+            position += length;
+            return this;
+        }
+
+        public override ByteBuffer Put(ReadOnlySpan<byte> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
             position += length;
             return this;
         }

--- a/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt16ArrayBuffer.cs
@@ -116,6 +116,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override Int16Buffer Put(ReadOnlySpan<short> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override Int16Buffer Slice()
         {
             return new ReadWriteInt16ArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt32ArrayBuffer.cs
@@ -115,6 +115,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override Int32Buffer Put(ReadOnlySpan<int> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override Int32Buffer Slice()
         {
             return new ReadWriteInt32ArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteInt64ArrayBuffer.cs
@@ -113,6 +113,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override Int64Buffer Put(ReadOnlySpan<long> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override Int64Buffer Slice()
         {
             return new ReadWriteInt64ArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
+++ b/src/J2N/IO/ReadWriteSingleArrayBuffer.cs
@@ -113,6 +113,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override SingleBuffer Put(ReadOnlySpan<float> source) // J2N specific
+        {
+            int length = source.Length;
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            source.CopyTo(backingArray.AsSpan(offset + position, length));
+            position += length;
+            return this;
+        }
+
         public override SingleBuffer Slice()
         {
             return new ReadWriteSingleArrayBuffer(Remaining, backingArray, offset + position);

--- a/src/J2N/IO/SingleArrayBuffer.cs
+++ b/src/J2N/IO/SingleArrayBuffer.cs
@@ -86,6 +86,17 @@ namespace J2N.IO
             return this;
         }
 
+        public override SingleBuffer Get(Span<float> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            backingArray.AsSpan(offset + position, length).CopyTo(destination);
+            position += length;
+            return this;
+        }
+
         //public override sealed bool IsDirect => false;
 
         public override sealed ByteOrder Order => ByteOrder.NativeOrder;

--- a/src/J2N/IO/SingleToByteBufferAdapter.cs
+++ b/src/J2N/IO/SingleToByteBufferAdapter.cs
@@ -156,6 +156,7 @@ namespace J2N.IO
             return byteBuffer.GetSingle(index << 2);
         }
 
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) to floats and override Get(Span<float>)
 
         //public override bool IsDirect => byteBuffer.IsDirect;
 
@@ -195,6 +196,8 @@ namespace J2N.IO
             byteBuffer.PutSingle(index << 2, value);
             return this;
         }
+
+        // J2N TODO: Need a way to convert the bytes (in the specified endianness) from floats and override Put(ReadOnlySpan<float>)
 
         public override SingleBuffer Slice()
         {

--- a/src/J2N/IO/StringBuilderAdapter.cs
+++ b/src/J2N/IO/StringBuilderAdapter.cs
@@ -169,8 +169,12 @@ namespace J2N.IO
 
         public override CharBuffer Slice()
         {
-            // J2N TODO: Copy the bytes and return a CharMemoryAdapter here
-            return new CharSequenceAdapter(sequence.Subsequence(position, limit - position)); // J2N: Corrected 2nd parameter
+            int length = Remaining;
+            // J2N NOTE: If the caller slices again, this will be more efficient than using CharSequenceAdapter around a string
+            // and will also index faster if the StringBuilder has more than one chunk.
+            char[] chars = new char[length];
+            sequence.CopyTo(position, chars, 0, length);
+            return new ReadOnlyCharArrayBuffer(length, chars, arrayOffset: 0);
         }
 
         public override CharBuffer Subsequence(int startIndex, int length)

--- a/src/J2N/IO/StringBuilderAdapter.cs
+++ b/src/J2N/IO/StringBuilderAdapter.cs
@@ -1,0 +1,191 @@
+﻿#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using J2N.Text;
+using System;
+using System.Text;
+
+namespace J2N.IO
+{
+    /// <summary>
+    /// This class wraps a char sequence to be a <see cref="char"/> buffer.
+    /// <para/>
+    /// Implementation notice:
+    /// <list type="bullet">
+    ///     <item><description>Char sequence based buffer is always readonly.</description></item>
+    /// </list>
+    /// </summary>
+    internal sealed class StringBuilderAdapter : CharBuffer
+    {
+        internal static StringBuilderAdapter Copy(StringBuilderAdapter other)
+        {
+            return new StringBuilderAdapter(other.sequence)
+            {
+                limit = other.limit,
+                position = other.position,
+                mark = other.mark
+            };
+        }
+
+        internal readonly StringBuilder sequence;
+
+        internal StringBuilderAdapter(StringBuilder chseq)
+            : base(chseq.Length)
+        {
+            sequence = chseq;
+        }
+
+        public override CharBuffer AsReadOnlyBuffer() => Duplicate();
+
+        public override CharBuffer Compact()
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override CharBuffer Duplicate() => Copy(this);
+
+        public override char Get()
+        {
+            if (position == limit)
+            {
+                throw new BufferUnderflowException();
+            }
+            return sequence[position++];
+        }
+
+        public override char Get(int index)
+        {
+            if ((uint)index >= (uint)limit)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            return sequence[index];
+        }
+
+        public override sealed CharBuffer Get(char[] destination, int offset, int length) // J2N TODO: API - rename startIndex instead of offset
+        {
+            if (destination is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.destination);
+            if (offset < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(offset, ExceptionArgument.offset);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(length, ExceptionArgument.length);
+            if (offset > destination.Length - length) // Checks for int overflow
+                ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(offset, length);
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+
+            int newPosition = position + length;
+            sequence.CopyTo(position, destination, offset, length);
+            position = newPosition;
+            return this;
+        }
+
+        public override CharBuffer Get(Span<char> destination) // J2N specific
+        {
+            int length = destination.Length;
+            if (length > Remaining)
+                throw new BufferUnderflowException();
+
+            int newPosition = position + length;
+            sequence.CopyTo(position, destination, length);
+            position = newPosition;
+            return this;
+        }
+
+        //public override bool IsDirect => false;
+
+        public override bool IsReadOnly => true;
+
+        public override ByteOrder Order => ByteOrder.NativeOrder;
+
+        protected override char[] ProtectedArray
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        protected override int ProtectedArrayOffset
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        protected override bool ProtectedHasArray => false;
+
+        public override CharBuffer Put(char value)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override CharBuffer Put(int index, char value)
+        {
+            throw new ReadOnlyBufferException();
+        }
+
+        public override sealed CharBuffer Put(char[] source, int offset, int length) // J2N TODO: API - rename startIndex instead of offset
+        {
+            if (source is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            if (offset < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(offset, ExceptionArgument.offset);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(length, ExceptionArgument.length);
+            if (offset > source.Length - length) // Checks for int overflow
+                ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(offset, length);
+            if (length > Remaining)
+                throw new BufferOverflowException();
+
+            throw new ReadOnlyBufferException();
+        }
+
+        public override CharBuffer Put(string source, int startIndex, int length)
+        {
+            if (source is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+            if (startIndex < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(startIndex, ExceptionArgument.startIndex);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(length, ExceptionArgument.length);
+            if (startIndex > source.Length - length) // Checks for int overflow
+                ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(startIndex, length);
+
+            throw new ReadOnlyBufferException();
+        }
+
+        public override CharBuffer Slice()
+        {
+            // J2N TODO: Copy the bytes and return a CharMemoryAdapter here
+            return new CharSequenceAdapter(sequence.Subsequence(position, limit - position)); // J2N: Corrected 2nd parameter
+        }
+
+        public override CharBuffer Subsequence(int startIndex, int length)
+        {
+            if (startIndex < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(startIndex, ExceptionArgument.startIndex);
+            if (length < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(length, ExceptionArgument.length);
+            if (startIndex > Remaining - length) // Checks for int overflow
+                ThrowHelper.ThrowArgumentOutOfRange_IndexLengthString(startIndex, length);
+
+            StringBuilderAdapter result = Copy(this);
+            result.position = position + startIndex;
+            result.limit = position + startIndex + length;
+            return result;
+        }
+    }
+}

--- a/src/J2N/MemoryExtensions.cs
+++ b/src/J2N/MemoryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -428,5 +429,35 @@ namespace J2N
         }
 
         #endregion ReverseText
+
+        #region TryGetReference
+
+        /// <summary>
+        /// Sets the supplied <paramref name="reference"/> to the underlying <see cref="string"/> or <see cref="T:char[]"/>
+        /// of this <see cref="ReadOnlyMemory{Char}"/>. This allows use of <see cref="ReadOnlyMemory{Char}"/> as a field
+        /// of a struct or class without having the underlying <see cref="string"/> or <see cref="T:char[]"/> go out of scope.
+        /// </summary>
+        /// <param name="text">This <see cref="ReadOnlyMemory{Char}"/>.</param>
+        /// <param name="reference">When this method returns successfully, the refernce will be set by ref to the
+        /// underlying <see cref="string"/> or <see cref="T:char[]"/> of <paramref name="text"/>.</param>
+        /// <returns><c>true</c> if the underlying reference could be retrieved; otherwise, <c>false</c>.
+        /// Note that if the underlying memory is not a <see cref="string"/> or <see cref="T:char[]"/>,
+        /// this method will always return <c>false</c>.</returns>
+        internal static bool TryGetReference(this ReadOnlyMemory<char> text, [MaybeNullWhen(false)] ref object? reference)
+        {
+            if (MemoryMarshal.TryGetString(text, out string? stringValue, out _, out _) && stringValue is not null)
+            {
+                reference = stringValue;
+                return true;
+            }
+            else if (MemoryMarshal.TryGetArray(text, out ArraySegment<char> arraySegment) && arraySegment.Array is not null)
+            {
+                reference = arraySegment.Array;
+                return true;
+            }
+            return false;
+        }
+
+        #endregion
     }
 }

--- a/tests/NUnit/J2N.Tests/IO/TestByteBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestByteBuffer.cs
@@ -378,6 +378,42 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for ByteBuffer Get(Span<byte>)
+         */
+        [Test]
+        public virtual void TestGetbyteSpan() // J2N specific
+        {
+            Span<byte> array = new byte[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                ByteBuffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i));
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Get((byte[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        /*
          * Class under test for java.nio.ByteBuffer get(byte[])
          */
         [Test]
@@ -667,6 +703,57 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for ByteBuffer Put(ReadOnlySpan<byte>)
+         */
+        [Test]
+        public virtual void TestPutbyteSpan() // J2N specific
+        {
+            Span<byte> array = new byte[1];
+            if (buf.IsReadOnly)
+            {
+                try
+                {
+                    buf.Put(array);
+                    fail("Should throw Exception"); //$NON-NLS-1$
+                }
+                catch (ReadOnlyBufferException e)
+                {
+                    // expected
+                }
+                return;
+            }
+
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (byte)i;
+                ByteBuffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (byte)i);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((byte[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestByteBuffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestByteBuffer2.cs
@@ -51,6 +51,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((byte)Ic(i)));
         }
 
+        private static void bulkGetSpan(ByteBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<byte> a = new byte[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((byte)Ic(i)));
+        }
+
         private static void relPut(ByteBuffer b)
         {
             int n = b.Capacity;
@@ -78,6 +87,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (byte)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(ByteBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<byte> a = new byte[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (byte)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -312,7 +332,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -536,6 +569,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestCharBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestCharBuffer.cs
@@ -362,6 +362,32 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for CharBuffer Get(Span<char>)
+         */
+        [Test]
+        public virtual void TestGetcharSpan() // J2N specific
+        {
+            Span<char> array = new char[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                CharBuffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i));
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+        }
+
+        /*
          * Class under test for java.nio.CharBuffer get(char[])
          */
         [Test]
@@ -382,6 +408,15 @@ namespace J2N.IO
                 fail("Should throw Exception"); //$NON-NLS-1$
             }
             catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            try // J2N: Added check for guard clause
+            {
+                buf.Get((char[])null);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
             {
                 // expected
             }
@@ -548,6 +583,44 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for CharBuffer Put(ReadOnlySpan<char>)
+         */
+        [Test]
+        public virtual void TestPutcharSpan() // J2N specific
+        {
+            Span<char> array = new char[1];
+
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (char)i;
+                CharBuffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (char)i);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((char[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestCharBuffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestCharBuffer2.cs
@@ -54,6 +54,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((char)Ic(i)));
         }
 
+        private static void bulkGetSpan(CharBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<char> a = new char[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((char)Ic(i)));
+        }
+
         private static void relPut(CharBuffer b)
         {
             int n = b.Capacity;
@@ -81,6 +90,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (char)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(CharBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<char> a = new char[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (char)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -210,7 +230,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -431,6 +464,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestDoubleBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestDoubleBuffer.cs
@@ -304,6 +304,32 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for DoubleBuffer Get(Span<double>)
+         */
+        [Test]
+        public virtual void TestGetdoubleSpan() // J2N specific
+        {
+            Span<double> array = new double[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                DoubleBuffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i), 0.01);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+        }
+
+        /*
          * Class under test for java.nio.DoubleBuffer get(double[])
          */
         [Test]
@@ -324,6 +350,15 @@ namespace J2N.IO
                 fail("Should throw Exception"); //$NON-NLS-1$
             }
             catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            try // J2N: Added check for guard clause
+            {
+                buf.Get((double[])null);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
             {
                 // expected
             }
@@ -512,6 +547,44 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for DoubleBuffer Put(ReadOnlySpan<double>)
+         */
+        [Test]
+        public virtual void TestPutdoubleSpan() // J2N specific
+        {
+            Span<double> array = new double[1];
+
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (double)i;
+                DoubleBuffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (double)i, 0.0);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((double[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        /*
          * Class under test for java.nio.DoubleBuffer put(double[])
          */
         [Test]
@@ -534,6 +607,15 @@ namespace J2N.IO
                 fail("Should throw Exception"); //$NON-NLS-1$
             }
             catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put((double[])null);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
             {
                 // expected
             }

--- a/tests/NUnit/J2N.Tests/IO/TestDoubleBuffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestDoubleBuffer2.cs
@@ -57,6 +57,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((double)Ic(i)));
         }
 
+        private static void bulkGetSpan(DoubleBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<double> a = new double[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((double)Ic(i)));
+        }
+
         private static void relPut(DoubleBuffer b)
         {
             int n = b.Capacity;
@@ -84,6 +93,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (double)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(DoubleBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<double> a = new double[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (double)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -201,7 +221,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -413,6 +446,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestInt16Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt16Buffer.cs
@@ -270,6 +270,41 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for Int16Buffer Get(Span<short>)
+         */
+        public virtual void TestGetshortSpan() // J2N specific
+        {
+            Span<short> array = new short[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                Int16Buffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i));
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Get((short[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        /*
          * Class under test for java.nio.Int16Buffer get(short[])
          */
         public virtual void TestGetshortArray()
@@ -289,6 +324,15 @@ namespace J2N.IO
                 fail("Should throw Exception"); //$NON-NLS-1$
             }
             catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            try // J2N: Added check for guard clause
+            {
+                buf.Get((short[])null);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
             {
                 // expected
             }
@@ -465,6 +509,44 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for Int16Buffer Put(ReadOnlySpan<short>)
+         */
+        [Test]
+        public virtual void TestPutshortSpan() // J2N specific
+        {
+            Span<short> array = new short[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (short)i;
+                Int16Buffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (short)i);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Put((short[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestInt16Buffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt16Buffer2.cs
@@ -53,6 +53,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((short)Ic(i)));
         }
 
+        private static void bulkGetSpan(Int16Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<short> a = new short[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((short)Ic(i)));
+        }
+
         private static void relPut(Int16Buffer b)
         {
             int n = b.Capacity;
@@ -80,6 +89,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (short)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(Int16Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<short> a = new short[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (short)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -196,7 +216,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -389,6 +422,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestInt32Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt32Buffer.cs
@@ -268,6 +268,42 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for Int32Buffer Get(Span<int>)
+         */
+        [Test]
+        public virtual void TestGetintSpan() // J2N specific
+        {
+            Span<int> array = new int[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                Int32Buffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i));
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Get((int[])null);
+            //    fail("Should throw NPE"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        /*
          * Class under test for java.nio.Int32Buffer get(int[])
          */
         [Test]
@@ -482,6 +518,44 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for Int32Buffer Put(ReadOnlySpan<int>)
+         */
+        [Test]
+        public virtual void TestPutintSpan() // J2N specific
+        {
+            Span<int> array = new int[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (int)i;
+                Int32Buffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (int)i);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Put((int[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestInt32Buffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt32Buffer2.cs
@@ -54,6 +54,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((int)Ic(i)));
         }
 
+        private static void bulkGetSpan(Int32Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<int> a = new int[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((int)Ic(i)));
+        }
+
         private static void relPut(Int32Buffer b)
         {
             int n = b.Capacity;
@@ -81,6 +90,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (int)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(Int32Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<int> a = new int[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (int)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -200,7 +220,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -394,6 +427,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestInt64Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt64Buffer.cs
@@ -270,6 +270,43 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for Int64Buffer Get(Span<long>)
+         */
+        [Test]
+        public virtual void TestGetlongSpan() // J2N specific
+        {
+            Span<long> array = new long[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                Int64Buffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i));
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Get((long[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        /*
          * Class under test for java.nio.Int64Buffer get(long[])
          */
         [Test]
@@ -485,6 +522,44 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for Int64Buffer Put(ReadOnlySpan<long>)
+         */
+        [Test]
+        public virtual void TestPutlongSpan() // J2N specific
+        {
+            Span<long> array = new long[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (long)i;
+                Int64Buffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (long)i);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Put((long[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestInt64Buffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestInt64Buffer2.cs
@@ -53,6 +53,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((long)Ic(i)));
         }
 
+        private static void bulkGetSpan(Int64Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<long> a = new long[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((long)Ic(i)));
+        }
+
         private static void relPut(Int64Buffer b)
         {
             int n = b.Capacity;
@@ -80,6 +89,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (long)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(Int64Buffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<long> a = new long[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (long)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -199,7 +219,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -396,6 +429,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlyCharBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlyCharBuffer.cs
@@ -94,6 +94,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutcharSpan() // J2N specific
+        {
+            Span<char> array = new char[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((char[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutcharArray()
         {
             char[] array = new char[1];

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlyDoubleBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlyDoubleBuffer.cs
@@ -91,6 +91,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutdoubleSpan() // J2N specific
+        {
+            Span<double> array = new double[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((double[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutdoubleArray()
         {
             double[] array = new double[1];

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt16Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt16Buffer.cs
@@ -93,6 +93,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutshortSpan() // J2N specific
+        {
+            Span<short> array = new short[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((short[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutshortArray()
         {
             short[] array = new short[1];

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt32Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt32Buffer.cs
@@ -93,6 +93,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutintSpan() // J2N specific
+        {
+            Span<int> array = new int[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((int[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutintArray()
         {
             int[] array = new int[1];

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt64Buffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlyInt64Buffer.cs
@@ -93,6 +93,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutlongSpan() // J2N specific
+        {
+            Span<long> array = new long[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((long[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutlongArray()
         {
             long[] array = new long[1];

--- a/tests/NUnit/J2N.Tests/IO/TestReadOnlySingleBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestReadOnlySingleBuffer.cs
@@ -93,6 +93,31 @@ namespace J2N.IO
         }
 
         [Test]
+        public override void TestPutfloatSpan() // J2N specific
+        {
+            Span<float> array = new float[1];
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Put((float[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+        }
+
+        [Test]
         public override void TestPutfloatArray()
         {
             float[] array = new float[1];

--- a/tests/NUnit/J2N.Tests/IO/TestSingleBuffer.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestSingleBuffer.cs
@@ -293,6 +293,44 @@ namespace J2N.IO
         }
 
         /*
+         * Class under test for SingleBuffer Get(Span<float>)
+         */
+        [Test]
+        public virtual void TestGetfloatSpan() // J2N specific
+        {
+            Span<float> array = new float[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                SingleBuffer ret = buf.Get(array);
+                assertEquals(array[0], buf.Get(i), 0.01);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Get(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferUnderflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Get((float[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
+            buf.Get(new float[0].AsSpan());
+        }
+
+        /*
          * Class under test for java.nio.SingleBuffer get(float[])
          */
         [Test]
@@ -512,6 +550,44 @@ namespace J2N.IO
             {
                 // expected
             }
+        }
+
+        /*
+         * Class under test for SingleBuffer Put(ReadOnlySpan<float>)
+         */
+        [Test]
+        public virtual void TestPutfloatSpan() // J2N specific
+        {
+            Span<float> array = new float[1];
+            buf.Clear();
+            for (int i = 0; i < buf.Capacity; i++)
+            {
+                assertEquals(buf.Position, i);
+                array[0] = (float)i;
+                SingleBuffer ret = buf.Put(array);
+                assertEquals(buf.Get(i), (float)i, 0.0);
+                assertSame(ret, buf);
+            }
+            try
+            {
+                buf.Put(array);
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            // J2N: Null converts to empty span, should not throw
+            //try
+            //{
+            //    buf.Position = (buf.Limit);
+            //    buf.Put((float[])null);
+            //    fail("Should throw Exception"); //$NON-NLS-1$
+            //}
+            //catch (ArgumentNullException e)
+            //{
+            //    // expected
+            //}
         }
 
         /*

--- a/tests/NUnit/J2N.Tests/IO/TestSingleBuffer2.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestSingleBuffer2.cs
@@ -58,6 +58,15 @@ namespace J2N.IO
                 ck(b, (long)a[i + 7], (long)((float)Ic(i)));
         }
 
+        private static void bulkGetSpan(SingleBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            Span<float> a = new float[n + 7];
+            b.Get(a.Slice(7, n));
+            for (int i = 0; i < n; i++)
+                ck(b, (long)a[i + 7], (long)((float)Ic(i)));
+        }
+
         private static void relPut(SingleBuffer b)
         {
             int n = b.Capacity;
@@ -85,6 +94,17 @@ namespace J2N.IO
             for (int i = 0; i < n; i++)
                 a[i + 7] = (float)Ic(i);
             b.Put(a, 7, n);
+            b.Flip();
+        }
+
+        private static void bulkPutSpan(SingleBuffer b) // J2N specific
+        {
+            int n = b.Capacity;
+            b.Clear();
+            Span<float> a = new float[n + 7];
+            for (int i = 0; i < n; i++)
+                a[i + 7] = (float)Ic(i);
+            b.Put(a.Slice(7, n));
             b.Flip();
         }
 
@@ -203,7 +223,20 @@ namespace J2N.IO
             absGet(b);
             bulkGet(b);
 
+            relPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
+            absPut(b); // J2N specific
+            relGet(b);
+            absGet(b);
+            bulkGetSpan(b);
+
             bulkPutArray(b);
+            relGet(b);
+
+            bulkPutSpan(b); // J2N specific
             relGet(b);
 
             bulkPutBuffer(b);
@@ -419,6 +452,11 @@ namespace J2N.IO
             tryCatch(b, typeof(ReadOnlyBufferException), () =>
             {
                 bulkPutArray(rb);
+            });
+
+            tryCatch(b, typeof(ReadOnlyBufferException), () =>
+            {
+                bulkPutSpan(rb); // J2N specific
             });
 
             tryCatch(b, typeof(ReadOnlyBufferException), () =>

--- a/tests/NUnit/J2N.Tests/IO/TestWrappedCharBuffer3.cs
+++ b/tests/NUnit/J2N.Tests/IO/TestWrappedCharBuffer3.cs
@@ -1,0 +1,165 @@
+﻿using NUnit.Framework;
+using System;
+using System.Text;
+
+namespace J2N.IO
+{
+    internal class TestWrappedCharBuffer3 : TestReadOnlyCharBuffer
+    {
+        protected static readonly StringBuilder TEST_STRINGBUILDER = new StringBuilder("123456789abcdef12345");
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            buf = CharBuffer.Wrap(TEST_STRINGBUILDER);
+            baseBuf = buf;
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+            baseBuf = null;
+            buf = null;
+        }
+
+        [Test]
+        public void TestWrappedCharSequence_IllegalArg()
+        {
+            StringBuilder str = TEST_STRINGBUILDER;
+            try
+            {
+                CharBuffer.Wrap(str, -1, 0 - -1); // J2N: Corrected 3rd parameter
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                // expected
+            }
+            try
+            {
+                CharBuffer.Wrap(str, 21, 21 - 21); // J2N: Corrected 3rd parameter
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                // expected
+            }
+            try
+            {
+                CharBuffer.Wrap(str, 2, 1 - 2); // J2N: Corrected 3rd parameter
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                // expected
+            }
+            try
+            {
+                CharBuffer.Wrap(str, 0, 21 - 0); // J2N: Corrected 3rd parameter
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                // expected
+            }
+            try
+            {
+                CharBuffer.Wrap((String)null, -1, 21 - -1); // J2N: Corrected 3rd parameter
+                fail("Should throw Exception"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
+            {
+                // expected
+            }
+        }
+
+        [Test]
+        public override void TestArray()
+        {
+            try
+            {
+                var _ = buf.Array;
+                fail("Should throw UnsupportedOperationException"); //$NON-NLS-1$
+            }
+            catch (NotSupportedException e)
+            {
+            }
+        }
+
+        [Test]
+        public override void TestPutcharArrayintint()
+        {
+            char[] array = new char[1];
+            try
+            {
+                buf.Put(array, 0, array.Length - 0); // J2N: Corrected 3rd parameter
+                fail("Should throw ReadOnlyBufferException"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put((char[])null, 0, 1 - 0); // J2N: Corrected 3rd parameter
+                fail("Should throw NullPointerException"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put(new char[buf.Capacity + 1], 0, (buf.Capacity + 1) - 0); // J2N: Corrected 3rd parameter
+                fail("Should throw BufferOverflowException"); //$NON-NLS-1$
+            }
+            catch (BufferOverflowException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put(array, -1, array.Length - -1); // J2N: Corrected 3rd parameter
+                fail("Should throw IndexOutOfBoundsException"); //$NON-NLS-1$
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                // expected
+            }
+        }
+
+        [Test]
+        public override void TestPutCharBuffer()
+        {
+            CharBuffer other = CharBuffer.Allocate(1);
+            try
+            {
+                buf.Put(other);
+                fail("Should throw ReadOnlyBufferException"); //$NON-NLS-1$
+            }
+            catch (ReadOnlyBufferException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put((CharBuffer)null);
+                fail("Should throw NullPointerException"); //$NON-NLS-1$
+            }
+            catch (ArgumentNullException e)
+            {
+                // expected
+            }
+            try
+            {
+                buf.Put(buf);
+                fail("Should throw IllegalArgumentException"); //$NON-NLS-1$
+            }
+            catch (ArgumentException e)
+            {
+                // expected
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This adds basic support for spans on the `Get()` and `Put()` methods of the various buffers and adapters. The current implementation keeps the same calling order in the base classes (`ByteBuffer`, `CharBuffer`, etc) and each subclass overrides the implementation to provide a better optimized implementation. However, at this point the following methods are still reading one character at a time:

1. `CompareTo()`
2. `Equals()`
3. `GetHashCode()`

These will be optimized in another PR along with optimizations to the big/little endian conversions and consolidation of repetitious code.

This was discussed in https://github.com/apache/lucenenet/issues/1151