### PR TITLE
Broadened support for hardware intrinsics in `BitOperation` and `MathExtensions`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -73,6 +73,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_CALLERARGUMENTEXPRESSIONATTRIBUTE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COLLECTIONSMARSHAL_ASSPAN_LIST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMERICBITOPERATIONS</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_MATH_LOG2</DefineConstants>
 
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -27,14 +27,22 @@
 
     <DebugType>portable</DebugType>
   </PropertyGroup>
+  
+  <!-- Features in .NET 10.x+ only -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_BITOPERATIONS_ROUNDUPTOPOWEROF2</DefineConstants>
+    
+  </PropertyGroup>
 
   <!-- Features in .NET 8.x and .NET 9.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
-    <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x9FFF</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_BITOPERATIONS_UINTPTR</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_EXCEPTION_STATIC_GUARDCLAUSES</DefineConstants>
     <!-- J2N NOTE: This is technically supported in .NET 6.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
     <DefineConstants>$(DefineConstants);FEATURE_STRINGBUILDER_GETCHUNKS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_EXCEPTION_STATIC_GUARDCLAUSES</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_UNICODE_DEFINED_0x9FFF</DefineConstants>
 
   </PropertyGroup>
 
@@ -62,9 +70,9 @@
   <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x, and .NET 9.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
 
+    <DefineConstants>$(DefineConstants);FEATURE_CALLERARGUMENTEXPRESSIONATTRIBUTE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_COLLECTIONSMARSHAL_ASSPAN_LIST</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_NUMERICBITOPERATIONS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CALLERARGUMENTEXPRESSIONATTRIBUTE</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -39,6 +39,11 @@ namespace J2N
         private const long DoubleSignBitMask = unchecked((long)0x8000000000000000L);
 
         /// <summary>
+        /// The precomputed value of <see cref="Math.Log(double)"/> with a value of 2.
+        /// </summary>
+        private const double LogOf2 = 0.693147180559945309417232121458176568; // precomputed log(2)
+
+        /// <summary>
         /// Returns the signum function of the specified <see cref="int"/> value. (The
         /// return value is <c>-1</c> if the specified value is negative; <c>0</c> if the
         /// specified value is zero; and <c>1</c> if the specified value is positive.)
@@ -142,6 +147,22 @@ namespace J2N
         public static double ToDegrees(this int radians)
         {
             return ((double)radians) * 180 / Math.PI;
+        }
+
+        /// <summary>
+        /// Returns the base 2 logarithm of a specified number.
+        /// </summary>
+        /// <param name="value">A number whose logarithm is to be found.</param>
+        /// <returns></returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Log2(this double value)
+        {
+#if FEATURE_MATH_LOG2
+            return Math.Log2(value); // Hardware accelerated
+#else
+            return Math.Log(value) / LogOf2;
+#endif
         }
 
         /// <summary>

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -149,14 +149,14 @@ namespace J2N.Numerics
 #if FEATURE_NUMERICBITOPERATIONS
             return System.Numerics.BitOperations.PopCount(value);
 #else
-            const uint c1 = 0x_55555555u;
-            const uint c2 = 0x_33333333u;
-            const uint c3 = 0x_0F0F0F0Fu;
-            const uint c4 = 0x_01010101u;
+            const ulong c1 = 0x_55555555_55555555ul;
+            const ulong c2 = 0x_33333333_33333333ul;
+            const ulong c3 = 0x_0F0F0F0F_0F0F0F0Ful;
+            const ulong c4 = 0x_01010101_01010101ul;
 
             value -= (value >> 1) & c1;
             value = (value & c2) + ((value >> 2) & c2);
-            value = (((value + (value >> 4)) & c3) * c4) >> 24;
+            value = (((value + (value >> 4)) & c3) * c4) >> 56;
 
             return (int)value;
 #endif

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -399,7 +399,7 @@ namespace J2N.Numerics
                 // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_0111_1100_1011_0101_0011_0001u
                 ref MemoryMarshal.GetReference(TrailingZeroCountDeBruijn),
                 // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
-                (IntPtr)(int)(((value & (uint)-(int)value) * 0x077CB531u) >> 27)); // Multi-cast mitigates redundant conv.u8
+                (IntPtr)(int)(((((uint)value) & (uint)-(int)(uint)value) * 0x077CB531u) >> 27)); // Multi-cast mitigates redundant conv.u8
 #endif
         }
 

--- a/src/J2N/Numerics/BitOperation.cs
+++ b/src/J2N/Numerics/BitOperation.cs
@@ -18,7 +18,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-
+using System.Runtime.InteropServices;
 
 namespace J2N.Numerics
 {
@@ -28,16 +28,39 @@ namespace J2N.Numerics
     /// </summary>
     public static class BitOperation
     {
+        // C# no-alloc optimization that directly wraps the data section of the dll (similar to string constants)
+        // https://github.com/dotnet/roslyn/pull/24621
+
+#if !FEATURE_NUMERICBITOPERATIONS
+        private static ReadOnlySpan<byte> TrailingZeroCountDeBruijn => // 32
+        [
+            00, 01, 28, 02, 29, 14, 24, 03,
+            30, 22, 20, 15, 25, 17, 04, 08,
+            31, 27, 13, 23, 21, 19, 16, 07,
+            26, 12, 18, 06, 11, 05, 10, 09
+        ];
+#endif
+
+        private static ReadOnlySpan<byte> Log2DeBruijn => // 32
+        [
+            00, 09, 01, 10, 13, 21, 02, 29,
+            11, 14, 16, 18, 22, 25, 03, 30,
+            08, 12, 20, 28, 15, 17, 24, 07,
+            19, 27, 23, 06, 26, 05, 04, 31
+        ];
+
         #region BitCount
 
         /// <summary>
         /// Returns the population count (number of set bits) of an <see cref="int"/> mask.
+        /// Similar in behavior to the x86 instruction POPCNT.
         /// <para/>
         /// Usage Note: This is the same operation as Integer.bitCount() in the JDK.
         /// </summary>
         /// <param name="value">The <see cref="int"/> to examine.</param>
         /// <returns>The number of one-bits in the two's complement binary
         /// representation of the specified <paramref name="value"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PopCount(this int value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
@@ -54,13 +77,45 @@ namespace J2N.Numerics
         }
 
         /// <summary>
+        /// Returns the population count (number of set bits) of an <see cref="uint"/> mask.
+        /// Similar in behavior to the x86 instruction POPCNT.
+        /// <para/>
+        /// Usage Note: This is a similar operation as Integer.bitCount() in the JDK.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> to examine.</param>
+        /// <returns>The number of one-bits in the two's complement binary
+        /// representation of the specified <paramref name="value"/>.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int PopCount(this uint value)
+        {
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.PopCount(value);
+#else
+            const uint c1 = 0x_55555555u;
+            const uint c2 = 0x_33333333u;
+            const uint c3 = 0x_0F0F0F0Fu;
+            const uint c4 = 0x_01010101u;
+
+            value -= (value >> 1) & c1;
+            value = (value & c2) + ((value >> 2) & c2);
+            value = (((value + (value >> 4)) & c3) * c4) >> 24;
+
+            return (int)value;
+#endif
+        }
+
+        /// <summary>
         /// Returns the population count (number of set bits) of a <see cref="long"/> mask.
+        /// Similar in behavior to the x86 instruction POPCNT.
         /// <para/>
         /// Usage Note: This is the same operation as Long.bitCount() in the JDK.
         /// </summary>
         /// <param name="value">The <see cref="long"/> to examine.</param>
         /// <returns>The number of one-bits in the two's complement binary
         /// representation of the specified <paramref name="value"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int PopCount(this long value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
@@ -74,6 +129,60 @@ namespace J2N.Numerics
             value += (value >>> 16);
             value += (value >>> 32);
             return (int)value & 0x7f;
+#endif
+        }
+
+        /// <summary>
+        /// Returns the population count (number of set bits) of a <see cref="ulong"/> mask.
+        /// Similar in behavior to the x86 instruction POPCNT.
+        /// <para/>
+        /// Usage Note: This is the same operation as Long.bitCount() in the JDK.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> to examine.</param>
+        /// <returns>The number of one-bits in the two's complement binary
+        /// representation of the specified <paramref name="value"/>.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int PopCount(this ulong value)
+        {
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.PopCount(value);
+#else
+            const uint c1 = 0x_55555555u;
+            const uint c2 = 0x_33333333u;
+            const uint c3 = 0x_0F0F0F0Fu;
+            const uint c4 = 0x_01010101u;
+
+            value -= (value >> 1) & c1;
+            value = (value & c2) + ((value >> 2) & c2);
+            value = (((value + (value >> 4)) & c3) * c4) >> 24;
+
+            return (int)value;
+#endif
+        }
+
+        /// <summary>
+        /// Returns the population count (number of bits set) of a mask.
+        /// Similar in behavior to the x86 instruction POPCNT.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int PopCount(this nuint value)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.PopCount(value);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return PopCount((ulong)value);
+            }
+            else
+            {
+                return PopCount((uint)value);
+            }
 #endif
         }
 
@@ -111,13 +220,42 @@ namespace J2N.Numerics
 #if FEATURE_NUMERICBITOPERATIONS
             return System.Numerics.BitOperations.LeadingZeroCount((uint)value);
 #else
-            // Hacker's Delight, Figure 5-6
-            value |= value >> 1;
-            value |= value >> 2;
-            value |= value >> 4;
-            value |= value >> 8;
-            value |= value >> 16;
-            return PopCount(~value);
+            return 31 ^ Log2SoftwareFallback((uint)value);
+#endif
+        }
+
+        /// <summary>
+        /// Returns the number of zero bits preceding the highest-order
+        /// ("leftmost") one-bit in the two's complement binary representation
+        /// of the specified <paramref name="value"/>. Returns 32 if the
+        /// specified value has no one-bits in its two's complement representation,
+        /// in other words if it is equal to zero.
+        /// <para/>
+        /// Note that this method is closely related to the logarithm base 2.
+        /// For all positive <see cref="uint"/> values x:
+        /// <list type="bullet">
+        ///     <item><description>floor(log<sub>2</sub>(x)) = <c>31 - x.LeadingZeroCount()</c></description></item>
+        ///     <item><description>ceil(log<sub>2</sub>(x)) = <c>32 - (x - 1).LeadingZeroCount()</c></description></item>
+        /// </list>
+        /// <para/>
+        /// Usage Note: This is a similar operation as Integer.numberOfLeadingZeros() in the JDK.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> to examine.</param>
+        /// <returns>The number of zero bits preceding the highest-order
+        /// ("leftmost") one-bit in the two's complement binary representation
+        /// of the specified <paramref name="value"/>, or 32 if the value
+        /// is equal to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int LeadingZeroCount(this uint value)
+        {
+            if (value == 0)
+                return 32;
+
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.LeadingZeroCount(value);
+#else
+            return 31 ^ Log2SoftwareFallback(value);
 #endif
         }
 
@@ -162,6 +300,72 @@ namespace J2N.Numerics
 #endif
         }
 
+        /// <summary>
+        /// Returns the number of zero bits preceding the highest-order
+        /// ("leftmost") one-bit in the two's complement binary representation
+        /// of the specified <paramref name="value"/>. Returns 64 if the
+        /// specified value has no one-bits in its two's complement representation,
+        /// in other words if it is equal to zero.
+        /// <para/>
+        /// Note that this method is closely related to the logarithm base 2.
+        /// For all positive <see cref="ulong"/> values x:
+        /// <list type="bullet">
+        ///     <item><description>floor(log<sub>2</sub>(x)) = <c>63 - x.LeadingZeroCount()</c></description></item>
+        ///     <item><description>ceil(log<sub>2</sub>(x)) = <c>64 - (x - 1).LeadingZeroCount()</c></description></item>
+        /// </list>
+        /// <para/>
+        /// Usage Note: This is a similar operation as Long.numberOfLeadingZeros() in the JDK.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> to examine.</param>
+        /// <returns>The number of zero bits preceding the highest-order
+        /// ("leftmost") one-bit in the two's complement binary representation
+        /// of the specified <paramref name="value"/>, or 64 if the value
+        /// is equal to zero.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int LeadingZeroCount(this ulong value)
+        {
+            if (value == 0)
+                return 64;
+
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.LeadingZeroCount(value);
+#else
+            uint hi = (uint)(value >> 32);
+
+            if (hi == 0)
+            {
+                return 32 + LeadingZeroCount((uint)value);
+            }
+
+            return LeadingZeroCount(hi);
+#endif
+        }
+
+        /// <summary>
+        /// Count the number of leading zero bits in a mask.
+        /// Similar in behavior to the x86 instruction LZCNT.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int LeadingZeroCount(this nuint value)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.LeadingZeroCount(value);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return LeadingZeroCount((ulong)value);
+            }
+            else
+            {
+                return LeadingZeroCount((uint)value);
+            }
+#endif
+        }
+
         #endregion NumberOfLeadingZeros
 
         #region NumberOfTrailingZeros
@@ -172,6 +376,8 @@ namespace J2N.Numerics
         /// <paramref name="value"/>. Returns 32 if the specified value has no
         /// one-bits in its two's complement representation, in other words if it is
         /// equal to zero.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction TZCNT.
         /// <para/>
         /// Usage Note: This is the same operation as Integer.numberOfTrailingZeros() in the JDK.
         /// </summary>
@@ -188,7 +394,47 @@ namespace J2N.Numerics
 #if FEATURE_NUMERICBITOPERATIONS
             return System.Numerics.BitOperations.TrailingZeroCount((uint)value);
 #else
-            return PopCount((value & -value) - 1);
+            // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+            return Unsafe.AddByteOffset(
+                // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_0111_1100_1011_0101_0011_0001u
+                ref MemoryMarshal.GetReference(TrailingZeroCountDeBruijn),
+                // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
+                (IntPtr)(int)(((value & (uint)-(int)value) * 0x077CB531u) >> 27)); // Multi-cast mitigates redundant conv.u8
+#endif
+        }
+
+        /// <summary>
+        /// Returns the number of zero bits following the lowest-order ("rightmost")
+        /// one-bit in the two's complement binary representation of the specified
+        /// <paramref name="value"/>. Returns 32 if the specified value has no
+        /// one-bits in its two's complement representation, in other words if it is
+        /// equal to zero.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction TZCNT.
+        /// <para/>
+        /// Usage Note: This is the same operation as Integer.numberOfTrailingZeros() in the JDK.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> to examine.</param>
+        /// <returns>The number of zero bits following the lowest-order ("rightmost")
+        /// one-bit in the two's complement binary representation of the
+        /// specified <paramref name="value"/>, or 32 if the value is equal
+        /// to zero.</returns>
+        //[Intrinsic]
+        [CLSCompliant(false)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TrailingZeroCount(this uint value)
+        {
+            if (value == 0)
+                return 32;
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.TrailingZeroCount(value);
+#else
+            // uint.MaxValue >> 27 is always in range [0 - 31] so we use Unsafe.AddByteOffset to avoid bounds check
+            return Unsafe.AddByteOffset(
+                // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_0111_1100_1011_0101_0011_0001u
+                ref MemoryMarshal.GetReference(TrailingZeroCountDeBruijn),
+                // uint|long -> IntPtr cast on 32-bit platforms does expensive overflow checks not needed here
+                (IntPtr)(int)(((value & (uint)-(int)value) * 0x077CB531u) >> 27)); // Multi-cast mitigates redundant conv.u8
 #endif
         }
 
@@ -198,6 +444,8 @@ namespace J2N.Numerics
         /// <paramref name="value"/>. Returns 64 if the specified value has no
         /// one-bits in its two's complement representation, in other words if it is
         /// equal to zero.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction TZCNT.
         /// </summary>
         /// <param name="value">The <see cref="long"/> to examine.</param>
         /// <returns>The number of zero bits following the lowest-order ("rightmost")
@@ -212,7 +460,96 @@ namespace J2N.Numerics
 #if FEATURE_NUMERICBITOPERATIONS
             return System.Numerics.BitOperations.TrailingZeroCount((ulong)value);
 #else
-            return PopCount((value & -value) - 1);
+            uint lo = (uint)(ulong)value;
+
+            if (lo == 0)
+            {
+                return 32 + TrailingZeroCount((uint)(((ulong)value) >> 32));
+            }
+
+            return TrailingZeroCount(lo);
+#endif
+        }
+
+        /// <summary>
+        /// Returns the number of zero bits following the lowest-order ("rightmost")
+        /// one-bit in the two's complement binary representation of the specified
+        /// <paramref name="value"/>. Returns 64 if the specified value has no
+        /// one-bits in its two's complement representation, in other words if it is
+        /// equal to zero.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction TZCNT.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> to examine.</param>
+        /// <returns>The number of zero bits following the lowest-order ("rightmost")
+        /// one-bit in the two's complement binary representation of the
+        /// specified <paramref name="value"/>, or 64 if the value is equal
+        /// to zero.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int TrailingZeroCount(this ulong value)
+        {
+            if (value == 0)
+                return 64;
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.TrailingZeroCount(value);
+#else
+            uint lo = (uint)value;
+
+            if (lo == 0)
+            {
+                return 32 + TrailingZeroCount((uint)(value >> 32));
+            }
+
+            return TrailingZeroCount(lo);
+#endif
+        }
+
+        /// <summary>
+        /// Count the number of trailing zero bits in a mask.
+        /// Similar in behavior to the x86 instruction TZCNT.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int TrailingZeroCount(this nint value)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.TrailingZeroCount(value);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return TrailingZeroCount((ulong)(nuint)value);
+            }
+            else
+            {
+                return TrailingZeroCount((uint)(nuint)value);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Count the number of trailing zero bits in a mask.
+        /// Similar in behavior to the x86 instruction TZCNT.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int TrailingZeroCount(this nuint value)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.TrailingZeroCount(value);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return TrailingZeroCount((ulong)value);
+            }
+            else
+            {
+                return TrailingZeroCount((uint)value);
+            }
 #endif
         }
 
@@ -267,31 +604,188 @@ namespace J2N.Numerics
 
         #endregion HighestOneBit
 
+        #region IsPow2
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPow2(this int value) => (value & (value - 1)) == 0 && value > 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static bool IsPow2(this uint value) => (value & (value - 1)) == 0 && value != 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPow2(this long value) => (value & (value - 1)) == 0 && value > 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static bool IsPow2(this ulong value) => (value & (value - 1)) == 0 && value != 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPow2(this nint value) => (value & (value - 1)) == 0 && value > 0;
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static bool IsPow2(this nuint value) => (value & (value - 1)) == 0 && value != 0;
+
+        #endregion IsPow2
+
         #region Log2
 
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Log2(this uint value)
+        [CLSCompliant(false)]
+        public static int Log2(this int value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
-            return System.Numerics.BitOperations.Log2(value);
+            return System.Numerics.BitOperations.Log2((uint)value);
 #else
-            // The 0->0 contract is fulfilled by setting the LSB to 1.
-            // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
-            value |= 1;
-            return 31 ^ LeadingZeroCount((int)value);
+            // Fallback contract is 0->0
+            return Log2SoftwareFallback((uint)value);
 #endif
         }
 
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Log2(this ulong value)
+        [CLSCompliant(false)]
+        public static int Log2(this uint value)
         {
 #if FEATURE_NUMERICBITOPERATIONS
             return System.Numerics.BitOperations.Log2(value);
 #else
-            value |= 1;
-            return 63 ^ LeadingZeroCount((long)value);
+            // Fallback contract is 0->0
+            return Log2SoftwareFallback(value);
 #endif
         }
+
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int Log2(this long value)
+        {
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.Log2((ulong)value);
+#else
+            uint hi = (uint)(((ulong)value) >> 32);
+
+            if (hi == 0)
+            {
+                return Log2((uint)(ulong)value);
+            }
+
+            return 32 + Log2(hi);
+#endif
+        }
+
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int Log2(this ulong value)
+        {
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.Log2(value);
+#else
+            uint hi = (uint)(value >> 32);
+
+            if (hi == 0)
+            {
+                return Log2((uint)value);
+            }
+
+            return 32 + Log2(hi);
+#endif
+        }
+
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int Log2(this nuint value)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.Log2(value);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return Log2((ulong)value);
+            }
+            else
+            {
+                return Log2((uint)value);
+            }
+#endif
+        }
+
+#if !FEATURE_NUMERICBITOPERATIONS
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// Does not directly use any hardware intrinsics, nor does it incur branching.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        private static int Log2SoftwareFallback(uint value)
+        {
+            // No AggressiveInlining due to large method size
+            // Has conventional contract 0->0 (Log(0) is undefined)
+
+            // Fill trailing zeros with ones, eg 00010010 becomes 00011111
+            value |= value >> 01;
+            value |= value >> 02;
+            value |= value >> 04;
+            value |= value >> 08;
+            value |= value >> 16;
+
+            // Using deBruijn sequence, k=2, n=5 (2^5=32) : 0b_0000_0111_1100_0100_1010_1100_1101_1101u
+            return Log2DeBruijn[(int)((value * 0x07C4ACDDu) >> 27)];
+        }
+#endif
 
         #endregion Log2
 
@@ -440,6 +934,8 @@ namespace J2N.Numerics
         /// no-op, so all but the last five bits of the rotation distance can be
         /// ignored, even if the distance is negative:
         /// <c>val.RotateLeft(distance) == val.RotateLeft(distance &amp; 0x1F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROL.
         /// </summary>
         /// <param name="value">The <see cref="int"/> value to rotate left.</param>
         /// <param name="distance">The number of bits to rotate.</param>
@@ -463,8 +959,44 @@ namespace J2N.Numerics
 #endif
         }
 
-        internal static uint RotateLeft(this uint value, int distance) // J2N TODO: API - Make public once we have implementations for all methods accepting uint and ulong
-            => (value << distance) | (value >> (32 - distance));
+        /// <summary>
+        /// Returns the value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> left by the
+        /// specified number of bits.  (Bits shifted out of the left hand, or
+        /// high-order, side reenter on the right, or low-order.)
+        /// <para/>
+        /// Note that left rotation with a negative distance is equivalent to
+        /// right rotation: <c>val.RotateLeft(-distance) == val.RotateRight(distance)</c>.
+        /// Note also that rotation by any multiple of 32 is a
+        /// no-op, so all but the last five bits of the rotation distance can be
+        /// ignored, even if the distance is negative:
+        /// <c>val.RotateLeft(distance) == val.RotateLeft(distance &amp; 0x1F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROL.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> value to rotate left.</param>
+        /// <param name="distance">The number of bits to rotate.</param>
+        /// <returns>The value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> left by the
+        /// specified number of bits.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static uint RotateLeft(this uint value, int distance)
+        {
+            if (distance == 0)
+                return value;
+            /*
+             * According to JLS3, 15.19, the right operand of a shift is always
+             * implicitly masked with 0x1F, which the negation of 'distance' is
+             * taking advantage of.
+             */
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.RotateLeft(value, distance);
+#else
+            return (value << distance) | (value >> (32 - distance));
+#endif
+        }
 
         /// <summary>
         /// Returns the value obtained by rotating the two's complement binary
@@ -478,6 +1010,8 @@ namespace J2N.Numerics
         /// no-op, so all but the last six bits of the rotation distance can be
         /// ignored, even if the distance is negative:
         /// <c>val.RotateLeft(distance) == val.RotateLeft(distance &amp; 0x3F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROL.
         /// </summary>
         /// <param name="value">The <see cref="long"/> value to rotate left.</param>
         /// <param name="distance">The number of bits to rotate.</param>
@@ -501,7 +1035,74 @@ namespace J2N.Numerics
 #endif
         }
 
-        #endregion
+        /// <summary>
+        /// Returns the value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> left by the
+        /// specified number of bits.  (Bits shifted out of the left hand, or
+        /// high-order, side reenter on the right, or low-order.)
+        /// <para/>
+        /// Note that left rotation with a negative distance is equivalent to
+        /// right rotation: <c>val.RotateLeft(-distance) == val.RotateRight(distance)</c>
+        /// Note also that rotation by any multiple of 64 is a
+        /// no-op, so all but the last six bits of the rotation distance can be
+        /// ignored, even if the distance is negative:
+        /// <c>val.RotateLeft(distance) == val.RotateLeft(distance &amp; 0x3F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROL.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> value to rotate left.</param>
+        /// <param name="distance">The number of bits to rotate.</param>
+        /// <returns>The value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> left by the
+        /// specified number of bits.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static ulong RotateLeft(this ulong value, int distance)
+        {
+            if (distance == 0)
+                return value;
+            /*
+             * According to JLS3, 15.19, the right operand of a shift is always
+             * implicitly masked with 0x3F, which the negation of 'distance' is
+             * taking advantage of.
+             */
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.RotateLeft(value, distance);
+#else
+            return (value << distance) | (value >> (64 - distance));
+#endif
+        }
+
+        /// <summary>
+        /// Rotates the specified value left by the specified number of bits.
+        /// Similar in behavior to the x86 instruction ROL.
+        /// </summary>
+        /// <param name="value">The value to rotate.</param>
+        /// <param name="distance">The number of bits to rotate by.
+        /// Any value outside the range [0..31] is treated as congruent mod 32 on a 32-bit process,
+        /// and any value outside the range [0..63] is treated as congruent mod 64 on a 64-bit process.</param>
+        /// <returns>The rotated value.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static nuint RotateLeft(this nuint value, int distance)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.RotateLeft(value, distance);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return (nuint)RotateLeft((ulong)value, distance);
+            }
+            else
+            {
+                return (nuint)RotateLeft((uint)value, distance);
+            }
+#endif
+        }
+
+        #endregion RotateLeft
 
         #region RotateRight
 
@@ -517,6 +1118,8 @@ namespace J2N.Numerics
         /// no-op, so all but the last five bits of the rotation distance can be
         /// ignored, even if the distance is negative:
         /// <c>val.RotateRight(distance) == val.RotateLeft(distance &amp; 0x1F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROR.
         /// </summary>
         /// <param name="value">The <see cref="int"/> value to rotate right.</param>
         /// <param name="distance">The number of bits to rotate.</param>
@@ -542,6 +1145,45 @@ namespace J2N.Numerics
 
         /// <summary>
         /// Returns the value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> right by the
+        /// specified number of bits.  (Bits shifted out of the right hand, or
+        /// low-order, side reenter on the left, or high-order.)
+        /// <para/>
+        /// Note that right rotation with a negative distance is equivalent to
+        /// left rotation: <c>val.RotateRight(-distance) == val.RotateLeft(distance)</c>.
+        /// Note also that rotation by any multiple of 32 is a
+        /// no-op, so all but the last five bits of the rotation distance can be
+        /// ignored, even if the distance is negative:
+        /// <c>val.RotateRight(distance) == val.RotateLeft(distance &amp; 0x1F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROR.
+        /// </summary>
+        /// <param name="value">The <see cref="uint"/> value to rotate right.</param>
+        /// <param name="distance">The number of bits to rotate.</param>
+        /// <returns>The value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> right by the
+        /// specified number of bits.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static uint RotateRight(this uint value, int distance)
+        {
+            if (distance == 0)
+                return value;
+            /*
+             * According to JLS3, 15.19, the right operand of a shift is always
+             * implicitly masked with 0x1F, which the negation of 'distance' is
+             * taking advantage of.
+             */
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.RotateRight(value, distance);
+#else
+            return (value >> distance) | (value << (32 - distance));
+#endif
+        }
+
+        /// <summary>
+        /// Returns the value obtained by rotating the two's complement binary
         /// representation of the specified <see cref="long"/> value right by the
         /// specified number of bits.  (Bits shifted out of the right hand, or
         /// low-order, side reenter on the left, or high-order.)
@@ -552,6 +1194,8 @@ namespace J2N.Numerics
         /// no-op, so all but the last six bits of the rotation distance can be
         /// ignored, even if the distance is negative: 
         /// <c>val.RotateRight(distance) == val.RotateRight(distance &amp; 0x3F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROR.
         /// </summary>
         /// <param name="value">The <see cref="long"/> value to rotate right.</param>
         /// <param name="distance">The number of bits to rotate.</param>
@@ -575,7 +1219,240 @@ namespace J2N.Numerics
 #endif
         }
 
-        #endregion
+        /// <summary>
+        /// Returns the value obtained by rotating the two's complement binary
+        /// representation of the specified <see cref="long"/> value right by the
+        /// specified number of bits.  (Bits shifted out of the right hand, or
+        /// low-order, side reenter on the left, or high-order.)
+        /// <para/>
+        /// Note that right rotation with a negative distance is equivalent to
+        /// left rotation: <c>val.RotateRight(-distance) == val.RotateLeft(distance)</c>.
+        /// Note also that rotation by any multiple of 64 is a
+        /// no-op, so all but the last six bits of the rotation distance can be
+        /// ignored, even if the distance is negative: 
+        /// <c>val.RotateRight(distance) == val.RotateRight(distance &amp; 0x3F)</c>.
+        /// <para/>
+        /// Similar in behavior to the x86 instruction ROR.
+        /// </summary>
+        /// <param name="value">The <see cref="ulong"/> value to rotate right.</param>
+        /// <param name="distance">The number of bits to rotate.</param>
+        /// <returns>The value obtained by rotating the two's complement binary
+        /// representation of the specified <paramref name="value"/> right by the
+        /// specified number of bits.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static ulong RotateRight(this ulong value, int distance)
+        {
+            if (distance == 0)
+                return value;
+            /*
+             * According to JLS3, 15.19, the right operand of a shift is always
+             * implicitly masked with 0x3F, which the negation of 'distance' is
+             * taking advantage of.
+             */
+#if FEATURE_NUMERICBITOPERATIONS
+            return System.Numerics.BitOperations.RotateRight(value, distance);
+#else
+            return (value >> distance) | (value << (64 - distance));
+#endif
+        }
+
+        /// <summary>
+        /// Rotates the specified value right by the specified number of bits.
+        /// Similar in behavior to the x86 instruction ROR.
+        /// </summary>
+        /// <param name="value">The value to rotate.</param>
+        /// <param name="distance">The number of bits to rotate by.
+        /// Any value outside the range [0..31] is treated as congruent mod 32 on a 32-bit process,
+        /// and any value outside the range [0..63] is treated as congruent mod 64 on a 64-bit process.</param>
+        /// <returns>The rotated value.</returns>
+        //[Intrinsic]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static nuint RotateRight(this nuint value, int distance)
+        {
+#if FEATURE_BITOPERATIONS_UINTPTR
+            return System.Numerics.BitOperations.RotateRight(value, distance);
+#else
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return (nuint)RotateRight((ulong)value, distance);
+            }
+            else
+            {
+                return (nuint)RotateRight((uint)value, distance);
+            }
+#endif
+        }
+
+        #endregion RotateRight
+
+        #region RoundUpToPowerOf2
+
+        /// <summary>Round the given integral value up to a power of 2.</summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int RoundUpToPowerOf2(this int value)
+        {
+            if (value <= 0)
+                return 0;
+
+            // Cap check: max power of two for signed int is 1 << 30
+            if (value > (1 << 30))
+                return 0;
+
+#if FEATURE_BITOPERATIONS_ROUNDUPTOPOWEROF2
+            return (int)System.Numerics.BitOperations.RoundUpToPowerOf2((uint)value);
+#elif FEATURE_NUMERICBITOPERATIONS
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return (int)(0x1_0000_0000ul >> LeadingZeroCount(value - 1));
+            }
+            else
+            {
+                int shift = 32 - LeadingZeroCount(value - 1);
+                return (int)(1u ^ (uint)(shift >> 5)) << shift;
+            }
+#else
+            // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --value;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+#endif
+        }
+
+        /// <summary>Round the given integral value up to a power of 2.</summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static uint RoundUpToPowerOf2(this uint value)
+        {
+#if FEATURE_BITOPERATIONS_ROUNDUPTOPOWEROF2
+            return System.Numerics.BitOperations.RoundUpToPowerOf2(value);
+#elif FEATURE_NUMERICBITOPERATIONS
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return (uint)(0x1_0000_0000ul >> LeadingZeroCount(value - 1));
+            }
+            else
+            {
+                int shift = 32 - LeadingZeroCount(value - 1);
+                return (1u ^ (uint)(shift >> 5)) << shift;
+            }
+#else
+            // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --value;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            return value + 1;
+#endif
+        }
+
+        /// <summary>
+        /// Round the given integral value up to a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long RoundUpToPowerOf2(this long value)
+        {
+            if (value <= 0)
+                return 0;
+
+            // Cap check: max power of 2 for long is 1L << 62
+            if (value > (1L << 62))
+                return 0;
+
+#if FEATURE_BITOPERATIONS_ROUNDUPTOPOWEROF2
+            return (long)System.Numerics.BitOperations.RoundUpToPowerOf2((ulong)value);
+#elif FEATURE_NUMERICBITOPERATIONS
+            int shift = 64 - LeadingZeroCount(value - 1);
+            return (long)(1ul ^ (ulong)(shift >> 6)) << shift;
+#else
+            // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --value;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            value |= value >> 32;
+            return value + 1;
+#endif
+        }
+
+        /// <summary>
+        /// Round the given integral value up to a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static ulong RoundUpToPowerOf2(this ulong value)
+        {
+#if FEATURE_BITOPERATIONS_ROUNDUPTOPOWEROF2
+            return System.Numerics.BitOperations.RoundUpToPowerOf2(value);
+#elif FEATURE_NUMERICBITOPERATIONS
+            int shift = 64 - LeadingZeroCount(value - 1);
+            return (1ul ^ (ulong)(shift >> 6)) << shift;
+#else
+            // Based on https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --value;
+            value |= value >> 1;
+            value |= value >> 2;
+            value |= value >> 4;
+            value |= value >> 8;
+            value |= value >> 16;
+            value |= value >> 32;
+            return value + 1;
+#endif
+        }
+
+        /// <summary>
+        /// Round the given integral value up to a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>
+        /// The smallest power of 2 which is greater than or equal to <paramref name="value"/>.
+        /// If <paramref name="value"/> is 0 or the result overflows, returns 0.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static nuint RoundUpToPowerOf2(this nuint value)
+        {
+            if (IntPtr.Size == 8) // 64-bit process
+            {
+                return (nuint)RoundUpToPowerOf2((ulong)value);
+            }
+            else
+            {
+                return (nuint)RoundUpToPowerOf2((uint)value);
+            }
+        }
+
+        #endregion RoundUpToPowerOf2
 
         #region TripleShift
 
@@ -679,6 +1556,6 @@ namespace J2N.Numerics
             return (long)((ulong)number >> bits);
         }
 
-        #endregion
+        #endregion TripleShift
     }
 }

--- a/tests/J2N.TestUtilities/PlatformDetection.cs
+++ b/tests/J2N.TestUtilities/PlatformDetection.cs
@@ -117,6 +117,9 @@ namespace J2N.TestUtilities
             return Environment.GetEnvironmentVariable(variableName) is "true";
         }
 
+        public static bool Is32BitProcess => IntPtr.Size == 4;
+        public static bool Is64BitProcess => IntPtr.Size == 8;
+
         public static bool IsRiscV64Process => (int)RuntimeInformation.ProcessArchitecture == 9; // Architecture.RiscV64;
     }
 }

--- a/tests/Xunit/J2N.Runtime.Tests/Math/Double.Log2.cs
+++ b/tests/Xunit/J2N.Runtime.Tests/Math/Double.Log2.cs
@@ -1,0 +1,38 @@
+﻿// Source: https://github.com/dotnet/runtime/blob/v9.0.9/src/tests/JIT/Math/Functions/Double/Log2.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Xunit;
+
+namespace J2N.MathBenchmarks
+{
+    public partial class Double
+    {
+        // Tests Math.Log2(double) over 5000 iterations for the domain +1, +3
+
+        private const double log2Delta = 0.0004;
+        private const double log2ExpectedResult = 4672.9510376532398;
+
+        [Fact]
+        public void Log2() => Log2Test();
+
+        private static void Log2Test()
+        {
+            double result = 0.0, value = 1.0;
+
+            for (int iteration = 0; iteration < MathTests.Iterations; iteration++)
+            {
+                result += MathExtensions.Log2(value);
+                value += log2Delta;
+            }
+
+            double diff = Math.Abs(log2ExpectedResult - result);
+
+            if (double.IsNaN(result) || (diff > MathTests.DoubleEpsilon))
+            {
+                throw new Exception($"Expected Result {log2ExpectedResult,20:g17}; Actual Result {result,20:g17}");
+            }
+        }
+    }
+}

--- a/tests/Xunit/J2N.Runtime.Tests/Math/MathTests.cs
+++ b/tests/Xunit/J2N.Runtime.Tests/Math/MathTests.cs
@@ -1,0 +1,29 @@
+﻿// Source: https://github.com/dotnet/runtime/blob/v9.0.9/src/tests/JIT/Math/Functions/MathTests.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace J2N.MathBenchmarks
+{
+    public partial class MathTests
+    {
+        // double has a machine epsilon of approx: 2.22e-16. However, due to floating-point precision
+        // errors, this is too accurate when aggregating values of a set of iterations. Using the
+        // single-precision machine epsilon as our epsilon should be 'good enough' for the purposes
+        // of the perf testing as it ensures we get the expected value and that it is at least as precise
+        // as we would have computed with the single-precision version of the function (without aggregation).
+        public const double DoubleEpsilon = 1.19e-07;
+
+        // 5000 iterations is enough to cover the full domain of inputs for certain functions (such
+        // as Cos, which has a domain of 0 to PI) at reasonable intervals (in the case of Cos, the
+        // interval is PI / 5000 which is 0.0006283185307180). It should also give reasonable coverage
+        // for functions which have a larger domain (such as Atan, which covers the full set of real numbers).
+        public const int Iterations = 5000;
+
+        // float has a machine epsilon of approx: 1.19e-07. However, due to floating-point precision
+        // errors, this is too accurate when aggregating values of a set of iterations. Using the
+        // half-precision machine epsilon as our epsilon should be 'good enough' for the purposes
+        // of the perf testing as it ensures we get the expected value and that it is at least as precise
+        // as we would have computed with the half-precision version of the function (without aggregation).
+        public const float SingleEpsilon = 9.77e-04f;
+    }
+}

--- a/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
+++ b/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
@@ -1,4 +1,4 @@
-﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Numerics/BitOperationTests.cs
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Numerics/BitOperationsTests.cs
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
@@ -247,7 +247,7 @@ namespace J2N.Numerics.Tests
         [InlineData(uint.MaxValue, 0)]
         public static void BitOps_LeadingZeroCount_nuint_32(uint n, int expected)
         {
-            int actual = BitOperation.LeadingZeroCount(n);
+            int actual = BitOperation.LeadingZeroCount((nuint)n);
             Assert.Equal(expected, actual);
         }
 
@@ -270,7 +270,7 @@ namespace J2N.Numerics.Tests
         [InlineData(ulong.MaxValue, 0)]
         public static void BitOps_LeadingZeroCount_nuint_64(ulong n, int expected)
         {
-            int actual = BitOperation.LeadingZeroCount(n);
+            int actual = BitOperation.LeadingZeroCount((nuint)n);
             Assert.Equal(expected, actual);
         }
 
@@ -763,15 +763,15 @@ namespace J2N.Numerics.Tests
                 if (Environment.Is64BitProcess)
                 {
                     const ulong value = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
-                    Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
-                        BitOperation.RotateRight(value, 1));
-                    Assert.Equal(0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul,
-                        BitOperation.RotateRight(value, 2));
-                    Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
-                        BitOperation.RotateRight(value, 3));
-                    Assert.Equal(value, BitOperation.RotateRight(value, int.MinValue)); // % 64 = 0
-                    Assert.Equal(BitOperation.RotateLeft(value, 63),
-                        BitOperation.RotateRight(value, int.MaxValue)); // % 64 = 63
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateRight((nuint)value, 1));
+                    Assert.Equal((nuint)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul,
+                        BitOperation.RotateRight((nuint)value, 2));
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateRight((nuint)value, 3));
+                    Assert.Equal((nuint)value, BitOperation.RotateRight((nuint)value, int.MinValue)); // % 64 = 0
+                    Assert.Equal(BitOperation.RotateLeft((nuint)value, 63),
+                        BitOperation.RotateRight((nuint)value, int.MaxValue)); // % 64 = 63
                 }
                 else
                 {

--- a/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
+++ b/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
@@ -1,0 +1,995 @@
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Numerics/BitOperationTests.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using J2N.TestUtilities;
+using J2N.TestUtilities.Xunit;
+using System;
+using Xunit;
+
+namespace J2N.Numerics.Tests
+{
+    public static class BitOperationTests
+    {
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(0b1, true)]
+        [InlineData(0b10, true)]
+        [InlineData(0b100, true)]
+        [InlineData(0b1000, true)]
+        [InlineData(0b10000, true)]
+        [InlineData(0b100000, true)]
+        [InlineData(0b1000000, true)]
+        [InlineData(-0b1000000, false)]
+        [InlineData(0b1000001, false)]
+        [InlineData(0b1010001, false)]
+        [InlineData(0b1111111, false)]
+        [InlineData(-1, false)]
+        [InlineData(int.MaxValue, false)]
+        [InlineData(int.MinValue, false)]
+        public static void BitOps_IsPow2_int(int n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0u, false)]
+        [InlineData(0b1u, true)]
+        [InlineData(0b10u, true)]
+        [InlineData(0b100u, true)]
+        [InlineData(0b1000u, true)]
+        [InlineData(0b10000u, true)]
+        [InlineData(0b100000u, true)]
+        [InlineData(0b1000000u, true)]
+        [InlineData(0b1000001u, false)]
+        [InlineData(0b1010001u, false)]
+        [InlineData(0b1111111u, false)]
+        [InlineData(uint.MaxValue, false)]
+        [InlineData(unchecked((uint)int.MinValue), true)]
+        public static void BitOps_IsPow2_uint(uint n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0L, false)]
+        [InlineData(0b1L, true)]
+        [InlineData(0b10L, true)]
+        [InlineData(0b100L, true)]
+        [InlineData(0b1000L, true)]
+        [InlineData(0b10000L, true)]
+        [InlineData(0b100000L, true)]
+        [InlineData(0b1000000L, true)]
+        [InlineData(-0b1000000L, false)]
+        [InlineData(0b1000001L, false)]
+        [InlineData(0b1010001L, false)]
+        [InlineData(0b1111111L, false)]
+        [InlineData(-1L, false)]
+        [InlineData(long.MaxValue, false)]
+        [InlineData(long.MinValue, false)]
+        public static void BitOps_IsPow2_long(long n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0ul, false)]
+        [InlineData(0b1ul, true)]
+        [InlineData(0b10ul, true)]
+        [InlineData(0b100ul, true)]
+        [InlineData(0b1000ul, true)]
+        [InlineData(0b10000ul, true)]
+        [InlineData(0b100000ul, true)]
+        [InlineData(0b1000000ul, true)]
+        [InlineData(0b1000001ul, false)]
+        [InlineData(0b1010001ul, false)]
+        [InlineData(0b1111111ul, false)]
+        [InlineData(ulong.MaxValue, false)]
+        [InlineData(unchecked((ulong)long.MinValue), true)]
+        public static void BitOps_IsPow2_ulong(ulong n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0, false)]
+        [InlineData(0b1, true)]
+        [InlineData(0b10, true)]
+        [InlineData(0b100, true)]
+        [InlineData(0b1000, true)]
+        [InlineData(0b10000, true)]
+        [InlineData(0b100000, true)]
+        [InlineData(0b1000000, true)]
+        [InlineData(-0b1000000, false)]
+        [InlineData(0b1000001, false)]
+        [InlineData(0b1010001, false)]
+        [InlineData(0b1111111, false)]
+        [InlineData(-1, false)]
+        [InlineData(int.MaxValue, false)]
+        [InlineData(int.MinValue, false)]
+        public static void BitOps_IsPow2_nint_32(int n, bool expected)
+        {
+            //if (PlatformDetection.Is32BitProcess)
+            //{
+            //    throw new Xunit.Sdk.SkipException("Condition not met, skipping test.");
+            //}
+
+            bool actual = BitOperation.IsPow2((nint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0, false)]
+        [InlineData(0b1, true)]
+        [InlineData(0b10, true)]
+        [InlineData(0b100, true)]
+        [InlineData(0b1000, true)]
+        [InlineData(0b10000, true)]
+        [InlineData(0b100000, true)]
+        [InlineData(0b1000000, true)]
+        [InlineData(-0b1000000, false)]
+        [InlineData(0b1000001, false)]
+        [InlineData(0b1010001, false)]
+        [InlineData(0b1111111, false)]
+        [InlineData(-1, false)]
+        [InlineData(long.MaxValue, false)]
+        [InlineData(long.MinValue, false)]
+        public static void BitOps_IsPow2_nint_64(long n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2((nint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0u, false)]
+        [InlineData(0b1u, true)]
+        [InlineData(0b10u, true)]
+        [InlineData(0b100u, true)]
+        [InlineData(0b1000u, true)]
+        [InlineData(0b10000u, true)]
+        [InlineData(0b100000u, true)]
+        [InlineData(0b1000000u, true)]
+        [InlineData(0b1000001u, false)]
+        [InlineData(0b1010001u, false)]
+        [InlineData(0b1111111u, false)]
+        [InlineData(unchecked((uint)int.MinValue), true)]
+        [InlineData(uint.MaxValue, false)]
+        public static void BitOps_IsPow2_nuint_32(uint n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0u, false)]
+        [InlineData(0b1u, true)]
+        [InlineData(0b10u, true)]
+        [InlineData(0b100u, true)]
+        [InlineData(0b1000u, true)]
+        [InlineData(0b10000u, true)]
+        [InlineData(0b100000u, true)]
+        [InlineData(0b1000000u, true)]
+        [InlineData(0b1000001u, false)]
+        [InlineData(0b1010001u, false)]
+        [InlineData(0b1111111u, false)]
+        [InlineData(unchecked((uint)int.MinValue), true)]
+        [InlineData(ulong.MaxValue, false)]
+        public static void BitOps_IsPow2_nuint_64(ulong n, bool expected)
+        {
+            bool actual = BitOperation.IsPow2((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Theory]
+        [InlineData(0u, 32)]
+        [InlineData(0b1u, 31)]
+        [InlineData(0b10u, 30)]
+        [InlineData(0b100u, 29)]
+        [InlineData(0b1000u, 28)]
+        [InlineData(0b10000u, 27)]
+        [InlineData(0b100000u, 26)]
+        [InlineData(0b1000000u, 25)]
+        [InlineData(byte.MaxValue << 17, 32 - 8 - 17)]
+        [InlineData(byte.MaxValue << 9, 32 - 8 - 9)]
+        [InlineData(ushort.MaxValue << 11, 32 - 16 - 11)]
+        [InlineData(ushort.MaxValue << 2, 32 - 16 - 2)]
+        [InlineData(5 << 7, 32 - 3 - 7)]
+        [InlineData(uint.MaxValue, 0)]
+        public static void BitOps_LeadingZeroCount_uint(uint n, int expected)
+        {
+            int actual = BitOperation.LeadingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0ul, 64)]
+        [InlineData(0b1ul, 63)]
+        [InlineData(0b10ul, 62)]
+        [InlineData(0b100ul, 61)]
+        [InlineData(0b1000ul, 60)]
+        [InlineData(0b10000ul, 59)]
+        [InlineData(0b100000ul, 58)]
+        [InlineData(0b1000000ul, 57)]
+        [InlineData((ulong)byte.MaxValue << 41, 64 - 8 - 41)]
+        [InlineData((ulong)byte.MaxValue << 53, 64 - 8 - 53)]
+        [InlineData((ulong)ushort.MaxValue << 31, 64 - 16 - 31)]
+        [InlineData((ulong)ushort.MaxValue << 15, 64 - 16 - 15)]
+        [InlineData(ulong.MaxValue >> 5, 5)]
+        [InlineData(1ul << 63, 0)]
+        [InlineData(1ul << 62, 1)]
+        [InlineData(ulong.MaxValue, 0)]
+        public static void BitOps_LeadingZeroCount_ulong(ulong n, int expected)
+        {
+            int actual = BitOperation.LeadingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0u, 32)]
+        [InlineData(0b1u, 31)]
+        [InlineData(0b10u, 30)]
+        [InlineData(0b100u, 29)]
+        [InlineData(0b1000u, 28)]
+        [InlineData(0b10000u, 27)]
+        [InlineData(0b100000u, 26)]
+        [InlineData(0b1000000u, 25)]
+        [InlineData(byte.MaxValue << 17, 32 - 8 - 17)]
+        [InlineData(byte.MaxValue << 9, 32 - 8 - 9)]
+        [InlineData(ushort.MaxValue << 11, 32 - 16 - 11)]
+        [InlineData(ushort.MaxValue << 2, 32 - 16 - 2)]
+        [InlineData(5 << 7, 32 - 3 - 7)]
+        [InlineData(uint.MaxValue, 0)]
+        public static void BitOps_LeadingZeroCount_nuint_32(uint n, int expected)
+        {
+            int actual = BitOperation.LeadingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0ul, 64)]
+        [InlineData(0b1ul, 63)]
+        [InlineData(0b10ul, 62)]
+        [InlineData(0b100ul, 61)]
+        [InlineData(0b1000ul, 60)]
+        [InlineData(0b10000ul, 59)]
+        [InlineData(0b100000ul, 58)]
+        [InlineData(0b1000000ul, 57)]
+        [InlineData((ulong)byte.MaxValue << 41, 64 - 8 - 41)]
+        [InlineData((ulong)byte.MaxValue << 53, 64 - 8 - 53)]
+        [InlineData((ulong)ushort.MaxValue << 31, 64 - 16 - 31)]
+        [InlineData((ulong)ushort.MaxValue << 15, 64 - 16 - 15)]
+        [InlineData(ulong.MaxValue >> 5, 5)]
+        [InlineData(1ul << 63, 0)]
+        [InlineData(1ul << 62, 1)]
+        [InlineData(ulong.MaxValue, 0)]
+        public static void BitOps_LeadingZeroCount_nuint_64(ulong n, int expected)
+        {
+            int actual = BitOperation.LeadingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0u, 32)]
+        [InlineData(0b1u, 0)]
+        [InlineData(0b10u, 1)]
+        [InlineData(0b100u, 2)]
+        [InlineData(0b1000u, 3)]
+        [InlineData(0b10000u, 4)]
+        [InlineData(0b100000u, 5)]
+        [InlineData(0b1000000u, 6)]
+        [InlineData((uint)byte.MaxValue << 24, 24)]
+        [InlineData((uint)byte.MaxValue << 22, 22)]
+        [InlineData((uint)ushort.MaxValue << 16, 16)]
+        [InlineData((uint)ushort.MaxValue << 19, 19)]
+        [InlineData(uint.MaxValue << 5, 5)]
+        [InlineData(3u << 27, 27)]
+        [InlineData(uint.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_uint(uint n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 32)]
+        [InlineData(0b1, 0)]
+        [InlineData(0b10, 1)]
+        [InlineData(0b100, 2)]
+        [InlineData(0b1000, 3)]
+        [InlineData(0b10000, 4)]
+        [InlineData(0b100000, 5)]
+        [InlineData(0b1000000, 6)]
+        [InlineData(byte.MaxValue << 24, 24)]
+        [InlineData(byte.MaxValue << 22, 22)]
+        [InlineData(ushort.MaxValue << 16, 16)]
+        [InlineData(ushort.MaxValue << 19, 19)]
+        [InlineData(int.MaxValue << 5, 5)]
+        [InlineData(3 << 27, 27)]
+        [InlineData(int.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_int(int n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0ul, 64)]
+        [InlineData(0b1ul, 0)]
+        [InlineData(0b10ul, 1)]
+        [InlineData(0b100ul, 2)]
+        [InlineData(0b1000ul, 3)]
+        [InlineData(0b10000ul, 4)]
+        [InlineData(0b100000ul, 5)]
+        [InlineData(0b1000000ul, 6)]
+        [InlineData((ulong)byte.MaxValue << 40, 40)]
+        [InlineData((ulong)byte.MaxValue << 57, 57)]
+        [InlineData((ulong)ushort.MaxValue << 31, 31)]
+        [InlineData((ulong)ushort.MaxValue << 15, 15)]
+        [InlineData(ulong.MaxValue << 5, 5)]
+        [InlineData(3ul << 59, 59)]
+        [InlineData(5ul << 63, 63)]
+        [InlineData(ulong.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_ulong(ulong n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0L, 64)]
+        [InlineData(0b1L, 0)]
+        [InlineData(0b10L, 1)]
+        [InlineData(0b100L, 2)]
+        [InlineData(0b1000L, 3)]
+        [InlineData(0b10000L, 4)]
+        [InlineData(0b100000L, 5)]
+        [InlineData(0b1000000L, 6)]
+        [InlineData((long)byte.MaxValue << 40, 40)]
+        [InlineData((long)byte.MaxValue << 57, 57)]
+        [InlineData((long)ushort.MaxValue << 31, 31)]
+        [InlineData((long)ushort.MaxValue << 15, 15)]
+        [InlineData(long.MaxValue << 5, 5)]
+        [InlineData(3L << 59, 59)]
+        [InlineData(5L << 63, 63)]
+        [InlineData(long.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_long(long n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0u, 32)]
+        [InlineData(0b1u, 0)]
+        [InlineData(0b10u, 1)]
+        [InlineData(0b100u, 2)]
+        [InlineData(0b1000u, 3)]
+        [InlineData(0b10000u, 4)]
+        [InlineData(0b100000u, 5)]
+        [InlineData(0b1000000u, 6)]
+        [InlineData((uint)byte.MaxValue << 24, 24)]
+        [InlineData((uint)byte.MaxValue << 22, 22)]
+        [InlineData((uint)ushort.MaxValue << 16, 16)]
+        [InlineData((uint)ushort.MaxValue << 19, 19)]
+        [InlineData(uint.MaxValue << 5, 5)]
+        [InlineData(3u << 27, 27)]
+        [InlineData(uint.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_nuint_32(uint n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0ul, 64)]
+        [InlineData(0b1ul, 0)]
+        [InlineData(0b10ul, 1)]
+        [InlineData(0b100ul, 2)]
+        [InlineData(0b1000ul, 3)]
+        [InlineData(0b10000ul, 4)]
+        [InlineData(0b100000ul, 5)]
+        [InlineData(0b1000000ul, 6)]
+        [InlineData((ulong)byte.MaxValue << 40, 40)]
+        [InlineData((ulong)byte.MaxValue << 57, 57)]
+        [InlineData((ulong)ushort.MaxValue << 31, 31)]
+        [InlineData((ulong)ushort.MaxValue << 15, 15)]
+        [InlineData(ulong.MaxValue << 5, 5)]
+        [InlineData(3ul << 59, 59)]
+        [InlineData(5ul << 63, 63)]
+        [InlineData(ulong.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_nuint_64(ulong n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0, 32)]
+        [InlineData(0b1, 0)]
+        [InlineData(0b10, 1)]
+        [InlineData(0b100, 2)]
+        [InlineData(0b1000, 3)]
+        [InlineData(0b10000, 4)]
+        [InlineData(0b100000, 5)]
+        [InlineData(0b1000000, 6)]
+        [InlineData(byte.MaxValue << 24, 24)]
+        [InlineData(byte.MaxValue << 22, 22)]
+        [InlineData(ushort.MaxValue << 16, 16)]
+        [InlineData(ushort.MaxValue << 19, 19)]
+        [InlineData(int.MaxValue << 5, 5)]
+        [InlineData(3 << 27, 27)]
+        [InlineData(int.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_nint_32(int n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount((nint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0L, 64)]
+        [InlineData(0b1L, 0)]
+        [InlineData(0b10L, 1)]
+        [InlineData(0b100L, 2)]
+        [InlineData(0b1000L, 3)]
+        [InlineData(0b10000L, 4)]
+        [InlineData(0b100000L, 5)]
+        [InlineData(0b1000000L, 6)]
+        [InlineData((long)byte.MaxValue << 40, 40)]
+        [InlineData((long)byte.MaxValue << 57, 57)]
+        [InlineData((long)ushort.MaxValue << 31, 31)]
+        [InlineData((long)ushort.MaxValue << 15, 15)]
+        [InlineData(long.MaxValue << 5, 5)]
+        [InlineData(3L << 59, 59)]
+        [InlineData(5L << 63, 63)]
+        [InlineData(long.MaxValue, 0)]
+        public static void BitOps_TrailingZeroCount_nint_64(long n, int expected)
+        {
+            int actual = BitOperation.TrailingZeroCount((nint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(3, 2 - 1)]
+        [InlineData(4, 2)]
+        [InlineData(5, 3 - 1)]
+        [InlineData(6, 3 - 1)]
+        [InlineData(7, 3 - 1)]
+        [InlineData(8, 3)]
+        [InlineData(9, 4 - 1)]
+        [InlineData(byte.MaxValue, 8 - 1)]
+        [InlineData(ushort.MaxValue, 16 - 1)]
+        [InlineData(uint.MaxValue, 32 - 1)]
+        public static void BitOps_Log2_uint(uint n, int expected)
+        {
+            int actual = BitOperation.Log2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(3, 2 - 1)]
+        [InlineData(4, 2)]
+        [InlineData(5, 3 - 1)]
+        [InlineData(6, 3 - 1)]
+        [InlineData(7, 3 - 1)]
+        [InlineData(8, 3)]
+        [InlineData(9, 4 - 1)]
+        [InlineData(byte.MaxValue, 8 - 1)]
+        [InlineData(ushort.MaxValue, 16 - 1)]
+        [InlineData(uint.MaxValue, 32 - 1)]
+        [InlineData(ulong.MaxValue, 64 - 1)]
+        public static void BitOps_Log2_ulong(ulong n, int expected)
+        {
+            int actual = BitOperation.Log2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(3, 2 - 1)]
+        [InlineData(4, 2)]
+        [InlineData(5, 3 - 1)]
+        [InlineData(6, 3 - 1)]
+        [InlineData(7, 3 - 1)]
+        [InlineData(8, 3)]
+        [InlineData(9, 4 - 1)]
+        [InlineData(byte.MaxValue, 8 - 1)]
+        [InlineData(ushort.MaxValue, 16 - 1)]
+        [InlineData(uint.MaxValue, 32 - 1)]
+        public static void BitOps_Log2_nuint_32(uint n, int expected)
+        {
+            int actual = BitOperation.Log2((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0, 0)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(3, 2 - 1)]
+        [InlineData(4, 2)]
+        [InlineData(5, 3 - 1)]
+        [InlineData(6, 3 - 1)]
+        [InlineData(7, 3 - 1)]
+        [InlineData(8, 3)]
+        [InlineData(9, 4 - 1)]
+        [InlineData(byte.MaxValue, 8 - 1)]
+        [InlineData(ushort.MaxValue, 16 - 1)]
+        [InlineData(uint.MaxValue, 32 - 1)]
+        [InlineData(ulong.MaxValue, 64 - 1)]
+        public static void BitOps_Log2_nuint_64(ulong n, int expected)
+        {
+            int actual = BitOperation.Log2((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0b001, 1)]
+        [InlineData(0b010, 1)]
+        [InlineData(0b011, 2)]
+        [InlineData(0b100, 1)]
+        [InlineData(0b101, 2)]
+        [InlineData(0b110, 2)]
+        [InlineData(0b111, 3)]
+        [InlineData(0b1101, 3)]
+        [InlineData(0b1111, 4)]
+        [InlineData(0b10111, 4)]
+        [InlineData(0b11111, 5)]
+        [InlineData(0b110111, 5)]
+        [InlineData(0b111111, 6)]
+        [InlineData(0b1111110, 6)]
+        [InlineData(byte.MinValue, 0)] // 0
+        [InlineData(byte.MaxValue, 8)] // 255
+        [InlineData(unchecked((uint)sbyte.MinValue), 25)] // 4294967168
+        [InlineData(sbyte.MaxValue, 7)] // 127
+        [InlineData(ushort.MaxValue >> 3, 16 - 3)] // 8191
+        [InlineData(ushort.MaxValue, 16)] // 65535
+        [InlineData(unchecked((uint)short.MinValue), 32 - 15)] // 4294934528
+        [InlineData(short.MaxValue, 15)] // 32767
+        [InlineData(unchecked((uint)int.MinValue), 1)] // 2147483648
+        [InlineData(unchecked((uint)int.MaxValue), 31)] // 4294967168
+        [InlineData(uint.MaxValue >> 5, 32 - 5)] // 134217727
+        [InlineData(uint.MaxValue << 11, 32 - 11)] // 4294965248
+        [InlineData(uint.MaxValue, 32)] // 4294967295
+        public static void BitOps_PopCount_uint(uint n, int expected)
+        {
+            int actual = BitOperation.PopCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0b001, 1)]
+        [InlineData(0b010, 1)]
+        [InlineData(0b011, 2)]
+        [InlineData(0b100, 1)]
+        [InlineData(0b101, 2)]
+        [InlineData(0b110, 2)]
+        [InlineData(0b111, 3)]
+        [InlineData(0b1101, 3)]
+        [InlineData(0b1111, 4)]
+        [InlineData(0b10111, 4)]
+        [InlineData(0b11111, 5)]
+        [InlineData(0b110111, 5)]
+        [InlineData(0b111111, 6)]
+        [InlineData(0b1111110, 6)]
+        [InlineData(0b1111111, 7)]
+        [InlineData(byte.MinValue, 0)] // 0
+        [InlineData(byte.MaxValue, 8)] // 255
+        [InlineData(unchecked((ulong)sbyte.MinValue), 57)] // 18446744073709551488
+        [InlineData(sbyte.MaxValue, 7)] // 127
+        [InlineData(ushort.MaxValue, 16)] // 65535
+        [InlineData(unchecked((ulong)short.MinValue), 49)] // 18446744073709518848
+        [InlineData(short.MaxValue, 15)] // 32767
+        [InlineData(unchecked((ulong)int.MinValue), 64 - 31)] // 18446744071562067968
+        [InlineData(int.MaxValue, 31)] // 2147483647
+        [InlineData(ulong.MaxValue >> 9, 64 - 9)] // 36028797018963967
+        [InlineData(ulong.MaxValue << 11, 64 - 11)] // 18446744073709549568
+        [InlineData(ulong.MaxValue, 64)]
+        public static void BitOps_PopCount_ulong(ulong n, int expected)
+        {
+            int actual = BitOperation.PopCount(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0b001, 1)]
+        [InlineData(0b010, 1)]
+        [InlineData(0b011, 2)]
+        [InlineData(0b100, 1)]
+        [InlineData(0b101, 2)]
+        [InlineData(0b110, 2)]
+        [InlineData(0b111, 3)]
+        [InlineData(0b1101, 3)]
+        [InlineData(0b1111, 4)]
+        [InlineData(0b10111, 4)]
+        [InlineData(0b11111, 5)]
+        [InlineData(0b110111, 5)]
+        [InlineData(0b111111, 6)]
+        [InlineData(0b1111110, 6)]
+        public static void BitOps_PopCount_nuint_32(uint n, int expected)
+        {
+            int actual = BitOperation.PopCount((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0b001, 1)]
+        [InlineData(0b010, 1)]
+        [InlineData(0b011, 2)]
+        [InlineData(0b100, 1)]
+        [InlineData(0b101, 2)]
+        [InlineData(0b110, 2)]
+        [InlineData(0b111, 3)]
+        [InlineData(0b1101, 3)]
+        [InlineData(0b1111, 4)]
+        [InlineData(0b10111, 4)]
+        [InlineData(0b11111, 5)]
+        [InlineData(0b110111, 5)]
+        [InlineData(0b111111, 6)]
+        [InlineData(0b1111110, 6)]
+        [InlineData(0b1111111, 7)]
+        [InlineData(byte.MinValue, 0)] // 0
+        [InlineData(byte.MaxValue, 8)] // 255
+        [InlineData(unchecked((ulong)sbyte.MinValue), 57)] // 18446744073709551488
+        [InlineData(sbyte.MaxValue, 7)] // 127
+        [InlineData(ushort.MaxValue, 16)] // 65535
+        [InlineData(unchecked((ulong)short.MinValue), 49)] // 18446744073709518848
+        [InlineData(short.MaxValue, 15)] // 32767
+        [InlineData(unchecked((ulong)int.MinValue), 64 - 31)] // 18446744071562067968
+        [InlineData(int.MaxValue, 31)] // 2147483647
+        [InlineData(ulong.MaxValue >> 9, 64 - 9)] // 36028797018963967
+        [InlineData(ulong.MaxValue << 11, 64 - 11)] // 18446744073709549568
+        [InlineData(ulong.MaxValue, 64)]
+        public static void BitOps_PopCount_nuint_64(ulong n, int expected)
+        {
+            int actual = BitOperation.PopCount((nuint)n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0b00000000_00000000_00000000_00000001u, int.MaxValue, 0b10000000_00000000_00000000_00000000u)] // % 32 = 31
+        [InlineData(0b01000000_00000001_00000000_00000001u, 3, 0b00000000_00001000_00000000_00001010u)]
+        [InlineData(0b01000000_00000001_00000000_00000001u, 2, 0b00000000_00000100_00000000_00000101u)]
+        [InlineData(0b01010101_01010101_01010101_01010101u, 1, 0b10101010_10101010_10101010_10101010u)]
+        [InlineData(0b01010101_11111111_01010101_01010101u, 0, 0b01010101_11111111_01010101_01010101u)]
+        [InlineData(0b00000000_00000000_00000000_00000001u, -1, 0b10000000_00000000_00000000_00000000u)]
+        [InlineData(0b00000000_00000000_00000000_00000001u, -2, 0b01000000_00000000_00000000_00000000u)]
+        [InlineData(0b00000000_00000000_00000000_00000001u, -3, 0b00100000_00000000_00000000_00000000u)]
+        [InlineData(0b01010101_11111111_01010101_01010101u, int.MinValue, 0b01010101_11111111_01010101_01010101u)] // % 32 = 0
+        public static void BitOps_RotateLeft_uint(uint n, int offset, uint expected)
+        {
+            Assert.Equal(expected, BitOperation.RotateLeft(n, offset));
+        }
+
+        [Fact]
+        public static void BitOps_RotateLeft_nuint()
+        {
+            unchecked
+            {
+                if (Environment.Is64BitProcess)
+                {
+                    nuint value = (nuint)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateLeft(value, 1));
+                    Assert.Equal((nuint)0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul,
+                        BitOperation.RotateLeft(value, 2));
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateLeft(value, 3));
+                    Assert.Equal(value, BitOperation.RotateLeft(value, int.MinValue)); // % 64 = 0
+                    Assert.Equal(BitOperation.RotateLeft(value, 63),
+                        BitOperation.RotateLeft(value, int.MaxValue)); // % 64 = 63
+                }
+                else
+                {
+                    Assert.Equal((nuint)0b10000000_00000000_00000000_00000000u,
+                        BitOperation.RotateLeft((nuint)0b00000000_00000000_00000000_00000001u,
+                            int.MaxValue)); // % 32 = 31
+                    Assert.Equal((nuint)0b00000000_00001000_00000000_00001010u,
+                        BitOperation.RotateLeft((nuint)0b01000000_00000001_00000000_00000001u, 3));
+                    Assert.Equal((nuint)0b00000000_00000100_00000000_00000101u,
+                        BitOperation.RotateLeft((nuint)0b01000000_00000001_00000000_00000001u, 2));
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010u,
+                        BitOperation.RotateLeft((nuint)0b01010101_01010101_01010101_01010101u, 1));
+                    Assert.Equal((nuint)0b01010101_11111111_01010101_01010101u,
+                        BitOperation.RotateLeft((nuint)0b01010101_11111111_01010101_01010101u, 0));
+                    Assert.Equal((nuint)0b10000000_00000000_00000000_00000000u,
+                        BitOperation.RotateLeft((nuint)0b00000000_00000000_00000000_00000001u, -1));
+                    Assert.Equal((nuint)0b01000000_00000000_00000000_00000000u,
+                        BitOperation.RotateLeft((nuint)0b00000000_00000000_00000000_00000001u, -2));
+                    Assert.Equal((nuint)0b00100000_00000000_00000000_00000000u,
+                        BitOperation.RotateLeft((nuint)0b00000000_00000000_00000000_00000001u, -3));
+                    Assert.Equal((nuint)0b01010101_11111111_01010101_01010101u,
+                        BitOperation.RotateLeft((nuint)0b01010101_11111111_01010101_01010101u,
+                            int.MinValue)); // % 32 = 0
+                }
+            }
+        }
+
+        [Fact]
+        public static void BitOps_RotateLeft_ulong()
+        {
+            ulong value = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
+            Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitOperation.RotateLeft(value, 1));
+            Assert.Equal(0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul, BitOperation.RotateLeft(value, 2));
+            Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitOperation.RotateLeft(value, 3));
+            Assert.Equal(value, BitOperation.RotateLeft(value, int.MinValue)); // % 64 = 0
+            Assert.Equal(BitOperation.RotateLeft(value, 63), BitOperation.RotateLeft(value, int.MaxValue)); // % 64 = 63
+        }
+
+        [Theory]
+        [InlineData(0b10000000_00000000_00000000_00000000u, int.MaxValue, 0b00000000_00000000_00000000_00000001u)] // % 32 = 31
+        [InlineData(0b00000000_00001000_00000000_00001010u, 3, 0b01000000_00000001_00000000_00000001u)]
+        [InlineData(0b00000000_00000100_00000000_00000101u, 2, 0b01000000_00000001_00000000_00000001u)]
+        [InlineData(0b01010101_01010101_01010101_01010101u, 1, 0b10101010_10101010_10101010_10101010u)]
+        [InlineData(0b01010101_11111111_01010101_01010101u, 0, 0b01010101_11111111_01010101_01010101u)]
+        [InlineData(0b10000000_00000000_00000000_00000000u, -1, 0b00000000_00000000_00000000_00000001u)]
+        [InlineData(0b00000000_00000000_00000000_00000001u, -2, 0b00000000_00000000_00000000_00000100u)]
+        [InlineData(0b01000000_00000000_00000000_00000000u, -3, 0b00000000_00000000_00000000_00000010u)]
+        [InlineData(0b01010101_11111111_01010101_01010101u, int.MinValue, 0b01010101_11111111_01010101_01010101u)] // % 32 = 0
+        public static void BitOps_RotateRight_uint(uint n, int offset, uint expected)
+        {
+            Assert.Equal(expected, BitOperation.RotateRight(n, offset));
+        }
+
+        [Fact]
+        public static void BitOps_RotateRight_ulong()
+        {
+            ulong value = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
+            Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitOperation.RotateRight(value, 1));
+            Assert.Equal(0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul, BitOperation.RotateRight(value, 2));
+            Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul, BitOperation.RotateRight(value, 3));
+            Assert.Equal(value, BitOperation.RotateRight(value, int.MinValue)); // % 64 = 0
+            Assert.Equal(BitOperation.RotateLeft(value, 63), BitOperation.RotateRight(value, int.MaxValue)); // % 64 = 63
+        }
+
+        [Fact]
+        public static void BitOps_RotateRight_nuint()
+        {
+            unchecked
+            {
+                if (Environment.Is64BitProcess)
+                {
+                    const ulong value = 0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul;
+                    Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateRight(value, 1));
+                    Assert.Equal(0b01010101_01010101_01010101_01010101_01010101_01010101_01010101_01010101ul,
+                        BitOperation.RotateRight(value, 2));
+                    Assert.Equal(0b10101010_10101010_10101010_10101010_10101010_10101010_10101010_10101010ul,
+                        BitOperation.RotateRight(value, 3));
+                    Assert.Equal(value, BitOperation.RotateRight(value, int.MinValue)); // % 64 = 0
+                    Assert.Equal(BitOperation.RotateLeft(value, 63),
+                        BitOperation.RotateRight(value, int.MaxValue)); // % 64 = 63
+                }
+                else
+                {
+                    Assert.Equal((nuint)0b00000000_00000000_00000000_00000001u,
+                        BitOperation.RotateRight((nuint)0b10000000_00000000_00000000_00000000u,
+                            int.MaxValue)); // % 32 = 31
+                    Assert.Equal((nuint)0b01000000_00000001_00000000_00000001u,
+                        BitOperation.RotateRight((nuint)0b00000000_00001000_00000000_00001010u, 3));
+                    Assert.Equal((nuint)0b01000000_00000001_00000000_00000001u,
+                        BitOperation.RotateRight((nuint)0b00000000_00000100_00000000_00000101u, 2));
+                    Assert.Equal((nuint)0b10101010_10101010_10101010_10101010u,
+                        BitOperation.RotateRight((nuint)0b01010101_01010101_01010101_01010101u, 1));
+                    Assert.Equal((nuint)0b01010101_11111111_01010101_01010101u,
+                        BitOperation.RotateRight((nuint)0b01010101_11111111_01010101_01010101u, 0));
+                    Assert.Equal((nuint)0b00000000_00000000_00000000_00000001u,
+                        BitOperation.RotateRight((nuint)0b10000000_00000000_00000000_00000000u, -1));
+                    Assert.Equal((nuint)0b00000000_00000000_00000001_00000000u,
+                        BitOperation.RotateRight((nuint)0b00000000_00000000_00000000_01000000u, -2));
+                    Assert.Equal((nuint)0b00000000_00000000_00000000_00000010u,
+                        BitOperation.RotateRight((nuint)0b01000000_00000000_00000000_00000000u, -3));
+                    Assert.Equal((nuint)0b01010101_11111111_01010101_01010101u,
+                        BitOperation.RotateRight((nuint)0b01010101_11111111_01010101_01010101u,
+                            int.MinValue)); // % 32 = 0
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(2, 2)]
+        [InlineData(0x0096, 0x0100)]
+        [InlineData(0x05CD, 0x0800)]
+        [InlineData(0x0932, 0x1000)]
+        [InlineData(0x0004_C911, 0x0008_0000)]
+        [InlineData(0x00E0_A2E2, 0x0100_0000)]
+        [InlineData(0x0988_0713, 0x1000_0000)]
+        [InlineData(0x30A4_9649, 0x4000_0000)]
+        [InlineData(0x7FFF_FFFF, 0)] // overflow, not representable as int
+        [InlineData(unchecked((int)0x8000_0000u), 0)] // becomes negative
+        [InlineData(-1, 0)]
+        [InlineData(-12345, 0)]
+        public static void BitOps_RoundUpToPow2_int(int value, int expected) // J2N-specific tests for int
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2(value));
+        }
+
+        [Theory]
+        [InlineData(0u, 0u)]
+        [InlineData(1u, 1u)]
+        [InlineData(2u, 2u)]
+        [InlineData(0x0096u, 0x0100u)]
+        [InlineData(0x05CDu, 0x0800u)]
+        [InlineData(0x0932u, 0x1000u)]
+        [InlineData(0x0004_C911u, 0x0008_0000u)]
+        [InlineData(0x00E0_A2E2u, 0x0100_0000u)]
+        [InlineData(0x0988_0713u, 0x1000_0000u)]
+        [InlineData(0x30A4_9649u, 0x4000_0000u)]
+        [InlineData(0x7FFF_FFFFu, 0x8000_0000u)]
+        [InlineData(0x8000_0000u, 0x8000_0000u)]
+        [InlineData(0x8000_0001u, 0ul)]
+        [InlineData(0xFFFF_FFFFu, 0ul)]
+        [InlineData(uint.MaxValue, 0)]
+        public static void BitOps_RoundUpToPow2_uint(uint value, uint expected)
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2(value));
+        }
+
+        [Theory]
+        [InlineData(0L, 0L)]
+        [InlineData(1L, 1L)]
+        [InlineData(2L, 2L)]
+        [InlineData(0x0096L, 0x0100L)]
+        [InlineData(0x05cdL, 0x0800L)]
+        [InlineData(0x0932L, 0x1000L)]
+        [InlineData(0x0004_c911L, 0x0008_0000L)]
+        [InlineData(0x00e0_a2b2L, 0x0100_0000L)]
+        [InlineData(0x0988_0713L, 0x1000_0000L)]
+        [InlineData(0x30a4_9649L, 0x4000_0000L)]
+        [InlineData(0x7FFF_FFFFL, 0x8000_0000L)]
+        [InlineData(0x8000_0000L, 0x8000_0000L)]
+        [InlineData(0x8000_0001L, 0x1_0000_0000L)]
+        [InlineData(0xFFFF_FFFFL, 0x1_0000_0000L)]
+        [InlineData(0x0000_0003_343B_0D81L, 0x0000_0004_0000_0000L)]
+        [InlineData(0x0000_0D87_5EE2_8F19L, 0x0000_1000_0000_0000L)]
+        [InlineData(0x0006_2A08_4A7A_3A2DL, 0x0008_0000_0000_0000L)]
+        [InlineData(0x0101_BF76_4398_F791L, 0x0200_0000_0000_0000L)]
+        [InlineData(0x7FFF_FFFF_FFFF_FFFFL, 0)] // overflow, not representable as long
+        [InlineData(unchecked((long)0x8000_0000_0000_0000ul), 0)] // negative after cast
+        [InlineData(-1L, 0L)]
+        [InlineData(-123456789L, 0L)]
+        public static void BitOps_RoundUpToPow2_long(long value, long expected) // J2N-specific tests for long
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2(value));
+        }
+
+        [Theory]
+        [InlineData(0ul, 0ul)]
+        [InlineData(1ul, 1ul)]
+        [InlineData(2ul, 2ul)]
+        [InlineData(0x0096ul, 0x0100ul)]
+        [InlineData(0x05cdul, 0x0800ul)]
+        [InlineData(0x0932ul, 0x1000ul)]
+        [InlineData(0x0004_c911ul, 0x0008_0000ul)]
+        [InlineData(0x00e0_a2b2ul, 0x0100_0000ul)]
+        [InlineData(0x0988_0713ul, 0x1000_0000ul)]
+        [InlineData(0x30a4_9649ul, 0x4000_0000ul)]
+        [InlineData(0x7FFF_FFFFul, 0x8000_0000ul)]
+        [InlineData(0x8000_0000ul, 0x8000_0000ul)]
+        [InlineData(0x8000_0001ul, 0x1_0000_0000ul)]
+        [InlineData(0xFFFF_FFFFul, 0x1_0000_0000ul)]
+        [InlineData(0x0000_0003_343B_0D81ul, 0x0000_0004_0000_0000ul)]
+        [InlineData(0x0000_0D87_5EE2_8F19ul, 0x0000_1000_0000_0000ul)]
+        [InlineData(0x0006_2A08_4A7A_3A2Dul, 0x0008_0000_0000_0000ul)]
+        [InlineData(0x0101_BF76_4398_F791ul, 0x0200_0000_0000_0000ul)]
+        [InlineData(0x7FFF_FFFF_FFFF_FFFFul, 0x8000_0000_0000_0000ul)]
+        [InlineData(0x8000_0000_0000_0000ul, 0x8000_0000_0000_0000ul)]
+        [InlineData(0x8000_0000_0000_0001ul, 0ul)]
+        [InlineData(0xFFFF_FFFF_FFFF_FFFFul, 0ul)]
+        public static void BitOps_RoundUpToPow2_ulong(ulong value, ulong expected)
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2(value));
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is32BitProcess))]
+        [InlineData(0u, 0u)]
+        [InlineData(1u, 1u)]
+        [InlineData(2u, 2u)]
+        [InlineData(0x0096u, 0x0100u)]
+        [InlineData(0x05CDu, 0x0800u)]
+        [InlineData(0x0932u, 0x1000u)]
+        [InlineData(0x0004_C911u, 0x0008_0000u)]
+        [InlineData(0x00E0_A2E2u, 0x0100_0000u)]
+        [InlineData(0x0988_0713u, 0x1000_0000u)]
+        [InlineData(0x30A4_9649u, 0x4000_0000u)]
+        [InlineData(0x7FFF_FFFFu, 0x8000_0000u)]
+        [InlineData(0x8000_0000u, 0x8000_0000u)]
+        [InlineData(0x8000_0001u, 0ul)]
+        [InlineData(0xFFFF_FFFFu, 0ul)]
+        public static void BitOps_RoundUpToPow2_nuint_32(uint value, uint expected)
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2((nuint)value));
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))]
+        [InlineData(0ul, 0ul)]
+        [InlineData(1ul, 1ul)]
+        [InlineData(2ul, 2ul)]
+        [InlineData(0x0096ul, 0x0100ul)]
+        [InlineData(0x05cdul, 0x0800ul)]
+        [InlineData(0x0932ul, 0x1000ul)]
+        [InlineData(0x0004_c911ul, 0x0008_0000ul)]
+        [InlineData(0x00e0_a2b2ul, 0x0100_0000ul)]
+        [InlineData(0x0988_0713ul, 0x1000_0000ul)]
+        [InlineData(0x30a4_9649ul, 0x4000_0000ul)]
+        [InlineData(0x7FFF_FFFFul, 0x8000_0000ul)]
+        [InlineData(0x8000_0000ul, 0x8000_0000ul)]
+        [InlineData(0x8000_0001ul, 0x1_0000_0000ul)]
+        [InlineData(0xFFFF_FFFFul, 0x1_0000_0000ul)]
+        [InlineData(0x0000_0003_343B_0D81ul, 0x0000_0004_0000_0000ul)]
+        [InlineData(0x0000_0D87_5EE2_8F19ul, 0x0000_1000_0000_0000ul)]
+        [InlineData(0x0006_2A08_4A7A_3A2Dul, 0x0008_0000_0000_0000ul)]
+        [InlineData(0x0101_BF76_4398_F791ul, 0x0200_0000_0000_0000ul)]
+        [InlineData(0x7FFF_FFFF_FFFF_FFFFul, 0x8000_0000_0000_0000ul)]
+        [InlineData(0x8000_0000_0000_0000ul, 0x8000_0000_0000_0000ul)]
+        [InlineData(0x8000_0000_0000_0001ul, 0ul)]
+        [InlineData(0xFFFF_FFFF_FFFF_FFFFul, 0ul)]
+        public static void BitOps_RoundUpToPow2_nuint_64(ulong value, ulong expected)
+        {
+            Assert.Equal(expected, BitOperation.RoundUpToPowerOf2((nuint)value));
+        }
+
+        //[Theory]
+        //[InlineData(0, 0, 0)]
+        //[InlineData(0, 120, 4215344322)]
+        //[InlineData(0, byte.MaxValue, 2910671697)]
+        //[InlineData(123, byte.MaxValue, 1164749927)]
+        ////[ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
+        //public static void BitOps_Crc32C_byte(uint crc, byte data, uint expected)
+        //{
+        //    uint obtained = BitOperation.Crc32C(crc, data);
+        //    Assert.Equal(expected, obtained);
+        //}
+
+        //[Theory]
+        //[InlineData(0, 0, 0)]
+        //[InlineData(0, 120, 575477567)]
+        //[InlineData(0, ushort.MaxValue, 245266386)]
+        //[InlineData(123, ushort.MaxValue, 406112372)]
+        ////[ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
+        //public static void BitOps_Crc32C_ushort(uint crc, ushort data, uint expected)
+        //{
+        //    uint obtained = BitOperation.Crc32C(crc, data);
+        //    Assert.Equal(expected, obtained);
+        //}
+
+        //[Theory]
+        //[InlineData(0, 0, 0)]
+        //[InlineData(0, 120, 1671666103)]
+        //[InlineData(0, uint.MaxValue, 3080238136)]
+        //[InlineData(123, uint.MaxValue, 3055133878)]
+        ////[ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
+        //public static void BitOps_Crc32C_uint(uint crc, uint data, uint expected)
+        //{
+        //    uint obtained = BitOperation.Crc32C(crc, data);
+        //    Assert.Equal(expected, obtained);
+        //}
+
+        //[Theory]
+        //[InlineData(0, 0, 0)]
+        //[InlineData(0, 120, 3511526341)]
+        //[InlineData(0, ulong.MaxValue, 3293575501)]
+        //[InlineData(123, ulong.MaxValue, 3460750817)]
+        ////[ActiveIssue("https://github.com/dotnet/runtime/issues/76830", TestPlatforms.tvOS)]
+        //public static void BitOps_Crc32C_ulong(uint crc, ulong data, uint expected)
+        //{
+        //    uint obtained = BitOperation.Crc32C(crc, data);
+        //    Assert.Equal(expected, obtained);
+        //}
+    }
+}

--- a/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
+++ b/tests/Xunit/J2N.Runtime.Tests/Numerics/BitOperationTests.cs
@@ -113,11 +113,6 @@ namespace J2N.Numerics.Tests
         [InlineData(int.MinValue, false)]
         public static void BitOps_IsPow2_nint_32(int n, bool expected)
         {
-            //if (PlatformDetection.Is32BitProcess)
-            //{
-            //    throw new Xunit.Sdk.SkipException("Condition not met, skipping test.");
-            //}
-
             bool actual = BitOperation.IsPow2((nint)n);
             Assert.Equal(expected, actual);
         }
@@ -312,7 +307,7 @@ namespace J2N.Numerics.Tests
         [InlineData(int.MaxValue << 5, 5)]
         [InlineData(3 << 27, 27)]
         [InlineData(int.MaxValue, 0)]
-        public static void BitOps_TrailingZeroCount_int(int n, int expected)
+        public static void BitOps_TrailingZeroCount_int(int n, int expected) // J2N specific covering int overload
         {
             int actual = BitOperation.TrailingZeroCount(n);
             Assert.Equal(expected, actual);
@@ -358,7 +353,7 @@ namespace J2N.Numerics.Tests
         [InlineData(3L << 59, 59)]
         [InlineData(5L << 63, 63)]
         [InlineData(long.MaxValue, 0)]
-        public static void BitOps_TrailingZeroCount_long(long n, int expected)
+        public static void BitOps_TrailingZeroCount_long(long n, int expected) // J2N specific covering long overload
         {
             int actual = BitOperation.TrailingZeroCount(n);
             Assert.Equal(expected, actual);


### PR DESCRIPTION
This updates the `BitOperation` to support unsigned and native 32 and 64 bit integral types and also adds `IsPow2()`, `Log2()` and `RoundUpToPowerOf2()` support that was previously unavailable.

The paths were optimized to use hardware intrinsics if supported by the current target framework and the software fallback paths were also updated to use faster approaches.

`MathExtensions` also adds the `Log2(double)` overload, which is used by Lucene.Net.Queries.

## New APIs

```c#
namespace J2N
{
    public static class MathExtensions
    {
        public static double Log2(this double value)
    }
}
namespace J2N.Numerics
{
    public static class BitOperation
    {
        public static bool IsPow2(this int value)
        public static bool IsPow2(this uint value)
        public static bool IsPow2(this long value)
        public static bool IsPow2(this ulong value)
        public static bool IsPow2(this nint value)
        public static bool IsPow2(this nuint value)
        public static int LeadingZeroCount(this uint value)
        public static int LeadingZeroCount(this ulong value)
        public static int LeadingZeroCount(this nuint value)
        public static int Log2(this int value)
        public static int Log2(this uint value)
        public static int Log2(this long value)
        public static int Log2(this ulong value)
        public static int Log2(this nuint value)
        public static int PopCount(this uint value)
        public static int PopCount(this ulong value)
        public static int PopCount(this nuint value)
        public static uint RotateLeft(this uint value, int distance)
        public static ulong RotateLeft(this ulong value, int distance)
        public static nuint RotateLeft(this nuint value, int distance)
        public static uint RotateRight(this uint value, int distance)
        public static ulong RotateRight(this ulong value, int distance)
        public static nuint RotateRight(this nuint value, int distance)
        public static int RoundUpToPowerOf2(this int value)
        public static uint RoundUpToPowerOf2(this uint value)
        public static long RoundUpToPowerOf2(this long value)
        public static ulong RoundUpToPowerOf2(this ulong value)
        public static nuint RoundUpToPowerOf2(this nuint value)
        public static int TrailingZeroCount(this uint value)
        public static int TrailingZeroCount(this ulong value)
        public static int TrailingZeroCount(this nint value)
        public static int TrailingZeroCount(this nuint value)    
    }
}
```