### PR TITLE
Fixed clamping behavior on views for `TryGetPredecessor()` and `TryGetSuccessor()` in `SortedSet<T>.TreeSubSet` (Fixes #175)

### DIFF
--- a/src/J2N/Collections/Generic/SortedDictionary.cs
+++ b/src/J2N/Collections/Generic/SortedDictionary.cs
@@ -850,9 +850,38 @@ namespace J2N.Collections.Generic
         /// <param name="key">The key of the entry to get the predecessor of.</param>
         /// <param name="result">The <see cref="KeyValuePair{TKey, TValue}"/> representing the predessor, if any.</param>
         /// <returns><c>true</c> if a predecessor to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
-        public bool TryGetPredecessor(TKey key, out KeyValuePair<TKey, TValue> result)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool TryGetPredecessor(TKey key, out KeyValuePair<TKey, TValue> result) // J2N TODO: API - make this obsolete in 3.0
         {
             return _set.TryGetPredecessor(new KeyValuePair<TKey, TValue>(key, default!), out result);
+        }
+
+        /// <summary>
+        /// Gets the entry in the <see cref="SortedDictionary{TKey, TValue}"/> whose key
+        /// is the predecessor of the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The key of the entry to get the predecessor of.</param>
+        /// <param name="resultKey">Upon successful return, contains the key of the predecessor.</param>
+        /// <param name="resultValue">Upon successful return, contains the value of the predecessor.</param>
+        /// <returns><c>true</c> if a predecessor to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>strict predecessor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>lowerEntry()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetPredecessor(TKey key, [MaybeNullWhen(false)] out TKey resultKey, [MaybeNullWhen(false)] out TValue resultValue)
+        {
+            if (_set.TryGetPredecessor(new KeyValuePair<TKey, TValue>(key, default!), out KeyValuePair<TKey, TValue> result))
+            {
+                resultKey = result.Key;
+                resultValue = result.Value;
+                return true;
+            }
+            resultKey = default;
+            resultValue = default;
+            return false;
         }
 
         /// <summary>
@@ -862,9 +891,94 @@ namespace J2N.Collections.Generic
         /// <param name="key">The key of the entry to get the successor of.</param>
         /// <param name="result">The <see cref="KeyValuePair{TKey, TValue}"/> representing the successor, if any.</param>
         /// <returns><c>true</c> if a succesor to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
-        public bool TryGetSuccessor(TKey key, out KeyValuePair<TKey, TValue> result)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool TryGetSuccessor(TKey key, out KeyValuePair<TKey, TValue> result) // J2N TODO: API - make this obsolete in 3.0
         {
             return _set.TryGetSuccessor(new KeyValuePair<TKey, TValue>(key, default!), out result);
+        }
+
+        /// <summary>
+        /// Gets the entry in the <see cref="SortedDictionary{TKey, TValue}"/> whose key
+        /// is the successor of the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The key of the entry to get the successor of.</param>
+        /// <param name="resultKey">Upon successful return, contains the key of the successor.</param>
+        /// <param name="resultValue">Upon successful return, contains the value of the successor.</param>
+        /// <returns><c>true</c> if a succesor to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>strict successor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>higherEntry()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetSuccessor(TKey key, [MaybeNullWhen(false)] out TKey resultKey, [MaybeNullWhen(false)] out TValue resultValue)
+        {
+            if (_set.TryGetSuccessor(new KeyValuePair<TKey, TValue>(key, default!), out KeyValuePair<TKey, TValue> result))
+            {
+                resultKey = result.Key;
+                resultValue = result.Value;
+                return true;
+            }
+            resultKey = default;
+            resultValue = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the entry in the <see cref="SortedDictionary{TKey, TValue}"/> whose key
+        /// is the greatest element less than or equal to the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The key of the entry to get the floor of.</param>
+        /// <param name="resultKey">Upon successful return, contains the key of the floor.</param>
+        /// <param name="resultValue">Upon successful return, contains the value of the floor.</param>
+        /// <returns><c>true</c> if a floor to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>weak predecessor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>floorEntry()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetFloor(TKey key, [MaybeNullWhen(false)] out TKey resultKey, [MaybeNullWhen(false)] out TValue resultValue)
+        {
+            if (_set.TryGetFloor(new KeyValuePair<TKey, TValue>(key, default!), out KeyValuePair<TKey, TValue> result))
+            {
+                resultKey = result.Key;
+                resultValue = result.Value;
+                return true;
+            }
+            resultKey = default;
+            resultValue = default;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the entry in the <see cref="SortedDictionary{TKey, TValue}"/> whose key
+        /// is the lease element greater than or equal to the specified <paramref name="key"/>.
+        /// </summary>
+        /// <param name="key">The key of the entry to get the ceiling of.</param>
+        /// <param name="resultKey">Upon successful return, contains the key of the ceiling.</param>
+        /// <param name="resultValue">Upon successful return, contains the value of the ceiling.</param>
+        /// <returns><c>true</c> if a ceiling to <paramref name="key"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <b>weak successor</b> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>ceilingEntry()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetCeiling(TKey key, [MaybeNullWhen(false)] out TKey resultKey, [MaybeNullWhen(false)] out TValue resultValue)
+        {
+            if (_set.TryGetCeiling(new KeyValuePair<TKey, TValue>(key, default!), out KeyValuePair<TKey, TValue> result))
+            {
+                resultKey = result.Key;
+                resultValue = result.Value;
+                return true;
+            }
+            resultKey = default;
+            resultValue = default;
+            return false;
         }
 
         #endregion

--- a/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -449,12 +449,14 @@ namespace J2N.Collections.Generic
 #endif
 
                 // If item is at or below lower bound, no strict predecessor exists
-                if (IsTooLow(item) || (_lBoundActive &&
-                    Comparer.Compare(item!, _min!) == 0 &&
-                    _lBoundInclusive))
+                if (_lBoundActive)
                 {
-                    result = default!;
-                    return false;
+                    int c = Comparer.Compare(item!, _min!);
+                    if (c <= 0)
+                    {
+                        result = default!;
+                        return false;
+                    }
                 }
 
                 Node? current = root;
@@ -494,12 +496,14 @@ namespace J2N.Collections.Generic
 #endif
 
                 // If item is at or above upper bound, no strict successor exists
-                if (IsTooHigh(item) || (_uBoundActive &&
-                    Comparer.Compare(item!, _max!) == 0 &&
-                    _uBoundInclusive))
+                if (_uBoundActive)
                 {
-                    result = default!;
-                    return false;
+                    int c = Comparer.Compare(item!, _max!);
+                    if (c >= 0)
+                    {
+                        result = default!;
+                        return false;
+                    }
                 }
 
                 Node? current = root;

--- a/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.TreeSubSet.cs
@@ -441,6 +441,166 @@ namespace J2N.Collections.Generic
             }
 #endif
 
+            internal override bool DoTryGetPredecessor(T item, [MaybeNullWhen(false)] out T result)
+            {
+                VersionCheck();
+#if DEBUG
+                Debug.Assert(this.versionUpToDate() && root == _underlying.FindRange(_min, _max, _lBoundInclusive, _uBoundInclusive, _lBoundActive, _uBoundActive));
+#endif
+
+                // If item is at or below lower bound, no strict predecessor exists
+                if (IsTooLow(item) || (_lBoundActive &&
+                    Comparer.Compare(item!, _min!) == 0 &&
+                    _lBoundInclusive))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                Node? current = root;
+                Node? match = null;
+
+                while (current != null)
+                {
+                    int cmp = Comparer.Compare(item, current.Item);
+
+                    if (cmp > 0)
+                    {
+                        match = current;
+                        current = current.Right;
+                    }
+                    else
+                    {
+                        current = current.Left;
+                    }
+                }
+
+                // Final safety check: candidate must be within view
+                if (match == null || IsTooLow(match.Item))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                result = match.Item;
+                return true;
+            }
+
+            internal override bool DoTryGetSuccessor(T item, [MaybeNullWhen(false)] out T result)
+            {
+                VersionCheck();
+#if DEBUG
+                Debug.Assert(this.versionUpToDate() && root == _underlying.FindRange(_min, _max, _lBoundInclusive, _uBoundInclusive, _lBoundActive, _uBoundActive));
+#endif
+
+                // If item is at or above upper bound, no strict successor exists
+                if (IsTooHigh(item) || (_uBoundActive &&
+                    Comparer.Compare(item!, _max!) == 0 &&
+                    _uBoundInclusive))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                Node? current = root;
+                Node? match = null;
+
+                while (current != null)
+                {
+                    int cmp = Comparer.Compare(item, current.Item);
+
+                    if (cmp < 0)
+                    {
+                        match = current;
+                        current = current.Left;
+                    }
+                    else
+                    {
+                        current = current.Right;
+                    }
+                }
+
+                // Final safety check
+                if (match == null || IsTooHigh(match.Item))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                result = match.Item;
+                return true;
+            }
+
+            internal override bool DoTryGetFloor(T item, [MaybeNullWhen(false)] out T result)
+            {
+                VersionCheck();
+#if DEBUG
+                Debug.Assert(this.versionUpToDate() && root == _underlying.FindRange(_min, _max, _lBoundInclusive, _uBoundInclusive, _lBoundActive, _uBoundActive));
+#endif
+
+                Node? current = root;
+                Node? candidate = null;
+
+                while (current != null)
+                {
+                    int cmp = Comparer.Compare(item, current.Item);
+
+                    if (cmp < 0)
+                    {
+                        current = current.Left;
+                    }
+                    else
+                    {
+                        candidate = current;
+                        current = current.Right;
+                    }
+                }
+
+                if (candidate == null || IsTooLow(candidate.Item))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                result = candidate.Item;
+                return true;
+            }
+
+            internal override bool DoTryGetCeiling(T item, [MaybeNullWhen(false)] out T result)
+            {
+                VersionCheck();
+#if DEBUG
+                Debug.Assert(this.versionUpToDate() && root == _underlying.FindRange(_min, _max, _lBoundInclusive, _uBoundInclusive, _lBoundActive, _uBoundActive));
+#endif
+
+                Node? current = root;
+                Node? candidate = null;
+
+                while (current != null)
+                {
+                    int cmp = Comparer.Compare(item, current.Item);
+
+                    if (cmp > 0)
+                    {
+                        current = current.Right;
+                    }
+                    else
+                    {
+                        candidate = current;
+                        current = current.Left;
+                    }
+                }
+
+                if (candidate == null || IsTooHigh(candidate.Item))
+                {
+                    result = default!;
+                    return false;
+                }
+
+                result = candidate.Item;
+                return true;
+            }
+
 #if FEATURE_SERIALIZABLE
 
             [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]

--- a/src/J2N/Collections/Generic/SortedSet.cs
+++ b/src/J2N/Collections/Generic/SortedSet.cs
@@ -503,7 +503,16 @@ namespace J2N.Collections.Generic
         /// <param name="item">The entry to get the predecessor of.</param>
         /// <param name="result">The predessor, if any.</param>
         /// <returns><c>true</c> if a predecessor to <paramref name="item"/> exists; otherwise, <c>false</c>.</returns>
-        public bool TryGetPredecessor(T item, [MaybeNullWhen(false)] out T result)
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>strict predecessor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>lower()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetPredecessor(T item, [MaybeNullWhen(false)] out T result) => DoTryGetPredecessor(item, out result);
+
+        internal virtual bool DoTryGetPredecessor(T item, [MaybeNullWhen(false)] out T result)
         {
             Node? current = root, match = null;
 
@@ -548,7 +557,16 @@ namespace J2N.Collections.Generic
         /// <param name="item">The entry to get the successor of.</param>
         /// <param name="result">The successor, if any.</param>
         /// <returns><c>true</c> if a successor to <paramref name="item"/> exists; otherwise, <c>false</c>.</returns>
-        public bool TryGetSuccessor(T item, [MaybeNullWhen(false)] out T result)
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>strict successor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>higher()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetSuccessor(T item, [MaybeNullWhen(false)] out T result) => DoTryGetSuccessor(item, out result);
+
+        internal virtual bool DoTryGetSuccessor(T item, [MaybeNullWhen(false)] out T result)
         {
             Node? current = root, match = null;
 
@@ -584,6 +602,99 @@ namespace J2N.Collections.Generic
                 result = match.Item;
                 return true;
             }
+        }
+
+        /// <summary>
+        /// Gets the value in the <see cref="SortedSet{T}"/> whose value
+        /// is the greatest element less than or equal to <paramref name="item"/>.
+        /// </summary>
+        /// <param name="item">The entry to get the floor of.</param>
+        /// <param name="result">The floor, if any.</param>
+        /// <returns><c>true</c> if a floor to <paramref name="item"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <c>weak predecessor</c> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>floor()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetFloor(T item, [MaybeNullWhen(false)] out T result) => DoTryGetFloor(item, out result);
+
+        internal virtual bool DoTryGetFloor(T item, [MaybeNullWhen(false)] out T result)
+        {
+            Node? current = root;
+            Node? candidate = null;
+
+            while (current != null)
+            {
+                int cmp = comparer.Compare(item, current.Item);
+
+                if (cmp < 0)
+                {
+                    current = current.Left;
+                }
+                else
+                {
+                    candidate = current;
+                    current = current.Right;
+                }
+            }
+
+            if (candidate == null)
+            {
+                result = default!;
+                return false;
+            }
+
+            result = candidate.Item;
+            return true;
+        }
+
+
+        /// <summary>
+        /// Gets the value in the <see cref="SortedSet{T}"/> whose value
+        /// is the least element greater than or equal to <paramref name="item"/>.
+        /// </summary>
+        /// <param name="item">The entry to get the ceiling of.</param>
+        /// <param name="result">The ceiling, if any.</param>
+        /// <returns><c>true</c> if a ceiling to <paramref name="item"/> exists; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        /// This method is a O(log n) operation.
+        /// <para/>
+        /// This is referred to as <b>weak successor</b> in order theory.
+        /// <para/>
+        /// Usage Note: This corresponds to the <c>ceiling()</c> method in the JDK.
+        /// </remarks>
+        public bool TryGetCeiling(T item, [MaybeNullWhen(false)] out T result) => DoTryGetCeiling(item, out result);
+
+        internal virtual bool DoTryGetCeiling(T item, [MaybeNullWhen(false)] out T result)
+        {
+            Node? current = root;
+            Node? candidate = null;
+
+            while (current != null)
+            {
+                int cmp = comparer.Compare(item, current.Item);
+
+                if (cmp > 0)
+                {
+                    current = current.Right;
+                }
+                else
+                {
+                    candidate = current;
+                    current = current.Left;
+                }
+            }
+
+            if (candidate == null)
+            {
+                result = default!;
+                return false;
+            }
+
+            result = candidate.Item;
+            return true;
         }
 
         #endregion

--- a/tests/NUnit/J2N.Tests/Collections/Generic/TestSortedDictionary.cs
+++ b/tests/NUnit/J2N.Tests/Collections/Generic/TestSortedDictionary.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿// Based on: https://github.com/sestoft/C5/blob/master/C5.Tests/Trees/Dictionary.cs#L72-L126
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 
@@ -22,7 +23,7 @@ namespace J2N.Collections.Generic
         }
 
         [Test]
-        public void TestTryGetPredecessor()
+        public void TestTryGetPredecessor_KeyValuePair()
         {
             dict.Add("A", "1");
             dict.Add("C", "2");
@@ -39,7 +40,7 @@ namespace J2N.Collections.Generic
         }
 
         [Test]
-        public void TestTryGetSuccessor()
+        public void TestTryGetSuccessor_KeyValuePair()
         {
             dict.Add("A", "1");
             dict.Add("C", "2");
@@ -53,6 +54,74 @@ namespace J2N.Collections.Generic
             Assert.IsFalse(dict.TryGetSuccessor("E", out res));
             Assert.AreEqual(null, res.Key);
             Assert.AreEqual(null, res.Value);
+        }
+
+        [Test]
+        public void TestTryGetPredecessor()
+        {
+            dict.Add("A", "1");
+            dict.Add("C", "2");
+            dict.Add("E", "3");
+
+            Assert.IsTrue(dict.TryGetPredecessor("B", out _, out string value));
+            Assert.AreEqual("1", value);
+            Assert.IsTrue(dict.TryGetPredecessor("C", out _, out value));
+            Assert.AreEqual("1", value);
+
+            Assert.IsFalse(dict.TryGetPredecessor("A", out string key, out value));
+            Assert.AreEqual(null, key);
+            Assert.AreEqual(null, value);
+        }
+
+        [Test]
+        public void TestTryGetSuccessor()
+        {
+            dict.Add("A", "1");
+            dict.Add("C", "2");
+            dict.Add("E", "3");
+
+            Assert.IsTrue(dict.TryGetSuccessor("B", out _, out string value));
+            Assert.AreEqual("2", value);
+            Assert.IsTrue(dict.TryGetSuccessor("C", out _, out value));
+            Assert.AreEqual("3", value);
+
+            Assert.IsFalse(dict.TryGetSuccessor("E", out string key, out value));
+            Assert.AreEqual(null, key);
+            Assert.AreEqual(null, value);
+        }
+
+        [Test]
+        public void TestTryGetFloor()
+        {
+            dict.Add("A", "1");
+            dict.Add("C", "2");
+            dict.Add("E", "3");
+
+            Assert.IsTrue(dict.TryGetFloor("B", out _, out string value));
+            Assert.AreEqual("1", value);
+            Assert.IsTrue(dict.TryGetFloor("C", out _, out value));
+            Assert.AreEqual("2", value);
+
+            Assert.IsFalse(dict.TryGetFloor("@", out string key, out value));
+            Assert.AreEqual(null, key);
+            Assert.AreEqual(null, value);
+        }
+
+        [Test]
+        public void TestTryGetCeiling()
+        {
+            dict.Add("A", "1");
+            dict.Add("C", "2");
+            dict.Add("E", "3");
+
+            Assert.IsTrue(dict.TryGetCeiling("B", out _, out string value));
+            Assert.AreEqual("2", value);
+            Assert.IsTrue(dict.TryGetCeiling("C", out _, out value));
+            Assert.AreEqual("2", value);
+
+            Assert.IsFalse(dict.TryGetCeiling("F", out string key, out value));
+            Assert.AreEqual(null, key);
+            Assert.AreEqual(null, value);
         }
     }
 }

--- a/tests/NUnit/J2N.Tests/Collections/Generic/TestSortedSet.cs
+++ b/tests/NUnit/J2N.Tests/Collections/Generic/TestSortedSet.cs
@@ -1,4 +1,5 @@
-﻿using J2N.Util;
+﻿// Partly based on: https://github.com/sestoft/C5/blob/master/C5.Tests/Trees/RedBlackTreeSetTests.cs#L857-L966
+using J2N.Util;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -56,6 +57,24 @@ namespace J2N.Collections.Generic
         }
 
         [Test]
+        public void TestTryGetPredecessor_View()
+        {
+            loadup();
+            var view = tree.GetViewBetween(6, 14);
+
+            int res;
+            Assert.IsTrue(view.TryGetPredecessor(9, out res) && res == 8);
+            Assert.IsTrue(view.TryGetPredecessor(10, out res) && res == 8);
+
+            // The bottom (relative to view)
+            Assert.IsTrue(view.TryGetPredecessor(7, out res) && res == 6);
+
+            // The top (relative to view)
+            Assert.IsTrue(view.TryGetPredecessor(15, out res) && res == 14);
+        }
+
+
+        [Test]
         public void TestTryGetPredecessor_TooLow()
         {
             int res;
@@ -82,6 +101,24 @@ namespace J2N.Collections.Generic
         }
 
         [Test]
+        public void TestTryGetSuccessor_View()
+        {
+            loadup();
+            var view = tree.GetViewBetween(6, 14);
+
+            int res;
+            Assert.IsTrue(view.TryGetSuccessor(9, out res) && res == 10);
+            Assert.IsTrue(view.TryGetSuccessor(10, out res) && res == 12);
+
+            // The bottom (relative to view)
+            Assert.IsTrue(view.TryGetSuccessor(5, out res) && res == 6);
+
+            // The top (relative to view)
+            Assert.IsTrue(view.TryGetSuccessor(13, out res) && res == 14);
+        }
+
+
+        [Test]
         public void TestTryGetSuccessor_TooHigh()
         {
             int res;
@@ -90,6 +127,118 @@ namespace J2N.Collections.Generic
             Assert.IsFalse(tree.TryGetSuccessor(39, out res));
             Assert.AreEqual(0, res);
         }
+
+        [Test] // Regression for https://github.com/NightOwl888/J2N/issues/175
+        public void TestTryGetSuccessor_View_TooHigh()
+        {
+            var set = new SortedSet<int>();
+            for (int i = 0; i <= 10; i++)
+                set.Add(i);
+
+            // View contains [4..7]
+            var view = set.GetViewBetween(4, 7);
+
+            // Ask for successor of the maximum element in the view
+            bool found = view.TryGetSuccessor(7, out int successor);
+
+            Assert.IsFalse(found);
+        }
+
+
+        [Test]
+        public void TestTryGetFloor() // weak predecessor in C5, floor in JDK
+        {
+            loadup();
+            Assert.IsTrue(tree.TryGetFloor(7, out int res) && res == 6);
+            Assert.IsTrue(tree.TryGetFloor(8, out res) && res == 8);
+
+            //The bottom
+            Assert.IsTrue(tree.TryGetFloor(1, out res) && res == 0);
+            Assert.IsTrue(tree.TryGetFloor(0, out res) && res == 0);
+
+            //The top
+            Assert.IsTrue(tree.TryGetFloor(39, out res) && res == 38);
+            Assert.IsTrue(tree.TryGetFloor(38, out res) && res == 38);
+        }
+
+        [Test]
+        public void TestTryGetFloor_View()
+        {
+            loadup();
+            var view = tree.GetViewBetween(6, 14);
+
+            Assert.IsTrue(view.TryGetFloor(9, out int res) && res == 8);
+            Assert.IsTrue(view.TryGetFloor(10, out res) && res == 10);
+
+            // The bottom
+            Assert.IsTrue(view.TryGetFloor(6, out res) && res == 6);
+
+            // The top
+            Assert.IsTrue(view.TryGetFloor(15, out res) && res == 14);
+            Assert.IsTrue(view.TryGetFloor(14, out res) && res == 14);
+        }
+
+
+        [Test]
+        public void TestTryGetFloor_TooLow()
+        {
+            Assert.IsFalse(tree.TryGetFloor(-1, out int res));
+            Assert.AreEqual(0, res);
+        }
+
+        [Test]
+        public void TestTryGetCeiling() // weak successor in C5, floor in JDK
+        {
+            loadup();
+            Assert.IsTrue(tree.TryGetCeiling(6, out int res) && res == 6);
+            Assert.IsTrue(tree.TryGetCeiling(7, out res) && res == 8);
+
+            //The bottom
+            Assert.IsTrue(tree.TryGetCeiling(-1, out res) && res == 0);
+            Assert.IsTrue(tree.TryGetCeiling(0, out res) && res == 0);
+
+            //The top
+            Assert.IsTrue(tree.TryGetCeiling(37, out res) && res == 38);
+            Assert.IsTrue(tree.TryGetCeiling(38, out res) && res == 38);
+        }
+
+        [Test]
+        public void TestTryGetCeiling_View()
+        {
+            loadup();
+            var view = tree.GetViewBetween(6, 14);
+
+            Assert.IsTrue(view.TryGetCeiling(8, out int res) && res == 8);
+            Assert.IsTrue(view.TryGetCeiling(9, out res) && res == 10);
+
+            // The bottom
+            Assert.IsTrue(view.TryGetCeiling(5, out res) && res == 6);
+            Assert.IsTrue(view.TryGetCeiling(6, out res) && res == 6);
+
+            // The top
+            Assert.IsTrue(view.TryGetCeiling(13, out res) && res == 14);
+            Assert.IsTrue(view.TryGetCeiling(14, out res) && res == 14);
+        }
+
+
+
+        [Test]
+        public void TryGetCeiling_TooHigh()
+        {
+            Assert.IsFalse(tree.TryGetCeiling(39, out int res));
+            Assert.AreEqual(0, res);
+        }
+
+        [Test]
+        public void TryGetCeiling_View_TooHigh()
+        {
+            loadup();
+            var view = tree.GetViewBetween(6, 14);
+
+            Assert.IsFalse(view.TryGetCeiling(15, out int res));
+            Assert.AreEqual(0, res);
+        }
+
 
         public class MockComparer : IComparer<int>
         {


### PR DESCRIPTION
Fixes #175.

`J2N.Collections.Generic.SortedSet<T>.TreeSubSet`: Fixed bug due to not overriding and clamping `TryGetPredecessor()` and `TryGetSuccessor()`. Also added `TryGetFloor()` and `TryGetCeiling()`, since they are related JDK/C5 members.

Added all of the tests from C5 to confirm behavior, including new tests on views. I couldn't find any tests in the JDK for these members and they never existed in Apache Harmony.