### PR TITLE
Updated `Dictionary<TKey, TValue>` to match .NET 10 behavior (Fixes #157)

### DIFF
--- a/src/J2N/Collections/Generic/Dictionary.cs
+++ b/src/J2N/Collections/Generic/Dictionary.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Based on: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.ObjectModel;
@@ -381,7 +382,7 @@ namespace J2N.Collections.Generic
                 Debug.Assert(_entries!.Length >= source.Count);
                 Debug.Assert(_count == 0);
 
-                Entry[] oldEntries = source._entries!;
+                Entry[] oldEntries = source._entries!; // [!]: asserted above
                 if (source._comparer == _comparer)
                 {
                     // If comparers are the same, we can copy _entries without rehashing.
@@ -501,7 +502,7 @@ namespace J2N.Collections.Generic
                 if (typeof(TKey) == typeof(string))
                 {
                     Debug.Assert(_comparer is not null, "The comparer should never be null for a reference type.");
-                    return (IEqualityComparer<TKey>)InternalStringEqualityComparer.GetUnderlyingEqualityComparer((IEqualityComparer<string?>)_comparer!);
+                    return (IEqualityComparer<TKey>)InternalStringEqualityComparer.GetUnderlyingEqualityComparer((IEqualityComparer<string?>)_comparer!); // [!]: asserted above
                 }
                 else
                 {
@@ -858,6 +859,11 @@ namespace J2N.Collections.Generic
         /// </remarks>
         public int Count => _count - _freeCount;
 
+        /// <summary>
+        /// Gets the total numbers of elements the internal data structure can hold without resizing.
+        /// </summary>
+        public int Capacity => _entries?.Length ?? 0;
+
         bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => false;
 
         /// <summary>
@@ -951,9 +957,7 @@ namespace J2N.Collections.Generic
         /// with the specified key; otherwise, <c>false</c>.</returns>
         /// <remarks>This method is an O(log <c>n</c>) operation.</remarks>
         public bool ContainsKey([AllowNull] TKey key)
-        {
-            return !UnsafeHelpers.IsNullRef(ref FindValue(key));
-        }
+            => !UnsafeHelpers.IsNullRef(ref FindValue(key));
 
         /// <summary>
         /// Removes the element with the specified key from the <see cref="Dictionary{TKey, TValue}"/>.
@@ -1112,7 +1116,7 @@ namespace J2N.Collections.Generic
         /// </remarks>
 #pragma warning disable IDE0079 // Remove unnecessary suppression
 #pragma warning disable CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
-        public bool TryGetValue([AllowNull, MaybeNull] TKey key, [MaybeNullWhen(false)] out TValue value)
+        public bool TryGetValue([AllowNull] TKey key, [MaybeNullWhen(false)] out TValue value)
 #pragma warning restore CS8767 // Nullability of reference types in type of parameter 'value' of 'bool Dictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' doesn't match implicitly implemented member 'bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)' (possibly because of nullability attributes).
 #pragma warning restore IDE0079 // Remove unnecessary suppression
         {
@@ -1179,7 +1183,7 @@ namespace J2N.Collections.Generic
         /// that is the destination of the elements copied from the current <see cref="Dictionary{TKey, TValue}"/>.
         /// The array must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int index) // J2N NOTE: This API as private upstream, but low priority to fix.
         {
             if (array is null)
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
@@ -1444,11 +1448,11 @@ namespace J2N.Collections.Generic
 
                 try
                 {
-                    TKey tempKey = (TKey)key!;
+                    TKey tempKey = (TKey)key!; // [!]: checked above
 
                     try
                     {
-                        this[tempKey] = (TValue)value!;
+                        this[tempKey] = (TValue)value!; // [!]: checked above
                     }
                     catch (InvalidCastException)
                     {
@@ -1470,11 +1474,11 @@ namespace J2N.Collections.Generic
 
             try
             {
-                TKey tempKey = (TKey)key!;
+                TKey tempKey = (TKey)key!; // [!]: checked above
 
                 try
                 {
-                    Add(tempKey, (TValue)value!);
+                    Add(tempKey, (TValue)value!); // [!]: checked above
                 }
                 catch (InvalidCastException)
                 {
@@ -1491,7 +1495,7 @@ namespace J2N.Collections.Generic
         {
             if (IsCompatibleKey(key))
             {
-                return ContainsKey((TKey)key!);
+                return ContainsKey((TKey)key!); // [!]: checked above
             }
             return false;
         }
@@ -1502,7 +1506,7 @@ namespace J2N.Collections.Generic
         {
             if (IsCompatibleKey(key))
             {
-                Remove((TKey)key!);
+                Remove((TKey)key!); // [!]: checked above
             }
         }
 
@@ -1585,6 +1589,8 @@ namespace J2N.Collections.Generic
 
         internal ref TValue FindValue([AllowNull] TKey key)
         {
+            // J2N supports null keys
+
             ref Entry entry = ref UnsafeHelpers.NullRef<Entry>();
             if (_buckets != null)
             {
@@ -1734,7 +1740,7 @@ namespace J2N.Collections.Generic
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _freeList = -1;
-            if (Unsafe.SizeOf<IntPtr>() == sizeof(long)) // 64 bit
+            if (IntPtr.Size == 8) // 64-bit process
             {
                 _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)size);
             }
@@ -2002,7 +2008,7 @@ namespace J2N.Collections.Generic
 
             // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
             _buckets = new int[newSize];
-            if (Unsafe.SizeOf<IntPtr>() == sizeof(long)) // 64 bit
+            if (IntPtr.Size == 8) // 64-bit process
             {
                 _fastModMultiplier = HashHelpers.GetFastModMultiplier((uint)newSize);
             }
@@ -2023,7 +2029,7 @@ namespace J2N.Collections.Generic
         {
             Debug.Assert(_entries is not null);
 
-            Entry[] newEntries = _entries!;
+            Entry[] newEntries = _entries!; // [!]: asserted above
             int newCount = 0;
             for (int i = 0; i < count; i++)
             {
@@ -2048,7 +2054,7 @@ namespace J2N.Collections.Generic
         {
             int[] buckets = _buckets!;
 
-            if (Unsafe.SizeOf<IntPtr>() == sizeof(long)) // 64 bit
+            if (IntPtr.Size == 8) // 64-bit process
             {
                 return ref buckets[HashHelpers.FastMod(hashCode, (uint)buckets.Length, _fastModMultiplier)];
             }
@@ -2060,6 +2066,468 @@ namespace J2N.Collections.Generic
 
         #endregion Hash Table
 
+        #region AlternateLookup
+
+#if FEATURE_IALTERNATEEQUALITYCOMPARER
+
+        /// <summary>
+        /// Gets an instance of a type that may be used to perform operations on the current <see cref="Dictionary{TKey, TValue}"/>
+        /// using a <typeparamref name="TAlternateKey"/> as a key instead of a <typeparamref name="TKey"/>.
+        /// </summary>
+        /// <typeparam name="TAlternateKey">The alternate type of a key for performing lookups.</typeparam>
+        /// <returns>The created lookup instance.</returns>
+        /// <exception cref="InvalidOperationException">The dictionary's comparer is not compatible with <typeparamref name="TAlternateKey"/>.</exception>
+        /// <remarks>
+        /// The dictionary must be using a comparer that implements <see cref="IAlternateEqualityComparer{TAlternateKey, TKey}"/> with
+        /// <typeparamref name="TAlternateKey"/> and <typeparamref name="TKey"/>. If it doesn't, an exception will be thrown.
+        /// </remarks>
+        public AlternateLookup<TAlternateKey> GetAlternateLookup<TAlternateKey>()
+            where TAlternateKey : allows ref struct
+        {
+            if (!AlternateLookup<TAlternateKey>.IsCompatibleKey(this))
+            {
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.InvalidOperation_IncompatibleComparer);
+            }
+
+            return new AlternateLookup<TAlternateKey>(this);
+        }
+
+        /// <summary>
+        /// Gets an instance of a type that may be used to perform operations on the current <see cref="Dictionary{TKey, TValue}"/>
+        /// using a <typeparamref name="TAlternateKey"/> as a key instead of a <typeparamref name="TKey"/>.
+        /// </summary>
+        /// <typeparam name="TAlternateKey">The alternate type of a key for performing lookups.</typeparam>
+        /// <param name="lookup">The created lookup instance when the method returns true, or a default instance that should not be used if the method returns false.</param>
+        /// <returns>true if a lookup could be created; otherwise, false.</returns>
+        /// <remarks>
+        /// The dictionary must be using a comparer that implements <see cref="IAlternateEqualityComparer{TAlternateKey, TKey}"/> with
+        /// <typeparamref name="TAlternateKey"/> and <typeparamref name="TKey"/>. If it doesn't, the method will return false.
+        /// </remarks>
+        public bool TryGetAlternateLookup<TAlternateKey>(
+            out AlternateLookup<TAlternateKey> lookup)
+            where TAlternateKey : allows ref struct
+        {
+            if (AlternateLookup<TAlternateKey>.IsCompatibleKey(this))
+            {
+                lookup = new AlternateLookup<TAlternateKey>(this);
+                return true;
+            }
+
+            lookup = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Provides a type that may be used to perform operations on a <see cref="Dictionary{TKey, TValue}"/>
+        /// using a <typeparamref name="TAlternateKey"/> as a key instead of a <typeparamref name="TKey"/>.
+        /// </summary>
+        /// <typeparam name="TAlternateKey">The alternate type of a key for performing lookups.</typeparam>
+        public readonly struct AlternateLookup<TAlternateKey> where TAlternateKey : allows ref struct
+        {
+            /// <summary>Initialize the instance. The dictionary must have already been verified to have a compatible comparer.</summary>
+            internal AlternateLookup(Dictionary<TKey, TValue> dictionary)
+            {
+                Debug.Assert(dictionary is not null);
+                Debug.Assert(IsCompatibleKey(dictionary));
+                Dictionary = dictionary;
+            }
+
+            /// <summary>Gets the <see cref="Dictionary{TKey, TValue}"/> against which this instance performs operations.</summary>
+            public Dictionary<TKey, TValue> Dictionary { get; }
+
+            /// <summary>Gets or sets the value associated with the specified alternate key.</summary>
+            /// <param name="key">The alternate key of the value to get or set.</param>
+            /// <value>
+            /// The value associated with the specified alternate key. If the specified alternate key is not found, a get operation throws
+            /// a <see cref="KeyNotFoundException"/>, and a set operation creates a new element with the specified key.
+            /// </value>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            /// <exception cref="KeyNotFoundException">The property is retrieved and alternate key does not exist in the collection.</exception>
+            public TValue this[[AllowNull] TAlternateKey key]
+            {
+                get
+                {
+                    ref TValue value = ref FindValue(key, out _);
+                    if (Unsafe.IsNullRef(ref value))
+                    {
+                        ThrowHelper.ThrowKeyNotFoundException(GetAlternateComparer(Dictionary).Create(key));
+                    }
+
+                    return value;
+                }
+                set => GetValueRefOrAddDefault(key, out _) = value;
+            }
+
+            /// <summary>Checks whether the dictionary has a comparer compatible with <typeparamref name="TAlternateKey"/>.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static bool IsCompatibleKey(Dictionary<TKey, TValue> dictionary)
+            {
+                Debug.Assert(dictionary is not null);
+                return dictionary._comparer is IAlternateEqualityComparer<TAlternateKey, TKey>;
+            }
+
+            /// <summary>Gets the dictionary's alternate comparer. The dictionary must have already been verified as compatible.</summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal static IAlternateEqualityComparer<TAlternateKey, TKey> GetAlternateComparer(Dictionary<TKey, TValue> dictionary)
+            {
+                Debug.Assert(IsCompatibleKey(dictionary));
+                return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(dictionary._comparer)!;
+            }
+
+            /// <summary>Gets the value associated with the specified alternate key.</summary>
+            /// <param name="key">The alternate key of the value to get.</param>
+            /// <param name="value">
+            /// When this method returns, contains the value associated with the specified key, if the key is found;
+            /// otherwise, the default value for the type of the value parameter.
+            /// </param>
+            /// <returns><see langword="true"/> if an entry was found; otherwise, <see langword="false"/>.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool TryGetValue([AllowNull] TAlternateKey key, [MaybeNullWhen(false)] out TValue value)
+            {
+                ref TValue valueRef = ref FindValue(key, out _);
+                if (!Unsafe.IsNullRef(ref valueRef))
+                {
+                    value = valueRef;
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            /// <summary>Gets the value associated with the specified alternate key.</summary>
+            /// <param name="key">The alternate key of the value to get.</param>
+            /// <param name="actualKey">
+            /// When this method returns, contains the actual key associated with the alternate key, if the key is found;
+            /// otherwise, the default value for the type of the key parameter.
+            /// </param>
+            /// <param name="value">
+            /// When this method returns, contains the value associated with the specified key, if the key is found;
+            /// otherwise, the default value for the type of the value parameter.
+            /// </param>
+            /// <returns><see langword="true"/> if an entry was found; otherwise, <see langword="false"/>.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool TryGetValue([AllowNull] TAlternateKey key, [MaybeNullWhen(false)] out TKey actualKey, [MaybeNullWhen(false)] out TValue value)
+            {
+                ref TValue valueRef = ref FindValue(key, out actualKey);
+                if (!Unsafe.IsNullRef(ref valueRef))
+                {
+                    value = valueRef;
+                    Debug.Assert(actualKey is not null);
+                    return true;
+                }
+
+                value = default;
+                return false;
+            }
+
+            /// <summary>Determines whether the <see cref="Dictionary{TKey, TValue}"/> contains the specified alternate key.</summary>
+            /// <param name="key">The alternate key to check.</param>
+            /// <returns><see langword="true"/> if the key is in the dictionary; otherwise, <see langword="false"/>.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool ContainsKey([AllowNull] TAlternateKey key) =>
+                !Unsafe.IsNullRef(ref FindValue(key, out _));
+
+            /// <summary>Finds the entry associated with the specified alternate key.</summary>
+            /// <param name="key">The alternate key.</param>
+            /// <param name="actualKey">The actual key, if found.</param>
+            /// <returns>A reference to the value associated with the key, if found; otherwise, a null reference.</returns>
+            internal ref TValue FindValue([AllowNull] TAlternateKey key, [MaybeNullWhen(false)] out TKey actualKey)
+            {
+                Dictionary<TKey, TValue> dictionary = Dictionary;
+
+                ref Entry entry = ref Unsafe.NullRef<Entry>();
+                if (dictionary._buckets != null)
+                {
+                    Debug.Assert(dictionary._entries != null, "expected entries to be != null");
+
+                    if (key is not null)
+                    {
+                        IAlternateEqualityComparer<TAlternateKey, TKey> comparer = GetAlternateComparer(dictionary); // J2N: Moved within null check, since we don't need to look this up for null keys
+
+                        uint hashCode = (uint)comparer.GetHashCode(key);
+                        int i = dictionary.GetBucket(hashCode);
+                        Entry[]? entries = dictionary._entries;
+                        uint collisionCount = 0;
+                        i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        do
+                        {
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                goto ReturnNotFound;
+                            }
+
+                            entry = ref entries[i];
+                            if (entry.hashCode == hashCode && comparer.Equals(key, entry.key))
+                            {
+                                goto ReturnFound;
+                            }
+
+                            i = entry.next;
+
+                            collisionCount++;
+                        } while (collisionCount <= (uint)entries.Length);
+                    }
+                    else
+                    {
+                        uint hashCode = 0;
+                        int i = dictionary.GetBucket(hashCode);
+                        Entry[]? entries = dictionary._entries;
+                        uint collisionCount = 0;
+                        i--; // Value in _buckets is 1-based; subtract 1 from i. We do it here so it fuses with the following conditional.
+                        do
+                        {
+                            // Should be a while loop https://github.com/dotnet/runtime/issues/9422
+                            // Test in if to drop range check for following array access
+                            if ((uint)i >= (uint)entries.Length)
+                            {
+                                goto ReturnNotFound;
+                            }
+
+                            entry = ref entries[i];
+                            if (entry.hashCode == hashCode && entry.key is null)
+                            {
+                                goto ReturnFound;
+                            }
+
+                            i = entry.next;
+
+                            collisionCount++;
+                        } while (collisionCount <= (uint)entries.Length);
+                    }
+
+                    // The chain of entries forms a loop; which means a concurrent update has happened.
+                    // Break out of the loop and throw, rather than looping forever.
+                    goto ConcurrentOperation;
+                }
+
+                goto ReturnNotFound;
+
+            ConcurrentOperation:
+                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+            ReturnFound:
+                ref TValue value = ref entry.value;
+                actualKey = entry.key;
+            Return:
+                return ref value;
+            ReturnNotFound:
+                value = ref Unsafe.NullRef<TValue>();
+                actualKey = default!;
+                goto Return;
+            }
+
+            /// <summary>Removes the value with the specified alternate key from the <see cref="Dictionary{TKey, TValue}"/>.</summary>
+            /// <param name="key">The alternate key of the element to remove.</param>
+            /// <returns>true if the element is successfully found and removed; otherwise, false.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool Remove([AllowNull] TAlternateKey key) =>
+                Remove(key, out _, out _);
+
+            /// <summary>
+            /// Removes the value with the specified alternate key from the <see cref="Dictionary{TKey, TValue}"/>,
+            /// and copies the element to the value parameter.
+            /// </summary>
+            /// <param name="key">The alternate key of the element to remove.</param>
+            /// <param name="actualKey">The removed key.</param>
+            /// <param name="value">The removed element.</param>
+            /// <returns>true if the element is successfully found and removed; otherwise, false.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool Remove([AllowNull] TAlternateKey key, [MaybeNullWhen(false)] out TKey actualKey, [MaybeNullWhen(false)] out TValue value)
+            {
+                Dictionary<TKey, TValue> dictionary = Dictionary;
+                IAlternateEqualityComparer<TAlternateKey, TKey> comparer = GetAlternateComparer(dictionary);
+
+                if (dictionary._buckets != null)
+                {
+                    Debug.Assert(dictionary._entries != null, "entries should be non-null");
+                    uint collisionCount = 0;
+
+                    uint hashCode = (uint)comparer.GetHashCode(key);
+
+                    ref int bucket = ref dictionary.GetBucket(hashCode);
+                    Entry[]? entries = dictionary._entries;
+                    int last = -1;
+                    int i = bucket - 1; // Value in buckets is 1-based
+                    while (i >= 0)
+                    {
+                        ref Entry entry = ref entries[i];
+
+                        if (entry.hashCode == hashCode && comparer.Equals(key, entry.key))
+                        {
+                            if (last < 0)
+                            {
+                                bucket = entry.next + 1; // Value in buckets is 1-based
+                            }
+                            else
+                            {
+                                entries[last].next = entry.next;
+                            }
+
+                            actualKey = entry.key;
+                            value = entry.value;
+
+                            Debug.Assert((StartOfFreeList - dictionary._freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                            entry.next = StartOfFreeList - dictionary._freeList;
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                            {
+                                entry.key = default!;
+                            }
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                            {
+                                entry.value = default!;
+                            }
+
+                            dictionary._freeList = i;
+                            dictionary._freeCount++;
+                            return true;
+                        }
+
+                        last = i;
+                        i = entry.next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
+                    }
+                }
+
+                actualKey = default;
+                value = default;
+                return false;
+            }
+
+            /// <summary>Attempts to add the specified key and value to the dictionary.</summary>
+            /// <param name="key">The alternate key of the element to add.</param>
+            /// <param name="value">The value of the element to add.</param>
+            /// <returns>true if the key/value pair was added to the dictionary successfully; otherwise, false.</returns>
+            /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+            public bool TryAdd([AllowNull] TAlternateKey key, TValue value)
+            {
+                ref TValue? slot = ref GetValueRefOrAddDefault(key, out bool exists);
+                if (!exists)
+                {
+                    slot = value;
+                    return true;
+                }
+
+                return false;
+            }
+
+            /// <inheritdoc cref="CollectionMarshal.GetValueRefOrAddDefault{TKey, TValue}(Dictionary{TKey, TValue}, TKey, out bool)"/>
+            internal ref TValue? GetValueRefOrAddDefault([AllowNull] TAlternateKey key, out bool exists)
+            {
+                // NOTE: this method is a mirror of GetValueRefOrAddDefault above. Keep it in sync.
+
+                Dictionary<TKey, TValue> dictionary = Dictionary;
+                IAlternateEqualityComparer<TAlternateKey, TKey> comparer = GetAlternateComparer(dictionary);
+
+                if (dictionary._buckets == null)
+                {
+                    dictionary.Initialize(0);
+                }
+                Debug.Assert(dictionary._buckets != null);
+
+                Entry[]? entries = dictionary._entries;
+                Debug.Assert(entries != null, "expected entries to be non-null");
+
+                uint hashCode = (uint)comparer.GetHashCode(key);
+
+                uint collisionCount = 0;
+                ref int bucket = ref dictionary.GetBucket(hashCode);
+                int i = bucket - 1; // Value in _buckets is 1-based
+
+                Debug.Assert(comparer is not null);
+                while ((uint)i < (uint)entries.Length)
+                {
+                    if (entries[i].hashCode == hashCode && comparer.Equals(key, entries[i].key))
+                    {
+                        exists = true;
+
+                        return ref entries[i].value!;
+                    }
+
+                    i = entries[i].next;
+
+                    collisionCount++;
+                    if (collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+
+                TKey actualKey = comparer.Create(key);
+                if (actualKey is null)
+                {
+                    ThrowHelper.ThrowArgumentNullException(ExceptionArgument.key);
+                }
+
+                int index;
+                if (dictionary._freeCount > 0)
+                {
+                    index = dictionary._freeList;
+                    Debug.Assert((StartOfFreeList - entries[dictionary._freeList].next) >= -1, "shouldn't overflow because `next` cannot underflow");
+                    dictionary._freeList = StartOfFreeList - entries[dictionary._freeList].next;
+                    dictionary._freeCount--;
+                }
+                else
+                {
+                    int count = dictionary._count;
+                    if (count == entries.Length)
+                    {
+                        dictionary.Resize();
+                        bucket = ref dictionary.GetBucket(hashCode);
+                    }
+                    index = count;
+                    dictionary._count = count + 1;
+                    entries = dictionary._entries;
+                }
+
+                ref Entry entry = ref entries![index];
+                entry.hashCode = hashCode;
+                entry.next = bucket - 1; // Value in _buckets is 1-based
+                entry.key = actualKey;
+                entry.value = default!;
+                bucket = index + 1; // Value in _buckets is 1-based
+                dictionary._version++;
+
+                // Value types never rehash
+                if (!typeof(TKey).IsValueType && collisionCount > HashHelpers.HashCollisionThreshold && comparer is NonRandomizedStringEqualityComparer)
+                {
+                    // If we hit the collision threshold we'll need to switch to the comparer which is using randomized string hashing
+                    // i.e. EqualityComparer<string>.Default.
+                    dictionary.Resize(entries.Length, true);
+
+                    exists = false;
+
+                    // At this point the entries array has been resized, so the current reference we have is no longer valid.
+                    // We're forced to do a new lookup and return an updated reference to the new entry instance. This new
+                    // lookup is guaranteed to always find a value though and it will never return a null reference here.
+                    ref TValue? value = ref dictionary.FindValue(actualKey)!;
+
+                    Debug.Assert(!Unsafe.IsNullRef(ref value), "the lookup result cannot be a null ref here");
+
+                    return ref value;
+                }
+
+                exists = false;
+
+                return ref entry.value!;
+            }
+        }
+
+#endif
+
+        #endregion AlternateLookup
 
         #region Structural Equality
 
@@ -2189,11 +2657,14 @@ namespace J2N.Collections.Generic
         /// continue to be reflected in the <see cref="Dictionary{TKey, TValue}.KeyCollection"/>.
         /// </remarks>
 #if FEATURE_SERIALIZABLE
-        [Serializable]
+        [Serializable] // J2N TODO: API - remove (BCL doesn't do this)
 #endif
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
         public sealed class KeyCollection : ICollection<TKey>, ICollection
+#if FEATURE_IREADONLYCOLLECTIONS
+            , IReadOnlyCollection<TKey>
+#endif
         {
             private readonly Dictionary<TKey, TValue> dictionary;
 
@@ -2256,7 +2727,7 @@ namespace J2N.Collections.Generic
             /// <para/>
             /// This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
             /// </remarks>
-            public void CopyTo([MaybeNull] TKey[] array, int index)
+            public void CopyTo(TKey[] array, int index)
             {
                 if (array is null)
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
@@ -2413,7 +2884,7 @@ namespace J2N.Collections.Generic
             /// Default implementations of collections in the <see cref="J2N.Collections.Generic"/> namespace are not synchronized.
             /// </remarks>
 #if FEATURE_SERIALIZABLE
-            [Serializable]
+            [Serializable] // J2N TODO: API - remove (BCL doesn't do this)
 #endif
             public struct Enumerator : IEnumerator<TKey>, IEnumerator
             {
@@ -2548,11 +3019,14 @@ namespace J2N.Collections.Generic
         /// continue to be reflected in the <see cref="Dictionary{TKey, TValue}.ValueCollection"/>.
         /// </remarks>
 #if FEATURE_SERIALIZABLE
-        [Serializable]
+        [Serializable] // J2N TODO: API - remove (BCL doesn't do this)
 #endif
         [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
         public sealed class ValueCollection : ICollection<TValue>, ICollection
+#if FEATURE_IREADONLYCOLLECTIONS
+            , IReadOnlyCollection<TValue>
+#endif
         {
             private readonly Dictionary<TKey, TValue> dictionary;
 
@@ -2662,7 +3136,7 @@ namespace J2N.Collections.Generic
             /// <para/>
             /// This method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
             /// </remarks>
-            public void CopyTo([MaybeNull] TValue[] array, int index)
+            public void CopyTo(TValue[] array, int index)
             {
                 if (array is null)
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
@@ -2780,7 +3254,7 @@ namespace J2N.Collections.Generic
             /// Default implementations of collections in the <see cref="J2N.Collections.Generic"/> namespace are not synchronized.
             /// </remarks>
 #if FEATURE_SERIALIZABLE
-            [Serializable]
+            [Serializable] // J2N TODO: API - remove (BCL doesn't do this)
 #endif
             public struct Enumerator : IEnumerator<TValue>, IEnumerator
             {
@@ -2950,9 +3424,9 @@ namespace J2N.Collections.Generic
             internal Enumerator(Dictionary<TKey, TValue> dictionary, int getEnumeratorRetType)
             {
                 this.dictionary = dictionary;
-                this.getEnumeratorRetType = getEnumeratorRetType;
                 version = dictionary._version;
                 index = 0;
+                this.getEnumeratorRetType = getEnumeratorRetType;
                 current = default;
             }
 
@@ -2962,7 +3436,7 @@ namespace J2N.Collections.Generic
             /// <value>The element in the <see cref="Dictionary{TKey, TValue}"/> at the current position of the enumerator.</value>
             public KeyValuePair<TKey, TValue> Current => current;
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -3090,7 +3564,7 @@ namespace J2N.Collections.Generic
         /// </summary>
         internal static class CollectionsMarshalHelper
         {
-            ///// <inheritdoc cref="CollectionsMarshal.GetValueRefOrAddDefault{TKey, TValue}(Dictionary{TKey, TValue}, TKey, out bool)"/>
+            /// <inheritdoc cref="CollectionMarshal.GetValueRefOrAddDefault{TKey, TValue}(Dictionary{TKey, TValue}, TKey, out bool)"/>
             public static ref TValue? GetValueRefOrAddDefault(Dictionary<TKey, TValue> dictionary, [AllowNull] TKey key, out bool exists)
             {
                 // NOTE: this method is mirrored by Dictionary<TKey, TValue>.TryInsert above.
@@ -3130,7 +3604,7 @@ namespace J2N.Collections.Generic
                                 break;
                             }
 
-                            if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key!, key))
+                            if (entries[i].hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entries[i].key!, key)) // [!]: checked above
                             {
                                 exists = true;
 
@@ -3192,7 +3666,7 @@ namespace J2N.Collections.Generic
                                 break;
                             }
 
-                            if (entries[i].hashCode == hashCode && comparer!.Equals(entries[i].key!, key))
+                            if (entries[i].hashCode == hashCode && comparer!.Equals(entries[i].key!, key)) // [comparer!]: asserted above, [key!] checked above
                             {
                                 exists = true;
 

--- a/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
+++ b/src/J2N/Runtime/InteropServices/CollectionMarshal.cs
@@ -64,6 +64,27 @@ namespace J2N.Runtime.InteropServices
         public static ref TValue GetValueRefOrNullRef<TKey, TValue>(Dictionary<TKey, TValue> dictionary, [AllowNull] TKey key)
             => ref dictionary.FindValue(key);
 
+#if FEATURE_IALTERNATEEQUALITYCOMPARER
+
+        /// <summary>
+        /// Gets either a ref to a <typeparamref name="TValue"/> in the <see cref="Dictionary{TKey, TValue}"/> or a ref null if it does not exist in the <paramref name="dictionary"/>.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to get the ref to <typeparamref name="TValue"/> from.</param>
+        /// <param name="key">The key used for lookup.</param>
+        /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+        /// <typeparam name="TAlternateKey">The type of an alternate key for lookups in the dictionary.</typeparam>
+        /// <remarks>
+        /// Items should not be added or removed from the <see cref="Dictionary{TKey, TValue}"/> while the ref <typeparamref name="TValue"/> is in use.
+        /// The ref null can be detected using System.Runtime.CompilerServices.Unsafe.IsNullRef
+        /// </remarks>
+        public static ref TValue GetValueRefOrNullRef<TKey, TValue, TAlternateKey>(Dictionary<TKey, TValue>.AlternateLookup<TAlternateKey> dictionary, TAlternateKey key)
+            where TKey : notnull
+            where TAlternateKey : allows ref struct
+            => ref dictionary.FindValue(key, out _);
+
+#endif
+
         /// <summary>
         /// Gets a ref to a <typeparamref name="TValue"/> in the <see cref="Dictionary{TKey, TValue}"/>, adding a new entry with a default value if it does not exist in the <paramref name="dictionary"/>.
         /// </summary>
@@ -75,6 +96,24 @@ namespace J2N.Runtime.InteropServices
         /// <remarks>Items should not be added to or removed from the <see cref="Dictionary{TKey, TValue}"/> while the ref <typeparamref name="TValue"/> is in use.</remarks>
         public static ref TValue? GetValueRefOrAddDefault<TKey, TValue>(Dictionary<TKey, TValue> dictionary, [AllowNull] TKey key, out bool exists)
             => ref Dictionary<TKey, TValue>.CollectionsMarshalHelper.GetValueRefOrAddDefault(dictionary, key, out exists);
+
+#if FEATURE_IALTERNATEEQUALITYCOMPARER
+
+        /// <summary>
+        /// Gets a ref to a <typeparamref name="TValue"/> in the <see cref="Dictionary{TKey, TValue}.AlternateLookup{TAlternateKey}"/>, adding a new entry with a default value if it does not exist in the <paramref name="dictionary"/>.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to get the ref to <typeparamref name="TValue"/> from.</param>
+        /// <param name="key">The key used for lookup.</param>
+        /// <param name="exists">Whether or not a new entry for the given key was added to the dictionary.</param>
+        /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+        /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+        /// <typeparam name="TAlternateKey">The type of the alternate key in the dictionary lookup.</typeparam>
+        /// <remarks>Items should not be added to or removed from the <see cref="Dictionary{TKey, TValue}.AlternateLookup{TAlternateKey}"/> while the ref <typeparamref name="TValue"/> is in use.</remarks>
+        public static ref TValue? GetValueRefOrAddDefault<TKey, TValue, TAlternateKey>(Dictionary<TKey, TValue>.AlternateLookup<TAlternateKey> dictionary, TAlternateKey key, out bool exists)
+            where TAlternateKey : allows ref struct
+            => ref dictionary.GetValueRefOrAddDefault(key, out exists);
+
+#endif
 
         /// <summary>
         /// Sets the count of the <see cref="List{T}"/> to the specified value.

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.ConcurrentAccessDetection.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N;

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.Keys.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.Keys.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Keys.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.Values.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.Values.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.Values.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.Tests.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.Tests.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.Generic;
@@ -85,6 +86,35 @@ namespace J2N.Collections.Tests
             Dictionary<TKey, TValue> dictionary = new Dictionary<TKey, TValue>(count, comparer);
             Assert.Equal(0, dictionary.Count);
             Assert.Equal(comparer, dictionary.EqualityComparer);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        public void Dictionary_CreateWithCapacity_CapacityAtLeastPassedValue(int capacity)
+        {
+            Dictionary<TKey, TValue> dict = new Dictionary<TKey, TValue>(capacity);
+            Assert.True(capacity <= dict.Capacity);
+        }
+
+        #endregion
+
+        #region Properties
+
+        public void DictResized_CapacityChanged()
+        {
+            var dict = (Dictionary<TKey, TValue>)GenericIDictionaryFactory(1);
+            int initialCapacity = dict.Capacity;
+
+            int seed = 85877;
+            for (int i = 0; i < dict.Capacity; i++)
+            {
+                dict.Add(CreateTKey(seed++), CreateTValue(seed++));
+            }
+
+            int afterCapacity = dict.Capacity;
+
+            Assert.True(afterCapacity > initialCapacity);
         }
 
         #endregion
@@ -618,6 +648,142 @@ namespace J2N.Collections.Tests
 
             Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
         }
+
+        #endregion
+
+        #region GetAlternateComparer
+
+#if FEATURE_IALTERNATEEQUALITYCOMPARER
+
+        [Fact]
+        public void GetAlternateLookup_FailsWhenIncompatible()
+        {
+            var dictionary = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            dictionary.GetAlternateLookup<ReadOnlySpan<char>>();
+            Assert.True(dictionary.TryGetAlternateLookup<ReadOnlySpan<char>>(out _));
+
+            Assert.Throws<InvalidOperationException>(() => dictionary.GetAlternateLookup<ReadOnlySpan<byte>>());
+            Assert.Throws<InvalidOperationException>(() => dictionary.GetAlternateLookup<string>());
+            Assert.Throws<InvalidOperationException>(() => dictionary.GetAlternateLookup<int>());
+
+            Assert.False(dictionary.TryGetAlternateLookup<ReadOnlySpan<byte>>(out _));
+            Assert.False(dictionary.TryGetAlternateLookup<string>(out _));
+            Assert.False(dictionary.TryGetAlternateLookup<int>(out _));
+        }
+
+        public static SCG.IEnumerable<object[]> Dictionary_GetAlternateLookup_OperationsMatchUnderlyingDictionary_MemberData()
+        {
+            yield return new object[] { EqualityComparer<string>.Default };
+            yield return new object[] { StringComparer.Ordinal };
+            yield return new object[] { StringComparer.OrdinalIgnoreCase };
+            yield return new object[] { StringComparer.InvariantCulture };
+            yield return new object[] { StringComparer.InvariantCultureIgnoreCase };
+            yield return new object[] { StringComparer.CurrentCulture };
+            yield return new object[] { StringComparer.CurrentCultureIgnoreCase };
+        }
+
+        [Theory]
+        [MemberData(nameof(Dictionary_GetAlternateLookup_OperationsMatchUnderlyingDictionary_MemberData))]
+        public void Dictionary_GetAlternateLookup_OperationsMatchUnderlyingDictionary(SCG.IEqualityComparer<string> comparer)
+        {
+            // Test with a variety of comparers to ensure that the alternate lookup is consistent with the underlying dictionary
+            Dictionary<string, int> dictionary = new(comparer);
+            Dictionary<string, int>.AlternateLookup<ReadOnlySpan<char>> lookup = dictionary.GetAlternateLookup<ReadOnlySpan<char>>();
+            Assert.Same(dictionary, lookup.Dictionary);
+            Assert.Same(lookup.Dictionary, lookup.Dictionary);
+
+            string actualKey;
+            int value;
+
+            // Add to the dictionary and validate that the lookup reflects the changes
+            dictionary["123"] = 123;
+            Assert.True(lookup.ContainsKey("123".AsSpan()));
+            Assert.True(lookup.TryGetValue("123".AsSpan(), out value));
+            Assert.Equal(123, value);
+            Assert.Equal(123, lookup["123".AsSpan()]);
+            Assert.False(lookup.TryAdd("123".AsSpan(), 321));
+            Assert.True(lookup.Remove("123".AsSpan()));
+            Assert.False(dictionary.ContainsKey("123"));
+            Assert.Throws<SCG.KeyNotFoundException>(() => lookup["123".AsSpan()]);
+
+            // Add via the lookup and validate that the dictionary reflects the changes
+            Assert.True(lookup.TryAdd("123".AsSpan(), 123));
+            Assert.True(dictionary.ContainsKey("123"));
+            lookup.TryGetValue("123".AsSpan(), out value);
+            Assert.Equal(123, value);
+            Assert.False(lookup.Remove("321".AsSpan(), out actualKey, out value));
+            Assert.Null(actualKey);
+            Assert.Equal(0, value);
+            Assert.True(lookup.Remove("123".AsSpan(), out actualKey, out value));
+            Assert.Equal("123", actualKey);
+            Assert.Equal(123, value);
+
+            // Ensure that case-sensitivity of the comparer is respected
+            lookup["a".AsSpan()] = 42;
+            if (dictionary.EqualityComparer.Equals(EqualityComparer<string>.Default) ||
+                dictionary.EqualityComparer.Equals(StringComparer.Ordinal) ||
+                dictionary.EqualityComparer.Equals(StringComparer.InvariantCulture) ||
+                dictionary.EqualityComparer.Equals(StringComparer.CurrentCulture))
+            {
+                Assert.True(lookup.TryGetValue("a".AsSpan(), out actualKey, out value));
+                Assert.Equal("a", actualKey);
+                Assert.Equal(42, value);
+                Assert.True(lookup.TryAdd("A".AsSpan(), 42));
+                Assert.True(lookup.Remove("a".AsSpan()));
+                Assert.False(lookup.Remove("a".AsSpan()));
+                Assert.True(lookup.Remove("A".AsSpan()));
+            }
+            else
+            {
+                Assert.True(lookup.TryGetValue("A".AsSpan(), out actualKey, out value));
+                Assert.Equal("a", actualKey);
+                Assert.Equal(42, value);
+                Assert.False(lookup.TryAdd("A".AsSpan(), 42));
+                Assert.True(lookup.Remove("A".AsSpan()));
+                Assert.False(lookup.Remove("a".AsSpan()));
+                Assert.False(lookup.Remove("A".AsSpan()));
+            }
+
+            // Validate overwrites
+            lookup["a".AsSpan()] = 42;
+            Assert.Equal(42, dictionary["a"]);
+            lookup["a".AsSpan()] = 43;
+            Assert.True(lookup.Remove("a".AsSpan(), out actualKey, out value));
+            Assert.Equal("a", actualKey);
+            Assert.Equal(43, value);
+
+            // Test adding multiple entries via the lookup
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.Equal(i, dictionary.Count);
+                Assert.True(lookup.TryAdd(i.ToString().AsSpan(), i));
+                Assert.False(lookup.TryAdd(i.ToString().AsSpan(), i));
+            }
+
+            Assert.Equal(10, dictionary.Count);
+
+            // Test that the lookup and the dictionary agree on what's in and not in
+            for (int i = -1; i <= 10; i++)
+            {
+                Assert.Equal(dictionary.TryGetValue(i.ToString(), out int dv), lookup.TryGetValue(i.ToString().AsSpan(), out int lv));
+                Assert.Equal(dv, lv);
+            }
+
+            // Test removing multiple entries via the lookup
+            for (int i = 9; i >= 0; i--)
+            {
+                Assert.True(lookup.Remove(i.ToString().AsSpan(), out actualKey, out value));
+                Assert.Equal(i.ToString(), actualKey);
+                Assert.Equal(i, value);
+                Assert.False(lookup.Remove(i.ToString().AsSpan(), out actualKey, out value));
+                Assert.Null(actualKey);
+                Assert.Equal(0, value);
+                Assert.Equal(i, dictionary.Count);
+            }
+        }
+
+#endif
 
         #endregion
 

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Generic.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Generic.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Tests.cs
+++ b/tests/Xunit/J2N.Collections.Generic.Dictionary.Tests/Dictionary.Tests.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿// Source: https://github.com/dotnet/runtime/blob/v10.0.0-rc.2.25502.107/src/libraries/System.Collections/tests/Generic/Dictionary/Dictionary.Tests.cs
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using J2N.Collections.Generic;
@@ -268,6 +269,41 @@ namespace J2N.Collections.Tests
             }
         }
 
+        [Theory]
+        [InlineData(10)]
+        [InlineData(1000)]
+        [InlineData(1000_000)]
+        public void InsertionOpsOnly_Enumeration_PreservesInsertionOrder(int count)
+        {
+            var dictionary = new Dictionary<string, int>();
+            for (int i = 0; i < count; i++)
+            {
+                dictionary.Add(i.ToString(), i);
+            }
+
+            int j = 0;
+            foreach (SCG.KeyValuePair<string, int> kvp in dictionary)
+            {
+                Assert.Equal(j, int.Parse(kvp.Key));
+                Assert.Equal(j, kvp.Value);
+                j++;
+            }
+
+            j = 0;
+            foreach (string key in dictionary.Keys)
+            {
+                Assert.Equal(j.ToString(), key);
+                j++;
+            }
+
+            j = 0;
+            foreach (int value in dictionary.Values)
+            {
+                Assert.Equal(j, value);
+                j++;
+            }
+        }
+
         [Fact]
         public void TryAdd_ItemAlreadyExists_DoesNotInvalidateEnumerator()
         {
@@ -460,6 +496,14 @@ namespace J2N.Collections.Tests
             bf.Serialize(s, dict);
             s.Position = 0;
             dict = (Dictionary<T, T>)bf.Deserialize(s);
+
+            // J2N: this assertion fails on .NET <= 8, due to different internal implementations. Skipping it for now.
+            //if (equalityComparer.Equals(EqualityComparer<string>.Default))
+            //{
+            //    // EqualityComparer<string>.Default is mapped to StringEqualityComparer, but serialized as GenericEqualityComparer<string>
+            //    Assert.Equal("System.Collections.Generic.GenericEqualityComparer`1[System.String]", dict.EqualityComparer.GetType().ToString());
+            //    return;
+            //}
 
             if (internalTypeName == null)
             {


### PR DESCRIPTION
Fixes #157

This builds off of https://github.com/NightOwl888/J2N/pull/104 and adds the "alternate lookup" support that was added in .NET 9 and updates the tests. This is based on .NET 10 RC2.

Note that there are some missing `HashCollisionScenarios` tests that have been ported, but we need to finish #158 first before they will function, and we really should backport the "alternate lookup" feature before adding them to ensure everything is properly tested.