### PR TITLE
Added `EncodingExtensions` for `Span<T>` and `ReadOnlySpan<T>` support

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -135,6 +135,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ARRAYEMPTY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_BUFFER_MEMORYCOPY</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ENCODING_GETSTRING_BYTEPTR</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_GETBYTES_OFFSET_COUNT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_APPEND_CHARPTR</DefineConstants>
 

--- a/src/J2N/Runtime/InteropServices/MemoryMarshalHelper.cs
+++ b/src/J2N/Runtime/InteropServices/MemoryMarshalHelper.cs
@@ -1,0 +1,45 @@
+﻿#region Copyright 2019-2024 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using J2N.Runtime.CompilerServices;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace J2N.Runtime.InteropServices
+{
+    internal class MemoryMarshalHelper
+    {
+
+#pragma warning disable IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
+        /// <summary>
+        /// Returns a reference to the 0th element of the Span. If the Span is empty, returns a reference to fake non-null pointer. Such a reference can be used
+        /// for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe ref T GetNonNullPinnableReference<T>(Span<T> span) => ref (span.Length != 0) ? ref MemoryMarshal.GetReference(span) : ref Unsafe.AsRef<T>((void*)1);
+
+        /// <summary>
+        /// Returns a reference to the 0th element of the ReadOnlySpan. If the ReadOnlySpan is empty, returns a reference to fake non-null pointer. Such a reference
+        /// can be used for pinning but must never be dereferenced. This is useful for interop with methods that do not accept null pointers for zero-sized buffers.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe ref T GetNonNullPinnableReference<T>(ReadOnlySpan<T> span) => ref (span.Length != 0) ? ref MemoryMarshal.GetReference(span) : ref Unsafe.AsRef<T>((void*)1);
+#pragma warning restore IDE0060 // https://github.com/dotnet/roslyn-analyzers/issues/6228
+    }
+}

--- a/src/J2N/Text/EncodingExtensions.cs
+++ b/src/J2N/Text/EncodingExtensions.cs
@@ -1,0 +1,371 @@
+﻿// Adapted from: https://github.com/dotnet/runtime/blob/v9.0.4/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.Buffers;
+using J2N.Runtime.InteropServices;
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace J2N.Text
+{
+    /// <summary>
+    /// Extensions to <see cref="Encoding"/>.
+    /// </summary>
+    public static class EncodingExtensions
+    {
+        private const int CharStackBufferSize = 64;
+
+        /// <summary>
+        /// Calculates the number of bytes produced by encoding the characters in the specified
+        /// character span.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="chars">The span of characters to encode.</param>
+        /// <returns>The number of bytes produced by encoding the specified character span.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="EncoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.EncoderFallback"/> is set to <see cref="System.Text.EncoderExceptionFallback"/>.
+        /// </exception>
+        public static int GetByteCount(this Encoding encoding, ReadOnlySpan<char> chars)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            return GetByteCountInternal(encoding, chars);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int GetByteCountInternal(Encoding encoding, ReadOnlySpan<char> chars)
+        {
+            Debug.Assert(encoding is not null);
+
+            fixed (char* charsPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(chars))
+            {
+                return encoding!.GetByteCount(charsPtr, chars.Length);
+            }
+        }
+
+        /// <summary>
+        /// Encodes the specified character into a sequence of bytes.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="ch">The character to encode.</param>
+        /// <param name="buffer">The memory location to store the chars. Typically,
+        /// it should be <c>stackalloc byte[4]</c> since it will never be longer than 4 bytes.
+        /// Note that this <paramref name="buffer"/> is not intended for use by callers,
+        /// it is just a memory location to use when returning the result. The caller is
+        /// responsible for ensuring the memory location has a sufficient scope that is
+        /// at least as long as the scope of the return value.</param>
+        /// <returns>A <see cref="ReadOnlySpan{Byte}"/> containing the results of encoding
+        /// the specified character.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="buffer"/> has a
+        /// <see cref="Span{Byte}.Length"/> less than 4.</exception>
+        /// <exception cref="EncoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.EncoderFallback"/> is set to <see cref="System.Text.EncoderExceptionFallback"/>.
+        /// </exception>
+        public static unsafe ReadOnlySpan<byte> GetBytes(this Encoding encoding, char ch, Span<byte> buffer)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+            if (buffer.Length < 4)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(buffer))
+            {
+                char* charPtr = &ch;
+                int bytesWritten = encoding.GetBytes(charPtr, 1, bytesPtr, buffer.Length);
+                return buffer.Slice(0, bytesWritten);
+            }
+        }
+
+        /// <summary>
+        /// Encodes the specified code point into a sequence of bytes.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="codePoint">The code point to encode.</param>
+        /// <param name="buffer">The memory location to store the chars. Typically,
+        /// it should be <c>stackalloc byte[8]</c> since it will never be longer than 8 bytes.
+        /// Note that this <paramref name="buffer"/> is not intended for use by callers,
+        /// it is just a memory location to use when returning the result. The caller is
+        /// responsible for ensuring the memory location has a sufficient scope that is
+        /// at least as long as the scope of the return value.</param>
+        /// <returns>A <see cref="ReadOnlySpan{Byte}"/> containing the results of encoding
+        /// the specified character.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="buffer"/> has a <see cref="Span{Byte}.Length"/> less than 8.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// If <paramref name="codePoint"/> is not a valid Unicode code point.
+        /// </exception>
+        /// <exception cref="EncoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.EncoderFallback"/> is set to <see cref="System.Text.EncoderExceptionFallback"/>.
+        /// </exception>
+        public static unsafe ReadOnlySpan<byte> GetBytes(this Encoding encoding, int codePoint, Span<byte> buffer)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+            if (buffer.Length < 8)
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+
+            ReadOnlySpan<char> chars = Character.ToChars(codePoint, stackalloc char[2]);
+
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(buffer))
+            fixed (char* charsPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(chars))
+            {
+                int bytesWritten = encoding.GetBytes(charsPtr, chars.Length, bytesPtr, buffer.Length);
+                return buffer.Slice(0, bytesWritten);
+            }
+        }
+
+        /// <summary>
+        /// Encodes into a span of bytes a set of characters from the specified read-only span.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="chars">The span containing the set of characters to encode.</param>
+        /// <param name="bytes">The byte span to hold the encoded bytes.</param>
+        /// <returns>The number of encoded bytes.</returns>
+        /// <remarks>This is a polyfill for .NET target frameworks that do not have this overload.
+        /// It will be superseded where the overload exists on <see cref="Encoding"/>.</remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="EncoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.EncoderFallback"/> is set to <see cref="System.Text.EncoderExceptionFallback"/>.
+        /// </exception>
+        public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            return GetBytesInternal(encoding, chars, bytes);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int GetBytesInternal(Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+        {
+            Debug.Assert(encoding is not null);
+
+            fixed (char* charsPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(chars))
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(bytes))
+            {
+                return encoding!.GetBytes(charsPtr, chars.Length, bytesPtr, bytes.Length);
+            }
+        }
+
+        /// <summary>
+        /// Encodes into a span of bytes a set of characters from the specified read-only span if the destination is large enough.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="chars">The span containing the set of characters to encode.</param>
+        /// <param name="bytes">The byte span to hold the encoded bytes.</param>
+        /// <param name="bytesWritten">Upon successful completion of the operation, the number of bytes encoded into <paramref name="bytes"/>.</param>
+        /// <returns><see langword="true"/> if all of the characters were encoded into the destination; <see langword="false"/> if the destination was too small to contain all the encoded bytes.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="EncoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.EncoderFallback"/> is set to <see cref="System.Text.EncoderExceptionFallback"/>.
+        /// </exception>
+        public static bool TryGetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes, out int bytesWritten)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            int required = GetByteCountInternal(encoding, chars);
+            if (required <= bytes.Length)
+            {
+                bytesWritten = GetBytesInternal(encoding, chars, bytes);
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Calculates the number of characters produced by decoding the provided read-only byte span.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bytes">A read-only byte span to decode.</param>
+        /// <returns>The number of characters produced by decoding the byte span.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="DecoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.DecoderFallback"/> is set to <see cref="System.Text.DecoderExceptionFallback"/>.
+        /// </exception>
+        public static int GetCharCount(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            return GetCharCountInternal(encoding, bytes);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int GetCharCountInternal(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+            Debug.Assert(encoding is not null);
+
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(bytes))
+            {
+                return encoding!.GetCharCount(bytesPtr, bytes.Length);
+            }
+        }
+
+        /// <summary>
+        /// Decodes all the bytes in the specified read-only byte span into a character span.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bytes">A read-only span containing the sequence of bytes to decode.</param>
+        /// <param name="chars">The character span receiving the decoded bytes.</param>
+        /// <returns>The actual number of characters written at the span indicated by the <paramref name="chars"/> parameter</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="DecoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.DecoderFallback"/> is set to <see cref="System.Text.DecoderExceptionFallback"/>.
+        /// </exception>
+        public static int GetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            return GetCharsInternal(encoding, bytes, chars);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe int GetCharsInternal(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars)
+        {
+            Debug.Assert(encoding is not null);
+
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(bytes))
+            fixed (char* charsPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(chars))
+            {
+                return encoding!.GetChars(bytesPtr, bytes.Length, charsPtr, chars.Length);
+            }
+        }
+
+        /// <summary>
+        /// Decodes into a span of chars a set of bytes from the specified read-only span if the destination is large enough.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bytes">A read-only span containing the sequence of bytes to decode.</param>
+        /// <param name="chars">The character span receiving the decoded bytes.</param>
+        /// <param name="charsWritten">Upon successful completion of the operation, the number of chars decoded into <paramref name="chars"/>.</param>
+        /// <returns><see langword="true"/> if all of the characters were decoded into the destination; <see langword="false"/> if the destination was too small to contain all the decoded chars.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="encoding"/> is <c>null</c>.</exception>
+        /// <exception cref="DecoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.DecoderFallback"/> is set to <see cref="System.Text.DecoderExceptionFallback"/>.
+        /// </exception>
+        public static bool TryGetChars(this Encoding encoding, ReadOnlySpan<byte> bytes, Span<char> chars, out int charsWritten)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            int required = GetCharCountInternal(encoding, bytes);
+            if (required <= chars.Length)
+            {
+                charsWritten = GetCharsInternal(encoding, bytes, chars);
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        /// <summary>
+        /// Decodes all the bytes in the specified byte span into a string.
+        /// </summary>
+        /// <param name="encoding">The character encoding to use.</param>
+        /// <param name="bytes">A read-only byte span to decode to a Unicode string.</param>
+        /// <returns>A string that contains the decoded bytes from the provided read-only span.</returns>
+        /// <exception cref="DecoderFallbackException">
+        /// A fallback occurred (for more information, see
+        /// <a href="https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-encoding">Character Encoding in .NET</a>)
+        /// <para/>
+        /// -and-
+        /// <para/>
+        /// <see cref="Encoding.DecoderFallback"/> is set to <see cref="System.Text.DecoderExceptionFallback"/>.
+        /// </exception>
+        public static unsafe string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+        {
+            if (encoding is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.encoding);
+
+            fixed (byte* bytesPtr = &MemoryMarshalHelper.GetNonNullPinnableReference(bytes))
+            {
+#if FEATURE_ENCODING_GETSTRING_BYTEPTR
+                return encoding.GetString(bytesPtr, bytes.Length);
+#else
+                int byteLength = bytes.Length;
+
+                // Get our string length
+                int stringLength = encoding.GetCharCount(bytesPtr, byteLength);
+                Debug.Assert(stringLength >= 0);
+
+                char[]? buffer = null;
+                Span<char> chars = stringLength > CharStackBufferSize
+                    ? (buffer = ArrayPool<char>.Shared.Rent(stringLength)).AsSpan(0, stringLength)
+                    : stackalloc char[stringLength];
+                try
+                {
+                    fixed (char* pTempChars = &MemoryMarshal.GetReference(chars))
+                    {
+                        int doubleCheck = encoding.GetChars(bytesPtr, byteLength, pTempChars, stringLength);
+                        Debug.Assert(stringLength == doubleCheck,
+                            "Expected encoding.GetChars to return same length as encoding.GetCharCount");
+                    }
+
+                    return chars.ToString();
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.ReturnIfNotNull(buffer);
+                }
+#endif
+            }
+        }
+    }
+}

--- a/tests/NUnit/J2N.Tests/Text/TestEncodingExtensions.cs
+++ b/tests/NUnit/J2N.Tests/Text/TestEncodingExtensions.cs
@@ -1,0 +1,218 @@
+﻿// Adapted from: https://github.com/SimonCropp/Polyfill/blob/7.27.0/src/Tests/PolyfillTests_Encoding.cs
+
+// MIT License
+
+// Copyright (c) Simon Cropp
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace J2N.Text
+{
+    [TestFixture]
+    public class TestEncodingExtensions
+    {
+        [Test]
+        public void TestGetByteCount()
+        {
+            var encoding = Encoding.UTF8;
+            var chars = "Hello, World!".AsSpan();
+
+            var byteCount = EncodingExtensions.GetByteCount(encoding, chars);
+            Assert.AreEqual(13, byteCount);
+        }
+
+        [Test]
+        public void TestGetCharCount()
+        {
+            var encoding = Encoding.UTF8;
+            var utf8Bytes = "Hello, World!"u8.ToArray();
+            var byteSpan = new ReadOnlySpan<byte>(utf8Bytes);
+
+            var charCount = EncodingExtensions.GetCharCount(encoding, byteSpan);
+            Assert.AreEqual(13, charCount);
+        }
+
+        [Test]
+        public void TestGetChars()
+        {
+            // Arrange
+            var encoding = Encoding.UTF8;
+            var utf8Bytes = "Hello, World!"u8.ToArray();
+            var byteSpan = new ReadOnlySpan<byte>(utf8Bytes);
+            Span<char> charSpan = stackalloc char[utf8Bytes.Length];
+
+            // Act
+            var charCount = EncodingExtensions.GetChars(encoding, byteSpan, charSpan);
+
+            // Assert
+            var result = charSpan.Slice(0, charCount).ToString();
+            Assert.AreEqual("Hello, World!", result);
+        }
+
+        [Test]
+        public void TestGetString()
+        {
+            var array = (ReadOnlySpan<byte>)"value"u8.ToArray().AsSpan();
+            var result = EncodingExtensions.GetString(Encoding.UTF8, array);
+            Assert.AreEqual("value", result);
+        }
+
+        [Test]
+        public void TestGetString_Long()
+        {
+            const string testString = "Café naïve façade über schöne Straße — 🧠🌍💡✨🎉📚🔬🎨🧬🦄🚀🐍🌈🎵⚛️👾";
+            var array = (ReadOnlySpan<byte>)Encoding.UTF8.GetBytes(testString).AsSpan();
+            var result = EncodingExtensions.GetString(Encoding.UTF8, array);
+            Assert.AreEqual(testString, result);
+        }
+
+        [Test]
+        public void TestGetBytes()
+        {
+            var encoding = Encoding.UTF8;
+            var chars = "Hello, World!".AsSpan();
+            Span<byte> bytes = stackalloc byte[encoding.GetByteCount(chars)];
+
+            var byteCount = EncodingExtensions.GetBytes(encoding, chars, bytes);
+
+            Assert.AreEqual(encoding.GetByteCount(chars), byteCount);
+            Assert.AreEqual(encoding.GetBytes("Hello, World!"), bytes.ToArray());
+        }
+
+        [Test]
+        public void TestGetBytes_Char()
+        {
+            var encoding = Encoding.UTF8;
+            var chars = "Hello, World!".AsSpan();
+            Span<byte> buffer = stackalloc byte[4];
+            var expectedBytes = encoding.GetBytes("Hello, World!");
+            int byteIndex = 0;
+
+            foreach (char ch in chars)
+            {
+                ReadOnlySpan<byte> bytes = EncodingExtensions.GetBytes(encoding, ch, buffer);
+                int byteLength = bytes.Length;
+                Assert.IsTrue(expectedBytes.AsSpan(byteIndex, byteLength).SequenceEqual(bytes));
+                byteIndex += byteLength;
+            }
+        }
+
+        [Test]
+        public void TestGetBytes_Codepoint()
+        {
+            const string testString = "Café naïve façade über schöne Straße — 🧠🌍💡✨🎉📚🔬🎨🧬🦄🚀🐍🌈🎵⚛️👾";
+            var encoding = Encoding.UTF8;
+            var chars = testString.AsSpan();
+            Span<byte> buffer = stackalloc byte[8];
+            var expectedBytes = encoding.GetBytes(testString);
+            int codePointIndex = 0;
+            int byteIndex = 0;
+
+            while (codePointIndex < chars.Length)
+            {
+                int codePoint = Character.CodePointAt(chars, codePointIndex);
+                int charCount = Character.CharCount(codePoint);
+
+                ReadOnlySpan<byte> bytes = EncodingExtensions.GetBytes(encoding, codePoint, buffer);
+                int byteLength = bytes.Length;
+                Assert.IsTrue(expectedBytes.AsSpan(byteIndex, byteLength).SequenceEqual(bytes));
+                byteIndex += byteLength;
+
+                codePointIndex += charCount;
+            }
+        }
+
+        [Test]
+        public void Test_TryGetBytes_WithValidInput_ReturnsTrue()
+        {
+            // Arrange
+            var encoding = Encoding.UTF8;
+            var inputString = "Hello, World!";
+            var charSpan = inputString.AsSpan();
+            Span<byte> bytes = stackalloc byte[encoding.GetMaxByteCount(inputString.Length)];
+
+            // Act
+            var result = EncodingExtensions.TryGetBytes(encoding, charSpan, bytes, out var bytesWritten);
+
+            // Assert
+            Assert.IsTrue(result);
+            var expectedBytes = encoding.GetBytes(inputString);
+            Assert.IsTrue(expectedBytes.AsSpan().SequenceEqual(bytes.Slice(0, bytesWritten)));
+        }
+
+        [Test]
+        public void Test_TryGetBytes_WithSmallDestination_ReturnsFalse()
+        {
+            // Arrange
+            var encoding = Encoding.UTF8;
+            var inputString = "Hello, World!";
+            var charSpan = inputString.AsSpan();
+            Span<byte> byteSpan = stackalloc byte[5]; // Intentionally too small
+
+            // Act
+            var result = EncodingExtensions.TryGetBytes(encoding, charSpan, byteSpan, out var bytesWritten);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.AreEqual(0, bytesWritten);
+        }
+
+
+        [Test]
+        public void Test_TryGetChars_WithValidInput_ReturnsTrue()
+        {
+            // Arrange
+            var encoding = Encoding.UTF8;
+            var utf8Bytes = "Hello, World!"u8.ToArray();
+            var byteSpan = new ReadOnlySpan<byte>(utf8Bytes);
+            var charArray = new char[utf8Bytes.Length];
+            var charSpan = new Span<char>(charArray);
+
+            // Act
+            var result = EncodingExtensions.TryGetChars(encoding, byteSpan, charSpan, out var charsWritten);
+
+            // Assert
+            Assert.IsTrue(result);
+            Assert.AreEqual("Hello, World!", charSpan.Slice(0, charsWritten).ToString());
+        }
+
+        [Test]
+        public void Test_TryGetChars_WithSmallDestination_ReturnsFalse()
+        {
+            // Arrange
+            var encoding = Encoding.UTF8;
+            var utf8Bytes = "Hello, World!"u8.ToArray();
+            var byteSpan = new ReadOnlySpan<byte>(utf8Bytes);
+            var charArray = new char[5]; // Smaller than needed
+            var charSpan = new Span<char>(charArray);
+
+            // Act
+            var result = EncodingExtensions.TryGetChars(encoding, byteSpan, charSpan, out var charsWritten);
+
+            // Assert
+            Assert.IsFalse(result);
+            Assert.AreEqual(0, charsWritten);
+        }
+    }
+}


### PR DESCRIPTION
This adds support for System.Memory types `Span<T>` and `ReadOnlySpan<T>` to legacy .NET versions (.NET Framework and .NET Standard). These are implemented as extension methods with the same signature as the .NET Core methods so they are automatically "overridden" in modern .NET platforms with the concrete method signatures.

There are just 2 signatures that are added as new features beyond the set in .NET:

```c#
namespace J2N.Text
{
    public static class EncodingExtensions
    {
        public static unsafe ReadOnlySpan<byte> GetBytes(this Encoding encoding, char ch, Span<byte> buffer);
        public static unsafe ReadOnlySpan<byte> GetBytes(this Encoding encoding, int codePoint, Span<byte> buffer);
    }
}
```

These methods take a `char` or a code point rather than a sequence of characters, respectively. They require a buffer size of at least 4 and 8 bytes, respectively, and the result is sliced down to the actual number of bytes that were returned, so the `Length` property can be used to determine how many bytes.