### PR TITLE
Reverted `Log2()` legacy fallback implementation to the solution provided by Lucene

### DIFF
--- a/src/J2N/MathExtensions.cs
+++ b/src/J2N/MathExtensions.cs
@@ -38,10 +38,12 @@ namespace J2N
         /// </summary>
         private const long DoubleSignBitMask = unchecked((long)0x8000000000000000L);
 
+#if !FEATURE_MATH_LOG2
         /// <summary>
         /// The precomputed value of <see cref="Math.Log(double)"/> with a value of 2.
         /// </summary>
-        private const double LogOf2 = 0.693147180559945309417232121458176568; // precomputed log(2)
+        private static readonly double LogOf2 = Math.Log(2); // precomputed log(2)
+#endif
 
         /// <summary>
         /// Returns the signum function of the specified <see cref="int"/> value. (The


### PR DESCRIPTION
`J2N.MathExtensions.Log2()`: Reverted legacy fallback implementation to use the same approach that was used in Lucene. The precomputed value was not the correct IEEE 754 rounded value and this is a more robust fix than trying to store the value in a constant.

Changing the legacy fallback implementation caused Azure DevOps test runs to fail due to the test log error detection logic. I am not sure what the exact error was (and no tests failed), but this is the quickest way to resolve the issue to support .NET Framework. The hardware-optimized method used on .NET Core has not changed.