### PR TITLE
Enabled test reporting for J2N.TestUtilities.Xunit.Tests in Azure Pipelines

### DIFF
--- a/.build/azure-templates/publish-test-results-for-test-projects.yml
+++ b/.build/azure-templates/publish-test-results-for-test-projects.yml
@@ -182,3 +182,13 @@ steps:
     testResultsFormat: '${{ parameters.testResultsFormat }}'
     testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
     testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
+    testProjectName: 'J2N.TestUtilities.Xunit.Tests'
+    framework: '${{ parameters.framework }}'
+    osName: '${{ parameters.osName }}'
+    testPlatform: '${{ parameters.testPlatform }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'


### PR DESCRIPTION
`publish-test-results-for-test-projects.yml:` Enabled test reporting for J2N.TestUtilities.Xunit.Tests in Azure Pipelines.

This was accidentally omitted from #149.