### PR TITLE
Added BinarySerializer support for .NET 8+ tests

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -20,6 +20,7 @@
     <SystemNetHttpPackageReferenceVersion>4.3.4</SystemNetHttpPackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion Condition=" '$(TargetFramework)' == 'net45' ">4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <SystemRuntimeSerializationFormattersPackageReferenceVersion>10.0.0</SystemRuntimeSerializationFormattersPackageReferenceVersion>
     <SystemTextEncodingCodePagesPackageReferenceVersion>4.3.0</SystemTextEncodingCodePagesPackageReferenceVersion>
     <SystemTextRegularExpressionsPackageReferenceVersion>4.3.1</SystemTextRegularExpressionsPackageReferenceVersion>
     <XunitPackageReferenceVersion>2.9.3</XunitPackageReferenceVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -119,12 +119,6 @@
     <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
         To add it to the build, just add /p:IncludeICloneable to the command line. -->
     <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
-
-  </PropertyGroup>
-
-  <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 8.x (No .NET 9+ support) -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net8.')) ">
-
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
     <!-- serializable exeptions were added back in .NET Core 2.0.4: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#net-core -->
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE_EXCEPTIONS</DefineConstants>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -37,77 +37,14 @@
     <NoWarn Label="FormatterConverter serialization is obsolete">$(NoWarn);SYSLIB0050</NoWarn>
     <NoWarn Label=".ctor(SerializationInfo, StreamingContext) is obsolete">$(NoWarn);SYSLIB0051</NoWarn>
   </PropertyGroup>
-  
-  <UsingTask TaskName="UpdateRuntimeConfigProperty" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <RuntimeConfigFile ParameterType="System.String" Required="true" />
-      <PropertyName ParameterType="System.String" Required="true" />
-      <PropertyValue ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        if (File.Exists(RuntimeConfigFile))
-        {
-            // Read the file content
-            string jsonContent = File.ReadAllText(RuntimeConfigFile);
 
-            // Ensure runtimeOptions and configProperties sections exist
-            if (!jsonContent.Contains("\"runtimeOptions\""))
-            {
-                jsonContent = jsonContent.TrimEnd('}', '\n', '\r') + ",\n  \"runtimeOptions\": {\n    \"configProperties\": {\n    }\n  }\n}";
-            }
-            if (!jsonContent.Contains("\"configProperties\""))
-            {
-                int runtimeOptionsIndex = jsonContent.IndexOf("\"runtimeOptions\"");
-                int insertPosition = jsonContent.IndexOf('}', runtimeOptionsIndex);
-                jsonContent = jsonContent.Insert(insertPosition, ",\n    \"configProperties\": {\n    }\n");
-            }
+  <PropertyGroup Label="Binary Serializer Support">
+    <RequiresSerializationPatch  Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netstandard')) And !$(TargetFramework.StartsWith('net6.')) And !$(TargetFramework.StartsWith('net7.')) ">true</RequiresSerializationPatch>
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(RequiresSerializationPatch)' == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
 
-            // Check if the property already exists
-            int configPropertiesIndex = jsonContent.IndexOf("\"configProperties\"");
-            int propertyIndex = jsonContent.IndexOf("\"" + PropertyName + "\"", configPropertiesIndex);
+  <ItemGroup Label="Binary Serializer Support" Condition="'$(RequiresSerializationPatch)' == 'true' ">
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageReferenceVersion)" />
+  </ItemGroup>
 
-            if (propertyIndex != -1)
-            {
-                // Property exists, update its value
-                int valueStartIndex = jsonContent.IndexOf(':', propertyIndex) + 1;
-                int valueEndIndex = jsonContent.IndexOfAny(new char[] { ',', '}', '\n' }, valueStartIndex);
-                jsonContent = jsonContent.Remove(valueStartIndex, valueEndIndex - valueStartIndex)
-                                         .Insert(valueStartIndex, " " + PropertyValue);
-            }
-            else
-            {
-                // Property does not exist, add it
-                int closingBraceIndex = jsonContent.IndexOf('}', configPropertiesIndex);
-                jsonContent = jsonContent.Insert(closingBraceIndex, "  \"" + PropertyName + "\": " + PropertyValue + ",\n");
-            }
-
-            // Write the updated content back to the file
-            File.WriteAllText(RuntimeConfigFile, jsonContent);
-        }
-        else
-        {
-            Log.LogError("File not found: " + RuntimeConfigFile);
-        }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Target to invoke the task after build -->
-  <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
-    <PropertyGroup>
-      <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
-    </PropertyGroup>
-
-    <UpdateRuntimeConfigProperty 
-        RuntimeConfigFile="$(RuntimeConfigFile)" 
-        PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" 
-        PropertyValue="true" 
-        Condition="Exists('$(RuntimeConfigFile)') And '$(TargetFramework)' == 'net8.0'" />
-  </Target>
-  
 </Project>


### PR DESCRIPTION
Added test support for binary serialization on .NET 8+. Eliminated .NET 8 hack for enabling binary serialization.

This removes a hack that we added to modify the `.runtimeconfig.json` file directly and relies on the official [System.Runtime.Serialization.Formatters](https://www.nuget.org/packages/System.Runtime.Serialization.Formatters) package and `EnableUnsafeBinaryFormatterSerialization` MSBuild property to enable serialization in tests.

This also enables binary serialization APIs on .NET 9+ which ensures these APIs don't break binary compatibility between target frameworks. That is, APIs can be added on later target frameworks, but should not be removed as that could cause issues when the consuming projects multi-target `netstandard2.0` and `net9.0`+.