### PR TITLE
Fix IndexOf/LastIndexOf behavior for float/double types to match Java semantics, #146

### DIFF
--- a/src/J2N/Collections/Arrays.cs
+++ b/src/J2N/Collections/Arrays.cs
@@ -398,7 +398,10 @@ namespace J2N.Collections
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -416,7 +419,10 @@ namespace J2N.Collections
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -438,7 +444,10 @@ namespace J2N.Collections
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -456,29 +465,12 @@ namespace J2N.Collections
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count(count);
 
             // Special handling for float and double types to match Java's behavior
-            if (typeof(T) == typeof(float))
+            if (typeof(T) == typeof(float)
+                || typeof(T) == typeof(double)
+                || typeof(T) == typeof(float?)
+                || typeof(T) == typeof(double?))
             {
-                float floatValue = Unsafe.As<T, float>(ref value);
-                float[] floatArray = Unsafe.As<T[], float[]>(ref array);
-                return IndexOfFloatingPoint(floatArray, floatValue, startIndex, count, JCG.EqualityComparer<float>.Default);
-            }
-            else if (typeof(T) == typeof(double))
-            {
-                double doubleValue = Unsafe.As<T, double>(ref value);
-                double[] doubleArray = Unsafe.As<T[], double[]>(ref array);
-                return IndexOfFloatingPoint(doubleArray, doubleValue, startIndex, count, JCG.EqualityComparer<double>.Default);
-            }
-            else if (typeof(T) == typeof(float?))
-            {
-                float? floatValue = Unsafe.As<T, float?>(ref value);
-                float?[] floatArray = Unsafe.As<T[], float?[]>(ref array);
-                return IndexOfFloatingPoint(floatArray, floatValue, startIndex, count, JCG.EqualityComparer<float?>.Default);
-            }
-            else if (typeof(T) == typeof(double?))
-            {
-                double? doubleValue = Unsafe.As<T, double?>(ref value);
-                double?[] doubleArray = Unsafe.As<T[], double?[]>(ref array);
-                return IndexOfFloatingPoint(doubleArray, doubleValue, startIndex, count, JCG.EqualityComparer<double?>.Default);
+                return IndexOfFloatingPoint(array, value, startIndex, count, JCG.EqualityComparer<T>.Default);
             }
 
             // For all other types, delegate to Array.IndexOf
@@ -500,11 +492,15 @@ namespace J2N.Collections
         }
 
         /// <summary>
-        /// Searches for the specified object in the array and returns the index of the last occurrence.
+        /// Searches for the specified object in the array, searching backward from the end,
+        /// and returns the index of the last occurrence.
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -525,7 +521,10 @@ namespace J2N.Collections
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -549,7 +548,10 @@ namespace J2N.Collections
         /// </summary>
         /// <remarks>
         /// This method applies special-case handling for floating-point types (float, double, and their nullable variants)
-        /// to match Java's behavior with respect to NaN and signed zero comparisons.
+        /// to match the behavior of <c>java.util.Float</c> and <c>java.util.Double</c> in collections.
+        /// Specifically, NaN values are treated as equal to each other, and positive/negative zero are treated as distinct.
+        /// This is necessary because Java requires primitives to be wrapped in reference types when used in collections,
+        /// and those wrapper types have different comparison semantics than .NET's default behavior.
         /// </remarks>
         /// <typeparam name="T">The type of the array element.</typeparam>
         /// <param name="array">The array to search.</param>
@@ -569,29 +571,12 @@ namespace J2N.Collections
                 ThrowHelper.ThrowCountArgumentOutOfRange_ArgumentOutOfRange_Count(count);
 
             // Special handling for float and double types to match Java's behavior
-            if (typeof(T) == typeof(float))
+            if (typeof(T) == typeof(float)
+                || typeof(T) == typeof(double)
+                || typeof(T) == typeof(float?)
+                || typeof(T) == typeof(double?))
             {
-                float floatValue = Unsafe.As<T, float>(ref value);
-                float[] floatArray = Unsafe.As<T[], float[]>(ref array);
-                return LastIndexOfFloatingPoint(floatArray, floatValue, startIndex, count, JCG.EqualityComparer<float>.Default);
-            }
-            else if (typeof(T) == typeof(double))
-            {
-                double doubleValue = Unsafe.As<T, double>(ref value);
-                double[] doubleArray = Unsafe.As<T[], double[]>(ref array);
-                return LastIndexOfFloatingPoint(doubleArray, doubleValue, startIndex, count, JCG.EqualityComparer<double>.Default);
-            }
-            else if (typeof(T) == typeof(float?))
-            {
-                float? floatValue = Unsafe.As<T, float?>(ref value);
-                float?[] floatArray = Unsafe.As<T[], float?[]>(ref array);
-                return LastIndexOfFloatingPoint(floatArray, floatValue, startIndex, count, JCG.EqualityComparer<float?>.Default);
-            }
-            else if (typeof(T) == typeof(double?))
-            {
-                double? doubleValue = Unsafe.As<T, double?>(ref value);
-                double?[] doubleArray = Unsafe.As<T[], double?[]>(ref array);
-                return LastIndexOfFloatingPoint(doubleArray, doubleValue, startIndex, count, JCG.EqualityComparer<double?>.Default);
+                return LastIndexOfFloatingPoint<T>(array, value, startIndex, count, JCG.EqualityComparer<T>.Default);
             }
 
             // For all other types, delegate to Array.LastIndexOf

--- a/src/J2N/Collections/Generic/EqualityComparer.cs
+++ b/src/J2N/Collections/Generic/EqualityComparer.cs
@@ -206,6 +206,10 @@ namespace J2N.Collections.Generic
             if (double.IsNaN(x) && double.IsNaN(y))
                 return true;
 
+            // If only one is NaN, they're not equal
+            if (double.IsNaN(x) || double.IsNaN(y))
+                return false;
+
             // Deal with +0.0 and -0.0
             long d1 = BitConversion.DoubleToRawInt64Bits(x); // NaN already dealt with, so we can use "raw" here
             long d2 = BitConversion.DoubleToRawInt64Bits(y);
@@ -284,6 +288,10 @@ namespace J2N.Collections.Generic
 
             if (float.IsNaN(x) && float.IsNaN(y))
                 return true;
+
+            // If only one is NaN, they're not equal
+            if (float.IsNaN(x) || float.IsNaN(y))
+                return false;
 
             // Deal with +0.0 and -0.0
             int f1 = BitConversion.SingleToRawInt32Bits(x); // NaN already dealt with, so we can use "raw" here

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using J2N.Collections;
 using J2N.Collections.ObjectModel;
 using J2N.Runtime.CompilerServices;
 using J2N.Text;
@@ -1614,7 +1615,7 @@ namespace J2N.Collections.Generic
             CoModificationCheck();
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, offset, Size);
+            int result = Arrays.IndexOf(_items, item, offset, Size);
             return result > -1 ? result - offset : result;
         }
 
@@ -1656,7 +1657,7 @@ namespace J2N.Collections.Generic
 
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, index + offset, Size - index);
+            int result = Arrays.IndexOf(_items, item, index + offset, Size - index);
             return result > -1 ? result - offset : result;
         }
 
@@ -1701,7 +1702,7 @@ namespace J2N.Collections.Generic
 
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, index + offset, count);
+            int result = Arrays.IndexOf(_items, item, index + offset, count);
             return result > -1 ? result - offset : result;
         }
 
@@ -2024,7 +2025,7 @@ namespace J2N.Collections.Generic
                 ThrowHelper.ThrowArgumentOutOfRangeException(count, ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_BiggerThanCollection);
 
             int offset = Offset;
-            int result = Array.LastIndexOf(_items, item, index + offset, count);
+            int result = Arrays.LastIndexOf(_items, item, index + offset, count);
             return result > -1 ? result - offset : result;
         }
 

--- a/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
+++ b/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
@@ -252,5 +252,208 @@ namespace J2N.Collections.Tests
         }
 
         #endregion
+
+        #region Float and Double NaN and Signed Zero Tests
+
+        // These tests ensure that float and double IndexOf/LastIndexOf methods match Java's behavior
+        // regarding NaN and signed zero comparisons.
+
+        /// <summary>
+        /// Tests IndexOf with float NaN values. In Java/J2N, NaN == NaN, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void IndexOf_FloatNaN()
+        {
+            if (typeof(T) != typeof(float))
+                return;
+
+            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)float.NaN, (T)(object)3.0f };
+
+            // NaN should be found at index 1
+            Assert.Equal(1, list.IndexOf(float.NaN));
+            Assert.Equal(1, list.IndexOf(float.NaN, 0));
+            Assert.Equal(1, list.IndexOf(float.NaN, 0, 3));
+
+            // NaN at different positions
+            var list2 = new List<float> { float.NaN, 1.0f, float.NaN, 3.0f, float.NaN };
+            Assert.Equal(0, list2.IndexOf(float.NaN));
+            Assert.Equal(2, list2.IndexOf(float.NaN, 1));
+            Assert.Equal(2, list2.IndexOf(float.NaN, 2, 3));
+        }
+
+        /// <summary>
+        /// Tests IndexOf with double NaN values. In Java/J2N, NaN == NaN, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void IndexOf_DoubleNaN()
+        {
+            if (typeof(T) != typeof(double))
+                return;
+
+            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)double.NaN, (T)(object)3.0d };
+
+            // NaN should be found at index 1
+            Assert.Equal(1, list.IndexOf(double.NaN));
+            Assert.Equal(1, list.IndexOf(double.NaN, 0));
+            Assert.Equal(1, list.IndexOf(double.NaN, 0, 3));
+
+            // NaN at different positions
+            var list2 = new List<double> { double.NaN, 1.0d, double.NaN, 3.0d, double.NaN };
+            Assert.Equal(0, list2.IndexOf(double.NaN));
+            Assert.Equal(2, list2.IndexOf(double.NaN, 1));
+            Assert.Equal(2, list2.IndexOf(double.NaN, 2, 3));
+        }
+
+        /// <summary>
+        /// Tests LastIndexOf with float NaN values. In Java/J2N, NaN == NaN, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void LastIndexOf_FloatNaN()
+        {
+            if (typeof(T) != typeof(float))
+                return;
+
+            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)float.NaN, (T)(object)3.0f };
+
+            // NaN should be found at index 1
+            Assert.Equal(1, list.LastIndexOf(float.NaN));
+            Assert.Equal(1, list.LastIndexOf(float.NaN, 2));
+            Assert.Equal(1, list.LastIndexOf(float.NaN, 2, 3));
+
+            // NaN at different positions
+            var list2 = new List<float> { float.NaN, 1.0f, float.NaN, 3.0f, float.NaN };
+            Assert.Equal(4, list2.LastIndexOf(float.NaN));
+            Assert.Equal(2, list2.LastIndexOf(float.NaN, 2));
+            Assert.Equal(0, list2.LastIndexOf(float.NaN, 1, 2));
+        }
+
+        /// <summary>
+        /// Tests LastIndexOf with double NaN values. In Java/J2N, NaN == NaN, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void LastIndexOf_DoubleNaN()
+        {
+            if (typeof(T) != typeof(double))
+                return;
+
+            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)double.NaN, (T)(object)3.0d };
+
+            // NaN should be found at index 1
+            Assert.Equal(1, list.LastIndexOf(double.NaN));
+            Assert.Equal(1, list.LastIndexOf(double.NaN, 2));
+            Assert.Equal(1, list.LastIndexOf(double.NaN, 2, 3));
+
+            // NaN at different positions
+            var list2 = new List<double> { double.NaN, 1.0d, double.NaN, 3.0d, double.NaN };
+            Assert.Equal(4, list2.LastIndexOf(double.NaN));
+            Assert.Equal(2, list2.LastIndexOf(double.NaN, 2));
+            Assert.Equal(0, list2.LastIndexOf(double.NaN, 1, 2));
+        }
+
+        /// <summary>
+        /// Tests IndexOf with float signed zero. In Java/J2N, +0.0f != -0.0f, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void IndexOf_FloatSignedZero()
+        {
+            if (typeof(T) != typeof(float))
+                return;
+
+            float positiveZero = 0.0f;
+            float negativeZero = -0.0f;
+
+            List<float> list = (List<float>)(object)new List<T>
+            {
+                (T)(object)positiveZero,
+                (T)(object)1.0f,
+                (T)(object)negativeZero,
+                (T)(object)3.0f
+            };
+
+            // +0.0f should be found at index 0, not at index 2
+            Assert.Equal(0, list.IndexOf(positiveZero));
+            Assert.Equal(2, list.IndexOf(negativeZero));
+        }
+
+        /// <summary>
+        /// Tests IndexOf with double signed zero. In Java/J2N, +0.0d != -0.0d, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void IndexOf_DoubleSignedZero()
+        {
+            if (typeof(T) != typeof(double))
+                return;
+
+            double positiveZero = 0.0d;
+            double negativeZero = -0.0d;
+
+            List<double> list = (List<double>)(object)new List<T>
+            {
+                (T)(object)positiveZero,
+                (T)(object)1.0d,
+                (T)(object)negativeZero,
+                (T)(object)3.0d
+            };
+
+            // +0.0d should be found at index 0, not at index 2
+            Assert.Equal(0, list.IndexOf(positiveZero));
+            Assert.Equal(2, list.IndexOf(negativeZero));
+        }
+
+        /// <summary>
+        /// Tests LastIndexOf with float signed zero. In Java/J2N, +0.0f != -0.0f, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void LastIndexOf_FloatSignedZero()
+        {
+            if (typeof(T) != typeof(float))
+                return;
+
+            float positiveZero = 0.0f;
+            float negativeZero = -0.0f;
+
+            List<float> list = (List<float>)(object)new List<T>
+            {
+                (T)(object)positiveZero,
+                (T)(object)1.0f,
+                (T)(object)negativeZero,
+                (T)(object)positiveZero,
+                (T)(object)3.0f
+            };
+
+            // Searching for +0.0f should return the last occurrence at index 3
+            // Searching for -0.0f should return the occurrence at index 2
+            Assert.Equal(3, list.LastIndexOf(positiveZero));
+            Assert.Equal(2, list.LastIndexOf(negativeZero));
+        }
+
+        /// <summary>
+        /// Tests LastIndexOf with double signed zero. In Java/J2N, +0.0d != -0.0d, unlike .NET's BCL.
+        /// </summary>
+        [Fact]
+        public void LastIndexOf_DoubleSignedZero()
+        {
+            if (typeof(T) != typeof(double))
+                return;
+
+            double positiveZero = 0.0d;
+            double negativeZero = -0.0d;
+
+            List<double> list = (List<double>)(object)new List<T>
+            {
+                (T)(object)positiveZero,
+                (T)(object)1.0d,
+                (T)(object)negativeZero,
+                (T)(object)positiveZero,
+                (T)(object)3.0d
+            };
+
+            // Searching for +0.0d should return the last occurrence at index 3
+            // Searching for -0.0d should return the occurrence at index 2
+            Assert.Equal(3, list.LastIndexOf(positiveZero));
+            Assert.Equal(2, list.LastIndexOf(negativeZero));
+        }
+
+        #endregion
     }
 }

--- a/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
+++ b/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
@@ -269,8 +269,8 @@ namespace J2N.Collections.Tests
 
             // Test with different NaN bit patterns
             float nanDefault = float.NaN; // 0x7FC00000
-            float nanVariant1 = BitConverter.Int32BitsToSingle(0x7FC00001);
-            float nanVariant2 = BitConverter.Int32BitsToSingle(0xFFC00001);
+            float nanVariant1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+            float nanVariant2 = BitConversion.Int32BitsToSingle(unchecked((int)0xFFC00001));
 
             List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)nanDefault, (T)(object)3.0f };
 
@@ -313,8 +313,8 @@ namespace J2N.Collections.Tests
 
             // Test with different NaN bit patterns
             double nanDefault = double.NaN; // 0x7FF8000000000000
-            double nanVariant1 = BitConverter.Int64BitsToDouble(0x7FF8000000000001);
-            double nanVariant2 = BitConverter.Int64BitsToDouble(0xFFF8000000000001);
+            double nanVariant1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001);
+            double nanVariant2 = BitConversion.Int64BitsToDouble(unchecked((long)0xFFF8000000000001));
 
             List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)nanDefault, (T)(object)3.0d };
 
@@ -357,8 +357,8 @@ namespace J2N.Collections.Tests
 
             // Test with different NaN bit patterns
             float nanDefault = float.NaN; // 0x7FC00000
-            float nanVariant1 = BitConverter.Int32BitsToSingle(0x7FC00001);
-            float nanVariant2 = BitConverter.Int32BitsToSingle(0xFFC00001);
+            float nanVariant1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+            float nanVariant2 = BitConversion.Int32BitsToSingle(unchecked((int)0xFFC00001));
 
             List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)nanDefault, (T)(object)3.0f };
 
@@ -401,8 +401,8 @@ namespace J2N.Collections.Tests
 
             // Test with different NaN bit patterns
             double nanDefault = double.NaN; // 0x7FF8000000000000
-            double nanVariant1 = BitConverter.Int64BitsToDouble(0x7FF8000000000001);
-            double nanVariant2 = BitConverter.Int64BitsToDouble(0xFFF8000000000001);
+            double nanVariant1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001);
+            double nanVariant2 = BitConversion.Int64BitsToDouble(unchecked((long)0xFFF8000000000001));
 
             List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)nanDefault, (T)(object)3.0d };
 

--- a/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
+++ b/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.Tests.IndexOf.cs
@@ -267,18 +267,39 @@ namespace J2N.Collections.Tests
             if (typeof(T) != typeof(float))
                 return;
 
-            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)float.NaN, (T)(object)3.0f };
+            // Test with different NaN bit patterns
+            float nanDefault = float.NaN; // 0x7FC00000
+            float nanVariant1 = BitConverter.Int32BitsToSingle(0x7FC00001);
+            float nanVariant2 = BitConverter.Int32BitsToSingle(0xFFC00001);
 
-            // NaN should be found at index 1
-            Assert.Equal(1, list.IndexOf(float.NaN));
-            Assert.Equal(1, list.IndexOf(float.NaN, 0));
-            Assert.Equal(1, list.IndexOf(float.NaN, 0, 3));
+            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)nanDefault, (T)(object)3.0f };
 
-            // NaN at different positions
-            var list2 = new List<float> { float.NaN, 1.0f, float.NaN, 3.0f, float.NaN };
-            Assert.Equal(0, list2.IndexOf(float.NaN));
-            Assert.Equal(2, list2.IndexOf(float.NaN, 1));
-            Assert.Equal(2, list2.IndexOf(float.NaN, 2, 3));
+            // NaN should be found at index 1 regardless of NaN bit pattern
+            Assert.Equal(1, list.IndexOf(nanDefault));
+            Assert.Equal(1, list.IndexOf(nanVariant1));
+            Assert.Equal(1, list.IndexOf(nanVariant2));
+
+            Assert.Equal(1, list.IndexOf(nanDefault, 0));
+            Assert.Equal(1, list.IndexOf(nanVariant1, 0));
+            Assert.Equal(1, list.IndexOf(nanVariant2, 0));
+
+            Assert.Equal(1, list.IndexOf(nanDefault, 0, 3));
+            Assert.Equal(1, list.IndexOf(nanVariant1, 0, 3));
+            Assert.Equal(1, list.IndexOf(nanVariant2, 0, 3));
+
+            // NaN at different positions with multiple NaN bit patterns
+            var list2 = new List<float> { nanVariant1, 1.0f, nanDefault, 3.0f, nanVariant2 };
+            Assert.Equal(0, list2.IndexOf(nanDefault));
+            Assert.Equal(0, list2.IndexOf(nanVariant1));
+            Assert.Equal(0, list2.IndexOf(nanVariant2));
+
+            Assert.Equal(2, list2.IndexOf(nanDefault, 1));
+            Assert.Equal(2, list2.IndexOf(nanVariant1, 1));
+            Assert.Equal(2, list2.IndexOf(nanVariant2, 1));
+
+            Assert.Equal(2, list2.IndexOf(nanDefault, 2, 3));
+            Assert.Equal(2, list2.IndexOf(nanVariant1, 2, 3));
+            Assert.Equal(2, list2.IndexOf(nanVariant2, 2, 3));
         }
 
         /// <summary>
@@ -290,18 +311,39 @@ namespace J2N.Collections.Tests
             if (typeof(T) != typeof(double))
                 return;
 
-            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)double.NaN, (T)(object)3.0d };
+            // Test with different NaN bit patterns
+            double nanDefault = double.NaN; // 0x7FF8000000000000
+            double nanVariant1 = BitConverter.Int64BitsToDouble(0x7FF8000000000001);
+            double nanVariant2 = BitConverter.Int64BitsToDouble(0xFFF8000000000001);
 
-            // NaN should be found at index 1
-            Assert.Equal(1, list.IndexOf(double.NaN));
-            Assert.Equal(1, list.IndexOf(double.NaN, 0));
-            Assert.Equal(1, list.IndexOf(double.NaN, 0, 3));
+            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)nanDefault, (T)(object)3.0d };
 
-            // NaN at different positions
-            var list2 = new List<double> { double.NaN, 1.0d, double.NaN, 3.0d, double.NaN };
-            Assert.Equal(0, list2.IndexOf(double.NaN));
-            Assert.Equal(2, list2.IndexOf(double.NaN, 1));
-            Assert.Equal(2, list2.IndexOf(double.NaN, 2, 3));
+            // NaN should be found at index 1 regardless of NaN bit pattern
+            Assert.Equal(1, list.IndexOf(nanDefault));
+            Assert.Equal(1, list.IndexOf(nanVariant1));
+            Assert.Equal(1, list.IndexOf(nanVariant2));
+
+            Assert.Equal(1, list.IndexOf(nanDefault, 0));
+            Assert.Equal(1, list.IndexOf(nanVariant1, 0));
+            Assert.Equal(1, list.IndexOf(nanVariant2, 0));
+
+            Assert.Equal(1, list.IndexOf(nanDefault, 0, 3));
+            Assert.Equal(1, list.IndexOf(nanVariant1, 0, 3));
+            Assert.Equal(1, list.IndexOf(nanVariant2, 0, 3));
+
+            // NaN at different positions with multiple NaN bit patterns
+            var list2 = new List<double> { nanVariant1, 1.0d, nanDefault, 3.0d, nanVariant2 };
+            Assert.Equal(0, list2.IndexOf(nanDefault));
+            Assert.Equal(0, list2.IndexOf(nanVariant1));
+            Assert.Equal(0, list2.IndexOf(nanVariant2));
+
+            Assert.Equal(2, list2.IndexOf(nanDefault, 1));
+            Assert.Equal(2, list2.IndexOf(nanVariant1, 1));
+            Assert.Equal(2, list2.IndexOf(nanVariant2, 1));
+
+            Assert.Equal(2, list2.IndexOf(nanDefault, 2, 3));
+            Assert.Equal(2, list2.IndexOf(nanVariant1, 2, 3));
+            Assert.Equal(2, list2.IndexOf(nanVariant2, 2, 3));
         }
 
         /// <summary>
@@ -313,18 +355,39 @@ namespace J2N.Collections.Tests
             if (typeof(T) != typeof(float))
                 return;
 
-            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)float.NaN, (T)(object)3.0f };
+            // Test with different NaN bit patterns
+            float nanDefault = float.NaN; // 0x7FC00000
+            float nanVariant1 = BitConverter.Int32BitsToSingle(0x7FC00001);
+            float nanVariant2 = BitConverter.Int32BitsToSingle(0xFFC00001);
 
-            // NaN should be found at index 1
-            Assert.Equal(1, list.LastIndexOf(float.NaN));
-            Assert.Equal(1, list.LastIndexOf(float.NaN, 2));
-            Assert.Equal(1, list.LastIndexOf(float.NaN, 2, 3));
+            List<float> list = (List<float>)(object)new List<T> { (T)(object)1.0f, (T)(object)nanDefault, (T)(object)3.0f };
 
-            // NaN at different positions
-            var list2 = new List<float> { float.NaN, 1.0f, float.NaN, 3.0f, float.NaN };
-            Assert.Equal(4, list2.LastIndexOf(float.NaN));
-            Assert.Equal(2, list2.LastIndexOf(float.NaN, 2));
-            Assert.Equal(0, list2.LastIndexOf(float.NaN, 1, 2));
+            // NaN should be found at index 1 regardless of NaN bit pattern
+            Assert.Equal(1, list.LastIndexOf(nanDefault));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2));
+
+            Assert.Equal(1, list.LastIndexOf(nanDefault, 2));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1, 2));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2, 2));
+
+            Assert.Equal(1, list.LastIndexOf(nanDefault, 2, 3));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1, 2, 3));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2, 2, 3));
+
+            // NaN at different positions with multiple NaN bit patterns
+            var list2 = new List<float> { nanVariant1, 1.0f, nanDefault, 3.0f, nanVariant2 };
+            Assert.Equal(4, list2.LastIndexOf(nanDefault));
+            Assert.Equal(4, list2.LastIndexOf(nanVariant1));
+            Assert.Equal(4, list2.LastIndexOf(nanVariant2));
+
+            Assert.Equal(2, list2.LastIndexOf(nanDefault, 2));
+            Assert.Equal(2, list2.LastIndexOf(nanVariant1, 2));
+            Assert.Equal(2, list2.LastIndexOf(nanVariant2, 2));
+
+            Assert.Equal(0, list2.LastIndexOf(nanDefault, 1, 2));
+            Assert.Equal(0, list2.LastIndexOf(nanVariant1, 1, 2));
+            Assert.Equal(0, list2.LastIndexOf(nanVariant2, 1, 2));
         }
 
         /// <summary>
@@ -336,18 +399,39 @@ namespace J2N.Collections.Tests
             if (typeof(T) != typeof(double))
                 return;
 
-            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)double.NaN, (T)(object)3.0d };
+            // Test with different NaN bit patterns
+            double nanDefault = double.NaN; // 0x7FF8000000000000
+            double nanVariant1 = BitConverter.Int64BitsToDouble(0x7FF8000000000001);
+            double nanVariant2 = BitConverter.Int64BitsToDouble(0xFFF8000000000001);
 
-            // NaN should be found at index 1
-            Assert.Equal(1, list.LastIndexOf(double.NaN));
-            Assert.Equal(1, list.LastIndexOf(double.NaN, 2));
-            Assert.Equal(1, list.LastIndexOf(double.NaN, 2, 3));
+            List<double> list = (List<double>)(object)new List<T> { (T)(object)1.0d, (T)(object)nanDefault, (T)(object)3.0d };
 
-            // NaN at different positions
-            var list2 = new List<double> { double.NaN, 1.0d, double.NaN, 3.0d, double.NaN };
-            Assert.Equal(4, list2.LastIndexOf(double.NaN));
-            Assert.Equal(2, list2.LastIndexOf(double.NaN, 2));
-            Assert.Equal(0, list2.LastIndexOf(double.NaN, 1, 2));
+            // NaN should be found at index 1 regardless of NaN bit pattern
+            Assert.Equal(1, list.LastIndexOf(nanDefault));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2));
+
+            Assert.Equal(1, list.LastIndexOf(nanDefault, 2));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1, 2));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2, 2));
+
+            Assert.Equal(1, list.LastIndexOf(nanDefault, 2, 3));
+            Assert.Equal(1, list.LastIndexOf(nanVariant1, 2, 3));
+            Assert.Equal(1, list.LastIndexOf(nanVariant2, 2, 3));
+
+            // NaN at different positions with multiple NaN bit patterns
+            var list2 = new List<double> { nanVariant1, 1.0d, nanDefault, 3.0d, nanVariant2 };
+            Assert.Equal(4, list2.LastIndexOf(nanDefault));
+            Assert.Equal(4, list2.LastIndexOf(nanVariant1));
+            Assert.Equal(4, list2.LastIndexOf(nanVariant2));
+
+            Assert.Equal(2, list2.LastIndexOf(nanDefault, 2));
+            Assert.Equal(2, list2.LastIndexOf(nanVariant1, 2));
+            Assert.Equal(2, list2.LastIndexOf(nanVariant2, 2));
+
+            Assert.Equal(0, list2.LastIndexOf(nanDefault, 1, 2));
+            Assert.Equal(0, list2.LastIndexOf(nanVariant1, 1, 2));
+            Assert.Equal(0, list2.LastIndexOf(nanVariant2, 1, 2));
         }
 
         /// <summary>

--- a/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.cs
+++ b/tests/Xunit/J2N.Collections.Generic.List.Tests/List.Generic.cs
@@ -80,4 +80,22 @@ namespace J2N.Collections.Tests
 
         protected override bool Enumerator_Empty_Current_UndefinedOperation_Throws => true;
     }
+
+    public class List_Generic_Tests_float : List_Generic_Tests<float>
+    {
+        protected override float CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return (float)rand.NextDouble();
+        }
+    }
+
+    public class List_Generic_Tests_double : List_Generic_Tests<double>
+    {
+        protected override double CreateT(int seed)
+        {
+            Random rand = new Random(seed);
+            return rand.NextDouble();
+        }
+    }
 }


### PR DESCRIPTION
- Add IndexOf<T> wrapper methods to Arrays class with special handling for float, double, and nullable variants
- Add LastIndexOf<T> wrapper methods to Arrays class with special handling for float, double, and nullable variants
- Update List<T>.IndexOf() and LastIndexOf() to use new Arrays methods instead of Array methods
- Extract duplicated search logic into helper methods IndexOfFloatingPoint<T> and LastIndexOfFloatingPoint<T>
- Add comprehensive test cases for NaN and signed zero behavior

Fixes issue where NaN != NaN and +0.0 == -0.0 by leveraging J2N's EqualityComparer<T> which implements Java semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)