### PR TITLE
Fixed `IndexOf()`, `LastIndexOf()`, `Contains()` and `Remove()` of `List<T>` to support negative zero vs positive zero to match the JDK (fixes #146)

### DIFF
--- a/src/J2N/Collections/CollectionUtil.cs
+++ b/src/J2N/Collections/CollectionUtil.cs
@@ -22,6 +22,7 @@ using J2N.Text;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -36,6 +37,244 @@ namespace J2N.Collections
     {
         private const string SingleFormatArgument = "{0}";
         private const int CharStackBufferSize = 256;
+
+        #region IndexOf/LastIndexOf
+
+        /// <summary>
+        /// A strategy to handle JIT inlining with signed zero values in floating point types.
+        /// </summary>
+        /// <typeparam name="T">The type of value (a floating point type).</typeparam>
+        /// <typeparam name="TBits">The bit representation of the floating point type
+        /// (e.g. <see cref="long"/> or <see cref="int"/>).</typeparam>
+        /// <remarks>
+        /// This is a technique used in the BCL to optimize for JIT inlining of methods
+        /// that need to handle signed zero values in floating point types. Implementations
+        /// of this type must always remain a readonly struct and should never be boxed to
+        /// <see cref="ISignedZeroStrategy{T, TBits}"/> in practice.
+        /// </remarks>
+        internal interface ISignedZeroStrategy<T, TBits>
+        {
+            bool HasValue(T value);              // for nullable
+            bool IsZero(T value);
+            TBits GetBits(T value);
+        }
+
+        internal readonly struct DoubleStrategy : ISignedZeroStrategy<double, long>
+        {
+            public bool HasValue(double value) => true;
+
+            public bool IsZero(double value) => value == 0.0d;
+
+            public long GetBits(double value)
+                // NOTE: This is the same operation as BitConversion.DoubleToRawInt64Bits
+                => Unsafe.As<double, long>(ref value);
+        }
+
+        internal readonly struct SingleStrategy : ISignedZeroStrategy<float, int>
+        {
+            public bool HasValue(float value) => true;
+
+            public bool IsZero(float value) => value == 0.0f;
+
+            public int GetBits(float value)
+                // NOTE: This is the same operation as BitConversion.SingleToRawInt32Bits
+                => Unsafe.As<float, int>(ref value);
+        }
+
+        internal readonly struct NullableDoubleStrategy : ISignedZeroStrategy<double?, long>
+        {
+            public bool HasValue(double? value) => value.HasValue;
+
+            public bool IsZero(double? value) => value!.Value == 0.0d;
+
+            public long GetBits(double? value)
+            {
+                double v = value!.Value;
+                // NOTE: This is the same operation as BitConversion.DoubleToRawInt64Bits
+                return Unsafe.As<double, long>(ref v);
+            }
+        }
+
+        internal readonly struct NullableSingleStrategy : ISignedZeroStrategy<float?, int>
+        {
+            public bool HasValue(float? value) => value.HasValue;
+
+            public bool IsZero(float? value) => value!.Value == 0.0f;
+
+            public int GetBits(float? value)
+            {
+                float v = value!.Value;
+                // NOTE: This is the same operation as BitConversion.SingleToRawInt32Bits
+                return Unsafe.As<float, int>(ref v);
+            }
+        }
+
+        /// <summary>
+        /// Searches for the specified signed zero and returns the index of its first occurrence in a
+        /// one-dimensional array of floating point numbers. This is not a "normal" index of operation,
+        /// it narrowly searches only for signed zero to cover a special case omitted by the BCL that exists
+        /// in the JDK and is specifically to provide behavior consistent with the <c>java.util.Double</c> and
+        /// <c>java.util.Float</c> implementations when used in collections.
+        /// </summary>
+        /// <typeparam name="T">The type of floating point number.</typeparam>
+        /// <typeparam name="TStrategy">A strategy struct that implements <see cref="ISignedZeroStrategy{T, TBits}"/>
+        /// that supplies information about the underlying type.</typeparam>
+        /// <typeparam name="TBits">The integral type representation of the floating point number when
+        /// converted to raw bits.</typeparam>
+        /// <param name="array">The one-dimensional array to search.</param>
+        /// <param name="value">The signed zero to locate in the array.</param>
+        /// <param name="startIndex">The starting index of the search. 0 (zero) is valid in an empty array.</param>
+        /// <param name="count">The number of elements to search.</param>
+        /// <returns>The index of the first occurrence of signed zero <paramref name="value"/>, if it's found in the
+        /// <paramref name="array"/> from index <paramref name="startIndex"/> to <paramref name="startIndex"/> +
+        /// <paramref name="count"/> - 1; otherwise, the lower bound of the array minus 1.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is outside the range of valid indexes for <paramref name="array"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="count"/> is less than 0.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the <paramref name="array"/>.
+        /// </exception>
+        /// <exception cref="RankException"><paramref name="array"/> is multidimensional.</exception>
+        /// <remarks>
+        /// This method treats negative zero and positive zero for floating point numbers as two distinct values that
+        /// are not equal.
+        /// <para/>
+        /// The caller is responsible for ensuring <paramref name="value"/> is a zero value and that it is not
+        /// <see langword="null"/> if it is a <see cref="Nullable{T}"/> type.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfSignedZero<T, TStrategy, TBits>(T[] array, T value, int startIndex, int count)
+            where TStrategy : struct, ISignedZeroStrategy<T, TBits>
+            where TBits : unmanaged
+        {
+            TStrategy strategy = default; // The compiler hands us the right strategy struct based on TStrategy
+
+            Debug.Assert(strategy.HasValue(value), "Caller must ensure the value is not null.");
+            Debug.Assert(strategy.IsZero(value), "Caller must ensure the value is zero.");
+
+            // First pass goes to the BCL to find the first zero value.
+            // We also guard the input values with this call for invalid input.
+            int result = Array.IndexOf(array, value, startIndex, count);
+
+            // No zeros at all - we are done
+            if (result < 0)
+                return -1;
+
+            TBits targetBits = strategy.GetBits(value);
+
+            // We may miss if the sign of the zero value doesn't match what we are looking for
+            if (strategy.HasValue(array[result]) &&
+                strategy.GetBits(array[result]).Equals(targetBits))
+            {
+                return result;
+            }
+
+            // We found a zero value, but it was not the one we are looking for, so we must
+            // keep looking starting where the BCL left off for the one with the correct sign
+            int end = startIndex + count;
+
+            for (int i = result + 1; i < end; i++)
+            {
+                if (strategy.HasValue(array[i]) &&
+                    strategy.IsZero(array[i]) &&
+                    strategy.GetBits(array[i]).Equals(targetBits))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Searches for the specified signed zero and returns the index of its last occurrence in a
+        /// one-dimensional array of floating point numbers. This is not a "normal" last index of operation,
+        /// it narrowly searches only for signed zero to cover a special case omitted by the BCL that exists
+        /// in the JDK and is specifically to provide behavior consistent with the <c>java.util.Double</c> and
+        /// <c>java.util.Float</c> implementations when used in collections.
+        /// </summary>
+        /// <typeparam name="T">The type of floating point number.</typeparam>
+        /// <typeparam name="TStrategy">A strategy struct that implements <see cref="ISignedZeroStrategy{T, TBits}"/>
+        /// that supplies information about the underlying type.</typeparam>
+        /// <typeparam name="TBits">The integral type representation of the floating point number when
+        /// converted to raw bits.</typeparam>
+        /// <param name="array">The one-dimensional array to search.</param>
+        /// <param name="value">The signed zero to locate in the array.</param>
+        /// <param name="startIndex">The zero-based starting index of the backward search.</param>
+        /// <param name="count">The number of elements in the section to search.</param>
+        /// <returns>The zero-based index of the last occurrence of value within the range of elements
+        /// in <paramref name="array"/> that contains the number of elements specified in <paramref name="count"/>
+        /// and ends at <paramref name="startIndex"/>, if found; otherwise, -1.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startIndex"/> is outside the range of valid indexes for <paramref name="array"/>.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="count"/> is less than 0.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// <paramref name="startIndex"/> and <paramref name="count"/> do not specify a valid section in the <paramref name="array"/>.
+        /// </exception>
+        /// <remarks>
+        /// This method treats negative zero and positive zero for floating point numbers as two distinct values that
+        /// are not equal.
+        /// <para/>
+        /// The caller is responsible for ensuring <paramref name="value"/> is a zero value and that it is not
+        /// <see langword="null"/> if it is a <see cref="Nullable{T}"/> type.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int LastIndexOfSignedZero<T, TStrategy, TBits>(T[] array, T value, int startIndex, int count)
+            where TStrategy : struct, ISignedZeroStrategy<T, TBits>
+            where TBits : unmanaged
+        {
+            TStrategy strategy = default; // The compiler hands us the right strategy struct based on TStrategy
+
+            Debug.Assert(strategy.HasValue(value), "Caller must ensure the value is not null.");
+            Debug.Assert(strategy.IsZero(value), "Caller must ensure the value is zero.");
+
+            // First pass goes to the BCL to find the last zero value.
+            // We also guard the input values with this call for invalid input.
+            int result = Array.LastIndexOf(array, value, startIndex, count);
+
+            // No zeros at all - we are done
+            if (result < 0)
+                return -1;
+
+            TBits targetBits = strategy.GetBits(value);
+
+            // We may miss if the sign of the zero value doesn't match what we are looking for
+            if (strategy.HasValue(array[result]) && 
+                strategy.GetBits(array[result]).Equals(targetBits))
+            {
+                return result;
+            }
+
+            // We found a zero value, but it was not the one we are looking for, so we must
+            // keep looking starting where the BCL left off for the one with the correct sign
+            int end = startIndex - count + 1;
+
+            for (int i = result - 1; i >= end; i--)
+            {
+                if (strategy.HasValue(array[i]) &&
+                    strategy.IsZero(array[i]) &&
+                    strategy.GetBits(array[i]).Equals(targetBits))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        #endregion IndexOf/LastIndexOf
 
         #region Equals
 

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -759,8 +759,8 @@ namespace J2N.Collections.Generic
         /// <param name="item">The object to locate in the <see cref="List{T}"/>. The value can be <c>null</c> for reference types.</param>
         /// <returns><c>true</c> if item is found in the <see cref="List{T}"/>; otherwise, <c>false</c>.</returns>
         /// <remarks>
-        /// This method determines equality by using the default equality comparer, as defined by the object's implementation of
-        /// the <see cref="IEquatable{T}.Equals(T)"/> method for <typeparamref name="T"/> (the type of values in the list).
+        /// This method determines equality using J2N's default equality comparer <see cref="EqualityComparer{T}.Default"/>
+        /// for <typeparamref name="T"/>, the type of values in the list.
         /// <para/>
         /// This method performs a linear search; therefore, this method is an O(<c>n</c>) operation, where <c>n</c> is <see cref="Count"/>.
         /// </remarks>
@@ -2225,9 +2225,8 @@ namespace J2N.Collections.Generic
         /// <returns><c>true</c> if item is successfully removed; otherwise, <c>false</c>. This method
         /// also returns <c>false</c> if item was not found in the <see cref="List{T}"/>.</returns>
         /// <remarks>
-        /// If type <typeparamref name="T"/> implements the <see cref="IEquatable{T}"/> generic interface,
-        /// the equality comparer is the <see cref="IEquatable{T}.Equals(T)"/> method of that interface;
-        /// otherwise, the default equality comparer is <see cref="Object.Equals(object)"/>.
+        /// This method determines equality using J2N's default equality comparer <see cref="EqualityComparer{T}.Default"/>
+        /// for <typeparamref name="T"/>, the type of values in the list.
         /// <para/>
         /// This method performs a linear search; therefore, this method is an O(<c>n</c>) operation,
         /// where <c>n</c> is <see cref="Count"/>.

--- a/src/J2N/Collections/Generic/List.cs
+++ b/src/J2N/Collections/Generic/List.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using static J2N.Collections.CollectionUtil;
 
 namespace J2N.Collections.Generic
 {
@@ -1614,8 +1615,52 @@ namespace J2N.Collections.Generic
             CoModificationCheck();
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, offset, Size);
-            return result > -1 ? result - offset : result;
+
+            // J2N: In the Array.IndexOf() method, -0.0 and 0.0 are considered equal,
+            // but in Java ArrayList<E>, they are not considered equal. So we need to
+            // check for this special case before calling Array.IndexOf().
+            if (typeof(T) == typeof(double))
+            {
+                double value = Unsafe.As<T, double>(ref item);
+                if (value == 0.0d)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double, DoubleStrategy, long>(Unsafe.As<T[], double[]>(ref _items), value, offset, Size),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float))
+            {
+                float value = Unsafe.As<T, float>(ref item);
+                if (value == 0.0f)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float, SingleStrategy, int>(Unsafe.As<T[], float[]>(ref _items), value, offset, Size),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(double?))
+            {
+                double? value = Unsafe.As<T, double?>(ref item);
+                if (value.HasValue && value.Value == 0.0d) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double?, NullableDoubleStrategy, long>(Unsafe.As<T[], double?[]>(ref _items), value, offset, Size),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float?))
+            {
+                float? value = Unsafe.As<T, float?>(ref item);
+                if (value.HasValue && value.Value == 0.0f) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float?, NullableSingleStrategy, int>(Unsafe.As<T[], float?[]>(ref _items), value, offset, Size),
+                        offset);
+                }
+            }
+
+            return CorrectOffset(Array.IndexOf(_items, item, offset, Size), offset);
         }
 
         int IList.IndexOf(object? item)
@@ -1656,8 +1701,52 @@ namespace J2N.Collections.Generic
 
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, index + offset, Size - index);
-            return result > -1 ? result - offset : result;
+
+            // J2N: In the Array.IndexOf() method, -0.0 and 0.0 are considered equal,
+            // but in Java ArrayList<E>, they are not considered equal. So we need to
+            // check for this special case before calling Array.IndexOf().
+            if (typeof(T) == typeof(double))
+            {
+                double value = Unsafe.As<T, double>(ref item);
+                if (value == 0.0d)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double, DoubleStrategy, long>(Unsafe.As<T[], double[]>(ref _items), value, index + offset, Size - index),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float))
+            {
+                float value = Unsafe.As<T, float>(ref item);
+                if (value == 0.0f)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float, SingleStrategy, int>(Unsafe.As<T[], float[]>(ref _items), value, index + offset, Size - index),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(double?))
+            {
+                double? value = Unsafe.As<T, double?>(ref item);
+                if (value.HasValue && value.Value == 0.0d) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double?, NullableDoubleStrategy, long>(Unsafe.As<T[], double?[]>(ref _items), value, index + offset, Size - index),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float?))
+            {
+                float? value = Unsafe.As<T, float?>(ref item);
+                if (value.HasValue && value.Value == 0.0f) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float?, NullableSingleStrategy, int>(Unsafe.As<T[], float?[]>(ref _items), value, index + offset, Size - index),
+                        offset);
+                }
+            }
+
+            return CorrectOffset(Array.IndexOf(_items, item, index + offset, Size - index), offset);
         }
 
         /// <summary>
@@ -1701,8 +1790,63 @@ namespace J2N.Collections.Generic
 
             Debug.Assert(Origin._items == _items); // J2N: Ensure SubList uses the latest array instance
             int offset = Offset;
-            int result = Array.IndexOf(_items, item, index + offset, count);
-            return result > -1 ? result - offset : result;
+
+            // J2N: In the Array.IndexOf() method, -0.0 and 0.0 are considered equal,
+            // but in Java ArrayList<E>, they are not considered equal. So we need to
+            // check for this special case before calling Array.IndexOf().
+            if (typeof(T) == typeof(double))
+            {
+                double value = Unsafe.As<T, double>(ref item);
+                if (value == 0.0d)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double, DoubleStrategy, long>(Unsafe.As<T[], double[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float))
+            {
+                float value = Unsafe.As<T, float>(ref item);
+                if (value == 0.0f)
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float, SingleStrategy, int>(Unsafe.As<T[], float[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(double?))
+            {
+                double? value = Unsafe.As<T, double?>(ref item);
+                if (value.HasValue && value.Value == 0.0d) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<double?, NullableDoubleStrategy, long>(Unsafe.As<T[], double?[]>(ref _items), value.Value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float?))
+            {
+                float? value = Unsafe.As<T, float?>(ref item);
+                if (value.HasValue && value.Value == 0.0f) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        IndexOfSignedZero<float?, NullableSingleStrategy, int>(Unsafe.As<T[], float?[]>(ref _items), value.Value, index + offset, count),
+                        offset);
+                }
+            }
+
+            return CorrectOffset(Array.IndexOf(_items, item, index + offset, count), offset);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int CorrectOffset(int index, int offset)
+        {
+            if (index > -1)
+            {
+                Debug.Assert(index - offset >= 0);
+                return index - offset;
+            }
+            return -1;
         }
 
         /// <summary>
@@ -2024,8 +2168,52 @@ namespace J2N.Collections.Generic
                 ThrowHelper.ThrowArgumentOutOfRangeException(count, ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_BiggerThanCollection);
 
             int offset = Offset;
-            int result = Array.LastIndexOf(_items, item, index + offset, count);
-            return result > -1 ? result - offset : result;
+
+            // J2N: In the Array.IndexOf() method, -0.0 and 0.0 are considered equal,
+            // but in Java ArrayList<E>, they are not considered equal. So we need to
+            // check for this special case before calling Array.IndexOf().
+            if (typeof(T) == typeof(double))
+            {
+                double value = Unsafe.As<T, double>(ref item);
+                if (value == 0.0d)
+                {
+                    return CorrectOffset(
+                        LastIndexOfSignedZero<double, DoubleStrategy, long>(Unsafe.As<T[], double[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float))
+            {
+                float value = Unsafe.As<T, float>(ref item);
+                if (value == 0.0f)
+                {
+                    return CorrectOffset(
+                        LastIndexOfSignedZero<float, SingleStrategy, int>(Unsafe.As<T[], float[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(double?))
+            {
+                double? value = Unsafe.As<T, double?>(ref item);
+                if (value.HasValue && value.Value == 0.0d) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        LastIndexOfSignedZero<double?, NullableDoubleStrategy, long>(Unsafe.As<T[], double?[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+            if (typeof(T) == typeof(float?))
+            {
+                float? value = Unsafe.As<T, float?>(ref item);
+                if (value.HasValue && value.Value == 0.0f) // Let the BCL handle the null case
+                {
+                    return CorrectOffset(
+                        LastIndexOfSignedZero<float?, NullableSingleStrategy, int>(Unsafe.As<T[], float?[]>(ref _items), value, index + offset, count),
+                        offset);
+                }
+            }
+
+            return CorrectOffset(Array.LastIndexOf(_items, item, index + offset, count), offset);
         }
 
         /// <summary>

--- a/tests/NUnit/J2N.Tests/Collections/Generic/TestList.cs
+++ b/tests/NUnit/J2N.Tests/Collections/Generic/TestList.cs
@@ -2682,7 +2682,206 @@ namespace J2N.Collections.Generic
             }
 
             #endregion IndexOf/LastIndexOf Tests
-        }
 
+            #region Contains Tests
+
+            [TestFixture]
+            public class ContainsTests
+            {
+                // Smoke tests to confirm that -0.0 and 0.0 are not considered equal on Contains()
+
+                [Test]
+                public void Test_Contains_Double_SignedZero()
+                {
+                    var list = new List<double> { -0.0 };
+                    Assert.IsFalse(list.Contains(0.0));
+                }
+
+                [Test]
+                public void Test_Contains_NullableDouble_SignedZero()
+                {
+                    var list = new List<double?> { -0.0 };
+                    Assert.IsFalse(list.Contains(0.0));
+                }
+
+                [Test]
+                public void Test_Contains_Single_SignedZero()
+                {
+                    var list = new List<float> { -0.0f };
+                    Assert.IsFalse(list.Contains(0.0f));
+                }
+
+                [Test]
+                public void Test_Contains_NullableSingle_SignedZero()
+                {
+                    var list = new List<float?> { -0.0f };
+                    Assert.IsFalse(list.Contains(0.0f));
+                }
+
+                // Smoke tests to confirm that NaN is considered equal to another NaN value
+
+                [Test]
+                public void Test_Contains_Double_NaN()
+                {
+                    double nan1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+                    double nan2 = double.NaN;
+
+                    var list = new List<double> { nan1 };
+
+                    Assert.IsTrue(double.IsNaN(nan1));
+                    Assert.IsTrue(double.IsNaN(nan2));
+
+                    Assert.IsTrue(list.Contains(nan2));
+                }
+
+                [Test]
+                public void Test_Contains_NullableDouble_NaN()
+                {
+                    double? nan1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+                    double? nan2 = double.NaN;
+
+                    var list = new List<double?> { nan1 };
+
+                    Assert.IsTrue(nan1.HasValue && double.IsNaN(nan1.Value));
+                    Assert.IsTrue(nan2.HasValue && double.IsNaN(nan2.Value));
+
+                    Assert.IsTrue(list.Contains(nan2));
+                }
+
+                [Test]
+                public void Test_Contains_Single_NaN()
+                {
+                    float nan1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+                    float nan2 = float.NaN;
+
+                    var list = new List<float> { nan1 };
+
+                    Assert.IsTrue(float.IsNaN(nan1));
+                    Assert.IsTrue(float.IsNaN(nan2));
+
+                    Assert.IsTrue(list.Contains(nan2));
+                }
+
+                [Test]
+                public void Test_Contains_NullableSingle_NaN()
+                {
+                    float? nan1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+                    float? nan2 = float.NaN;
+
+                    var list = new List<float?> { nan1 };
+
+                    Assert.IsTrue(nan1.HasValue && float.IsNaN(nan1.Value));
+                    Assert.IsTrue(nan2.HasValue && float.IsNaN(nan2.Value));
+
+                    Assert.IsTrue(list.Contains(nan2));
+                }
+            }
+
+            #endregion Contains Tests
+
+            #region Remove Tests
+
+            [TestFixture]
+            public class RemoveTests
+            {
+                // Smoke tests to confirm that -0.0 and 0.0 are not considered equal on Remove
+
+                [Test]
+                public void Test_Remove_Double_SignedZero()
+                {
+                    var list = new List<double> { -0.0 };
+                    Assert.IsFalse(list.Remove(0.0));
+                    Assert.AreEqual(1, list.Count);
+                    Assert.AreEqual(-0.0, list[0]);
+                }
+
+                [Test]
+                public void Test_Remove_NullableDouble_SignedZero()
+                {
+                    var list = new List<double?> { -0.0 };
+                    Assert.IsFalse(list.Remove(0.0));
+                    Assert.AreEqual(1, list.Count);
+                    Assert.AreEqual(-0.0, list[0]);
+                }
+
+                [Test]
+                public void Test_Remove_Single_SignedZero()
+                {
+                    var list = new List<float> { -0.0f };
+                    Assert.IsFalse(list.Remove(0.0f));
+                    Assert.AreEqual(1, list.Count);
+                    Assert.AreEqual(-0.0f, list[0]);
+                }
+
+                [Test]
+                public void Test_Remove_NullableSingle_SignedZero()
+                {
+                    var list = new List<float?> { -0.0f };
+                    Assert.IsFalse(list.Remove(0.0f));
+                    Assert.AreEqual(1, list.Count);
+                    Assert.AreEqual(-0.0f, list[0]);
+                }
+
+                // Smoke tests to confirm that NaN is considered equal to another NaN value
+
+                [Test]
+                public void Test_Remove_Double_NaN()
+                {
+                    double nan1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+                    double nan2 = double.NaN;
+
+                    Assert.IsTrue(nan1.IsNaN());
+
+                    var list = new List<double> { nan1 };
+
+                    Assert.IsTrue(list.Remove(nan2));
+                    Assert.AreEqual(0, list.Count);
+                }
+
+                [Test]
+                public void Test_Remove_NullableDouble_NaN()
+                {
+                    double? nan1 = BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+                    double? nan2 = double.NaN;
+
+                    Assert.IsTrue(nan1.Value.IsNaN());
+
+                    var list = new List<double?> { nan1 };
+
+                    Assert.IsTrue(list.Remove(nan2));
+                    Assert.AreEqual(0, list.Count);
+                }
+
+                [Test]
+                public void Test_Remove_Single_NaN()
+                {
+                    float nan1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+                    float nan2 = float.NaN;
+
+                    Assert.IsTrue(nan1.IsNaN());
+
+                    var list = new List<float> { nan1 };
+
+                    Assert.IsTrue(list.Remove(nan2));
+                    Assert.AreEqual(0, list.Count);
+                }
+
+                [Test]
+                public void Test_Remove_NullableSingle_NaN()
+                {
+                    float? nan1 = BitConversion.Int32BitsToSingle(0x7FC00001);
+                    float? nan2 = float.NaN;
+
+                    Assert.IsTrue(nan1.Value.IsNaN());
+
+                    var list = new List<float?> { nan1 };
+
+                    Assert.IsTrue(list.Remove(nan2));
+                    Assert.AreEqual(0, list.Count);
+                }
+            }
+
+            #endregion Remove Tests
+        }
     }
 }

--- a/tests/NUnit/J2N.Tests/Collections/Generic/TestList.cs
+++ b/tests/NUnit/J2N.Tests/Collections/Generic/TestList.cs
@@ -73,6 +73,7 @@ namespace J2N.Collections.Generic
         }
 #endif
 
+
         [Test]
         public void TestSubList_SelfAddRange()
         {
@@ -2038,6 +2039,649 @@ namespace J2N.Collections.Generic
             //{
             //    return new MockHashSet<T>(elements);
             //}
+        }
+
+
+        /// <summary>
+        /// Special case tests not covered by tests from Harmony. These are regression tests
+        /// for when we find mismatching comparison behavior between Java and .NET that we correct
+        /// by making the comparison behavior mirror the JDK.
+        /// </summary>
+        public class Comparisons
+        {
+
+            #region IndexOf/LastIndexOf Tests
+
+            // These tests ensure that float and double IndexOf/LastIndexOf methods match Java's behavior
+            // regarding NaN and signed zero comparisons.
+
+            public abstract class FloatingPointIndexOfTests<T>
+            {
+                protected abstract T PositiveZero { get; }
+                protected abstract T NegativeZero { get; }
+                protected abstract T NaN { get; }
+                protected abstract T CreateCustomNaN();
+                protected abstract T GetNonMatchingValue();
+                protected abstract bool IsNaN(T value);
+
+                protected virtual List<T> CreateList(int capacity)
+                {
+                    return new List<T>(capacity);
+                }
+
+                protected List<T> CreateListWithSingleValue(int index, T value)
+                {
+                    List<T> list = CreateList(10);
+                    for (int i = 0; i < 10; i++)
+                    {
+                        list.Add(GetNonMatchingValue());
+                    }
+
+                    list[index] = value;
+                    return list;
+                }
+
+                protected List<T> CreateListFrom(params T[] items)
+                {
+                    var list = CreateList(items.Length);
+                    for (int i = 0; i < items.Length; i++)
+                    {
+                        list.Add(items[i]);
+                    }
+                    return list;
+                }
+
+                public static IEnumerable<int> Positions()
+                {
+                    yield return 0;
+                    yield return 1;
+                    yield return 5;
+                    yield return 8;
+                }
+
+                public static IEnumerable<(int index, int count)> Ranges()
+                {
+                    yield return (0, 10); // full range
+                    yield return (0, 5);  // first half
+                    yield return (2, 5);  // middle
+                    yield return (5, 5);  // second half
+                    yield return (6, 4);  // tail
+                }
+
+                // --- NaN tests ---
+
+                [TestCaseSource(nameof(Positions))]
+                public void Test_IndexOf_NaN_FindsCustomNaN(int index)
+                {
+                    T customNaN = CreateCustomNaN();
+                    Assert.IsTrue(IsNaN(customNaN));
+
+                    var list = CreateListWithSingleValue(index, customNaN);
+
+                    AssertIndexOfOverloads(list, NaN, index);
+                    AssertLastIndexOfOverloads(list, NaN, index);
+                }
+
+                [TestCaseSource(nameof(Ranges))]
+                public void Test_IndexOf_NaN_WithRanges((int index, int count) range)
+                {
+                    int targetIndex = 5;
+
+                    T customNaN = CreateCustomNaN();
+                    var list = CreateListWithSingleValue(targetIndex, customNaN);
+
+                    int index = range.index;
+                    int count = range.count;
+
+                    int expected = (targetIndex >= index && targetIndex < index + count)
+                        ? targetIndex
+                        : -1;
+
+                    Assert.AreEqual(expected, list.IndexOf(NaN, index, count));
+                    Assert.AreEqual(expected, list.LastIndexOf(NaN, index + count - 1, count));
+                }
+
+                [Test]
+                public void Test_IndexOf_NaN_MultipleOccurrences_SelectsCorrectOne()
+                {
+                    T nan1 = CreateCustomNaN();
+                    T nan2 = NaN;
+                    T nan3 = CreateCustomNaN();
+
+                    List<T> list = CreateListFrom(
+                        nan1,                 // index 0
+                        GetNonMatchingValue(),
+                        nan2,                 // index 2
+                        GetNonMatchingValue(),
+                        nan3                  // index 4
+                    );
+
+                    // IndexOf should return FIRST NaN
+                    AssertIndexOfOverloads(list, NaN, 0);
+                    // Restrict to middle (should skip first NaN)
+                    Assert.AreEqual(2, list.IndexOf(NaN, 1));
+                    Assert.AreEqual(2, list.IndexOf(NaN, 1, 3));
+
+                    // LastIndexOf should return LAST NaN
+                    AssertLastIndexOfOverloads(list, NaN, 4);
+                    // Reverse: restrict to exclude last NaN
+                    Assert.AreEqual(2, list.LastIndexOf(NaN, 3));
+                    Assert.AreEqual(2, list.LastIndexOf(NaN, 3, 3));
+                }
+
+                [Test]
+                public void Test_IndexOf_NaN_StartIndex_SkipsEarlierMatch()
+                {
+                    T nan1 = CreateCustomNaN();
+                    T nan2 = NaN;
+
+                    List<T> list = CreateListFrom(
+                        nan1,                 // index 0
+                        GetNonMatchingValue(),
+                        nan2,                 // index 2
+                        GetNonMatchingValue()
+                    );
+
+                    // Start after first NaN - should find second
+                    Assert.AreEqual(2, list.IndexOf(NaN, 1));
+                    Assert.AreEqual(2, list.IndexOf(NaN, 1, list.Count - 1));
+
+                    // Reverse search from index 2 - should find index 2
+                    Assert.AreEqual(2, list.LastIndexOf(NaN, 2));
+                    Assert.AreEqual(2, list.LastIndexOf(NaN, 2, 1));
+
+                    // Reverse range: exclude index 2 - miss
+                    Assert.AreEqual(-1, list.LastIndexOf(NaN, 1, 1));
+                }
+
+                // --- Signed zero: mismatch ---
+
+                [TestCaseSource(nameof(Positions))]
+                public void Test_IndexOf_PositiveZero_DoesNotFindNegativeZero(int index)
+                {
+                    var list = CreateListWithSingleValue(index, NegativeZero);
+
+                    Assert.AreEqual(-1, list.IndexOf(PositiveZero));
+                    Assert.AreEqual(-1, list.LastIndexOf(PositiveZero));
+                }
+
+                [TestCaseSource(nameof(Positions))]
+                public void Test_IndexOf_NegativeZero_DoesNotFindPositiveZero(int index)
+                {
+                    List<T> list = CreateListWithSingleValue(index, PositiveZero);
+
+                    Assert.AreEqual(-1, list.IndexOf(NegativeZero));
+                    Assert.AreEqual(-1, list.LastIndexOf(NegativeZero));
+                }
+
+                [TestCaseSource(nameof(Ranges))]
+                public void Test_IndexOf_SignedZero_Mismatch_WithRanges((int index, int count) range)
+                {
+                    int targetIndex = 5;
+
+                    List<T> list = CreateListWithSingleValue(targetIndex, NegativeZero);
+
+                    int index = range.index;
+                    int count = range.count;
+
+                    Assert.AreEqual(-1, list.IndexOf(PositiveZero, index, count));
+                    Assert.AreEqual(-1, list.LastIndexOf(PositiveZero, index + count - 1, count));
+                }
+
+                // --- Signed zero: match ---
+
+                [TestCaseSource(nameof(Positions))]
+                public void Test_IndexOf_SignedZero_FindsSameSign(int index)
+                {
+                    List<T> list = CreateListWithSingleValue(index, NegativeZero);
+
+                    Assert.AreEqual(index, list.IndexOf(NegativeZero));
+                    Assert.AreEqual(index, list.LastIndexOf(NegativeZero));
+                }
+
+                [TestCaseSource(nameof(Ranges))]
+                public void Test_IndexOf_SignedZero_Match_WithRanges((int index, int count) range)
+                {
+                    int targetIndex = 5;
+
+                    List<T> list = CreateListWithSingleValue(targetIndex, NegativeZero);
+
+                    int index = range.index;
+                    int count = range.count;
+
+                    int expected = (targetIndex >= index && targetIndex < index + count)
+                        ? targetIndex
+                        : -1;
+
+                    Assert.AreEqual(expected, list.IndexOf(NegativeZero, index, count));
+                    Assert.AreEqual(expected, list.LastIndexOf(NegativeZero, index + count - 1, count));
+                }
+
+                // --- Slow path correctness (forward) ---
+
+                [Test]
+                public void Test_IndexOf_SignedZero_SlowPath_Forward()
+                {
+                    List<T> list = CreateListFrom(
+                        NegativeZero,
+                        GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(),
+                        PositiveZero,
+                        GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue()
+                    );
+
+                    AssertIndexOfOverloads(list, PositiveZero, 4);
+                }
+
+                // --- Slow path correctness (reverse) ---
+
+                [Test]
+                public void Test_LastIndexOf_SignedZero_SlowPath_Reverse()
+                {
+                    var list = CreateListFrom(
+                        PositiveZero,
+                        GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(),
+                        NegativeZero,
+                        GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue(), GetNonMatchingValue()
+                    );
+
+                    AssertLastIndexOfOverloads(list, PositiveZero, 0);
+                }
+
+                // --- Signed zero: multi-occurrence (forward) ---
+
+                [Test]
+                public void Test_IndexOf_SignedZero_MultipleOccurrences_SelectsFirstMatch()
+                {
+                    var list = CreateListFrom(
+                        PositiveZero,  // index 0
+                        GetNonMatchingValue(),
+                        NegativeZero,  // index 2
+                        PositiveZero,  // index 3
+                        GetNonMatchingValue()
+                    );
+
+                    Assert.AreEqual(0, list.IndexOf(PositiveZero));
+                    Assert.AreEqual(2, list.IndexOf(NegativeZero));
+
+                    // Start after first +0 - should find second +0
+                    Assert.AreEqual(3, list.IndexOf(PositiveZero, 1));
+
+                    // Range that excludes first +0
+                    Assert.AreEqual(3, list.IndexOf(PositiveZero, 1, 3));
+
+                    // Range that excludes both - miss
+                    Assert.AreEqual(-1, list.IndexOf(PositiveZero, 4, 1));
+
+                    // Negative zero range checks
+                    Assert.AreEqual(2, list.IndexOf(NegativeZero, 1));
+                    Assert.AreEqual(2, list.IndexOf(NegativeZero, 1, 3));
+                }
+
+                // --- Signed zero: multi-occurrence (reverse) ---
+
+                [Test]
+                public void Test_LastIndexOf_SignedZero_MultipleOccurrences_SelectsLastMatch()
+                {
+                    var list = CreateListFrom(
+                        PositiveZero,  // index 0
+                        GetNonMatchingValue(),
+                        NegativeZero,  // index 2
+                        PositiveZero,  // index 3
+                        GetNonMatchingValue()
+                    );
+
+                    Assert.AreEqual(3, list.LastIndexOf(PositiveZero));
+                    Assert.AreEqual(2, list.LastIndexOf(NegativeZero));
+
+                    // Restrict to exclude last +0
+                    Assert.AreEqual(0, list.LastIndexOf(PositiveZero, 2));
+
+                    // Restrict to only middle region (should miss)
+                    Assert.AreEqual(-1, list.LastIndexOf(PositiveZero, 2, 2));
+
+                    // Negative zero reverse range
+                    Assert.AreEqual(2, list.LastIndexOf(NegativeZero, 3));
+                    Assert.AreEqual(2, list.LastIndexOf(NegativeZero, 3, 3));
+                }
+
+                // --- Signed zero: start index behavior (reverse) ---
+
+                [Test]
+                public void Test_LastIndexOf_SignedZero_RespectsStartIndex()
+                {
+                    var list = CreateListFrom(
+                        PositiveZero,  // index 0
+                        GetNonMatchingValue(),
+                        NegativeZero,  // index 2
+                        PositiveZero,  // index 3
+                        GetNonMatchingValue()
+                    );
+
+                    // Restrict search to first half
+                    Assert.AreEqual(0, list.LastIndexOf(PositiveZero, 1));
+                    Assert.AreEqual(-1, list.LastIndexOf(NegativeZero, 1));
+
+                    // Only index 1 - no matches
+                    Assert.AreEqual(-1, list.LastIndexOf(PositiveZero, 1, 1));
+                    Assert.AreEqual(-1, list.LastIndexOf(NegativeZero, 1, 1));
+
+                    // Include index 0
+                    Assert.AreEqual(0, list.LastIndexOf(PositiveZero, 1, 2));
+
+                    // Include index 2 only
+                    Assert.AreEqual(2, list.LastIndexOf(NegativeZero, 2, 1));
+                }
+
+                
+
+                protected void AssertIndexOfOverloads(List<T> list, T value, int expected)
+                {
+                    Assert.AreEqual(expected, list.IndexOf(value), "IndexOf(item)");
+
+                    Assert.AreEqual(expected, list.IndexOf(value, 0), "IndexOf(item, index)");
+
+                    Assert.AreEqual(expected, list.IndexOf(value, 0, list.Count), "IndexOf(item, index, count)");
+                }
+
+                protected void AssertLastIndexOfOverloads(List<T> list, T value, int expected)
+                {
+                    Assert.AreEqual(expected, list.LastIndexOf(value), "LastIndexOf(item)");
+
+                    Assert.AreEqual(expected, list.LastIndexOf(value, list.Count - 1), "LastIndexOf(item, index)");
+
+                    Assert.AreEqual(expected, list.LastIndexOf(value, list.Count - 1, list.Count), "LastIndexOf(item, index, count)");
+                }
+            }
+
+            public abstract class NullableFloatingPointIndexOfTests<T> : FloatingPointIndexOfTests<T>
+            {
+                protected abstract T NullValue { get; }
+                protected abstract bool IsNull(T value);
+
+                // --- Null tests ---
+
+                [TestCaseSource(nameof(Positions))]
+                public void Test_IndexOf_Null_FindsNull(int index)
+                {
+                    List<T> list = CreateListWithSingleValue(index, NullValue);
+
+                    AssertIndexOfOverloads(list, NullValue, index);
+                    AssertLastIndexOfOverloads(list, NullValue, index);
+                }
+
+                [Test]
+                public void Test_IndexOf_Null_DoesNotMatchNonNull()
+                {
+                    List<T> list = CreateListFrom(GetNonMatchingValue());
+
+                    Assert.AreEqual(-1, list.IndexOf(NullValue));
+                    Assert.AreEqual(-1, list.LastIndexOf(NullValue));
+                }
+
+                [Test]
+                public void Test_IndexOf_Null_MultipleOccurrences()
+                {
+                    List<T> list = CreateListFrom(
+                        NullValue,                // 0
+                        GetNonMatchingValue(),
+                        NullValue,                // 2
+                        GetNonMatchingValue()
+                    );
+
+                    Assert.AreEqual(0, list.IndexOf(NullValue));
+                    Assert.AreEqual(2, list.LastIndexOf(NullValue));
+
+                    Assert.AreEqual(2, list.IndexOf(NullValue, 1));
+                    Assert.AreEqual(0, list.LastIndexOf(NullValue, 1));
+                }
+
+                [Test]
+                public void Test_IndexOf_Nullable_SignedZero_DoesNotMatchNull()
+                {
+                    List<T> list = CreateListFrom(
+                        NullValue,
+                        PositiveZero,
+                        NegativeZero
+                    );
+
+                    Assert.AreEqual(1, list.IndexOf(PositiveZero));
+                    Assert.AreEqual(2, list.IndexOf(NegativeZero));
+                }
+
+                [Test]
+                public void Test_IndexOf_Nullable_NaN_DoesNotMatchNull()
+                {
+                    List<T> list = CreateListFrom(
+                        NullValue,
+                        CreateCustomNaN()
+                    );
+
+                    Assert.AreEqual(1, list.IndexOf(NaN));
+                    Assert.AreEqual(-1, list.IndexOf(NullValue, 1));
+                }
+
+                [Test]
+                public void Test_IndexOf_Chaos_AllFloatingPointEdgeCases()
+                {
+                    T nan1 = CreateCustomNaN();
+                    T nan2 = NaN;
+                    T nan3 = CreateCustomNaN();
+
+                    List<T> list = CreateListFrom(
+                        NullValue,              // 0
+                        PositiveZero,           // 1
+                        NegativeZero,           // 2
+                        nan1,                   // 3
+                        GetNonMatchingValue(),  // 4
+                        nan2,                   // 5
+                        NullValue,              // 6
+                        NegativeZero,           // 7
+                        PositiveZero,           // 8
+                        nan3                    // 9
+                    );
+
+                    // --- NULL ---
+                    Assert.AreEqual(0, list.IndexOf(NullValue));
+                    Assert.AreEqual(6, list.LastIndexOf(NullValue));
+
+                    // --- POSITIVE ZERO ---
+                    Assert.AreEqual(1, list.IndexOf(PositiveZero));
+                    Assert.AreEqual(8, list.LastIndexOf(PositiveZero));
+
+                    // --- NEGATIVE ZERO ---
+                    Assert.AreEqual(2, list.IndexOf(NegativeZero));
+                    Assert.AreEqual(7, list.LastIndexOf(NegativeZero));
+
+                    // --- NaN (all variants must match) ---
+                    Assert.AreEqual(3, list.IndexOf(NaN));
+                    Assert.AreEqual(9, list.LastIndexOf(NaN));
+
+                    // --- RANGE RESTRICTIONS ---
+
+                    // Skip first null
+                    Assert.AreEqual(6, list.IndexOf(NullValue, 1));
+
+                    // Skip first +0
+                    Assert.AreEqual(8, list.IndexOf(PositiveZero, 2));
+
+                    // Skip first -0
+                    Assert.AreEqual(7, list.IndexOf(NegativeZero, 3));
+
+                    // Middle NaN only
+                    Assert.AreEqual(5, list.IndexOf(NaN, 4, 3));
+
+                    // Reverse restricted ranges
+
+                    Assert.AreEqual(6, list.LastIndexOf(NullValue, 6));
+                    Assert.AreEqual(1, list.LastIndexOf(PositiveZero, 2));
+                    Assert.AreEqual(2, list.LastIndexOf(NegativeZero, 3));
+
+                    // --- NON-MATCHES ---
+
+                    Assert.AreEqual(-1, list.IndexOf(PositiveZero, 9, 1)); // only NaN
+                    Assert.AreEqual(-1, list.LastIndexOf(NegativeZero, 0, 1)); // only null
+
+                    // --- CROSS-TYPE SAFETY ---
+
+                    // null should never match anything else
+                    Assert.AreEqual(-1, list.IndexOf(NullValue, 1, 5)); // region without null
+
+                    // NaN should not match zeros
+                    Assert.AreEqual(-1, list.IndexOf(NaN, 1, 2)); // only zeros
+
+                    // zeros should not match each other
+                    Assert.AreEqual(-1, list.IndexOf(PositiveZero, 2, 1)); // only -0
+                    Assert.AreEqual(-1, list.IndexOf(NegativeZero, 1, 1)); // only +0
+                }
+            }
+
+            [TestFixture]
+            public class DoubleIndexOfTests : FloatingPointIndexOfTests<double>
+            {
+                protected override double PositiveZero => 0.0;
+
+                protected override double NegativeZero =>
+                    BitConversion.Int64BitsToDouble(unchecked((long)0x8000000000000000));
+
+                protected override double NaN => double.NaN;
+
+                protected override double CreateCustomNaN() =>
+                    BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+
+                protected override bool IsNaN(double value) => double.IsNaN(value);
+
+                protected override double GetNonMatchingValue() => 1.0;
+            }
+
+            [TestFixture]
+            public class NullableDoubleIndexOfTests : NullableFloatingPointIndexOfTests<double?>
+            {
+                protected override double? PositiveZero => 0.0;
+                protected override double? NegativeZero =>
+                    BitConversion.Int64BitsToDouble(unchecked((long)0x8000000000000000));
+
+                protected override double? NaN => double.NaN;
+
+                protected override double? CreateCustomNaN() =>
+                    BitConversion.Int64BitsToDouble(0x7FF8000000000001L);
+
+                protected override bool IsNaN(double? value) =>
+                    value.HasValue && double.IsNaN(value.Value);
+
+                protected override double? GetNonMatchingValue() => 1.0;
+
+                protected override double? NullValue => null;
+
+                protected override bool IsNull(double? value) => !value.HasValue;
+            }
+
+            [TestFixture]
+            public class SingleIndexOfTests : FloatingPointIndexOfTests<float>
+            {
+                protected override float PositiveZero => 0.0f;
+
+                protected override float NegativeZero =>
+                    BitConversion.Int32BitsToSingle(unchecked((int)0x80000000));
+
+                protected override float NaN => float.NaN;
+
+                protected override float CreateCustomNaN() =>
+                    BitConversion.Int32BitsToSingle(0x7FC00001);
+
+                protected override bool IsNaN(float value) => float.IsNaN(value);
+
+                protected override float GetNonMatchingValue() => 1.0f;
+            }
+
+            [TestFixture]
+            public class NullableSingleIndexOfTests : NullableFloatingPointIndexOfTests<float?>
+            {
+                protected override float? PositiveZero => 0.0f;
+
+                protected override float? NegativeZero =>
+                    BitConversion.Int32BitsToSingle(unchecked((int)0x80000000));
+
+                protected override float? NaN => float.NaN;
+
+                protected override float? CreateCustomNaN() =>
+                    BitConversion.Int32BitsToSingle(0x7FC00001);
+
+                protected override bool IsNaN(float? value) =>
+                    value.HasValue && float.IsNaN(value.Value);
+
+                protected override float? GetNonMatchingValue() => 1.0f;
+
+                protected override float? NullValue => null;
+
+                protected override bool IsNull(float? value) => !value.HasValue;
+            }
+
+            public static class SubList
+            {
+                [TestFixture]
+                public class DoubleIndexOfTests : Comparisons.DoubleIndexOfTests
+                {
+                    protected override List<double> CreateList(int capacity)
+                    {
+                        // Create parent with padding before + after
+                        var parent = new List<double>(capacity + 10);
+
+                        for (int i = 0; i < 10; i++)
+                            parent.Add(GetNonMatchingValue());
+
+                        // return sublist view (offset = 5)
+                        return parent.GetView(5, 0);
+                    }
+                }
+
+                [TestFixture]
+                public class NullableDoubleIndexOfTests : Comparisons.NullableDoubleIndexOfTests
+                {
+                    protected override List<double?> CreateList(int capacity)
+                    {
+                        var parent = new List<double?>(capacity + 10);
+
+                        for (int i = 0; i < 10; i++)
+                            parent.Add(GetNonMatchingValue());
+
+                        return parent.GetView(5, 0);
+                    }
+                }
+
+                [TestFixture]
+                public class SingleIndexOfTests : Comparisons.SingleIndexOfTests
+                {
+                    protected override List<float> CreateList(int capacity)
+                    {
+                        // Create parent with padding before + after
+                        var parent = new List<float>(capacity + 10);
+
+                        for (int i = 0; i < 10; i++)
+                            parent.Add(GetNonMatchingValue());
+
+                        // return sublist view (offset = 5)
+                        return parent.GetView(5, 0);
+                    }
+                }
+
+                [TestFixture]
+                public class NullableSingleIndexOfTests : Comparisons.NullableSingleIndexOfTests
+                {
+                    protected override List<float?> CreateList(int capacity)
+                    {
+                        // Create parent with padding before + after
+                        var parent = new List<float?>(capacity + 10);
+
+                        for (int i = 0; i < 10; i++)
+                            parent.Add(GetNonMatchingValue());
+
+                        // return sublist view (offset = 5)
+                        return parent.GetView(5, 0);
+                    }
+                }
+            }
+
+            #endregion IndexOf/LastIndexOf Tests
         }
 
     }


### PR DESCRIPTION
This fixes all of the `IndexOf()`, `LastIndexOf()`, `Contains()` and `Remove()` overloads in `List<T>` to treat negative zero and positive zero as *separate values* to match the behavior of the JDK. The `NaN` matching behavior described in #146 as being wrong is already correct in the `Array.IndexOf()` and `Array.LastIndexOf()` implementations of the BCL, so we didn't need to correct for it.

Here are some .NET tests and Java tests that demonstrate the only gap is with -0.0 and 0.0 on floating point types.

<details>
  <summary>Java Double Tests</summary>

```java
  public void testIndexOf_FindsNaN_WithDifferentBitPattern() {
    // Create a NaN with a non-default payload (different bit pattern)
    long customNaNBits = 0x7ff8000000000001L; // still a valid NaN
    double customNaN = Double.longBitsToDouble(customNaNBits);

    if (!Double.isNaN(customNaN)) {
        throw new AssertionError("Custom NaN bits should produce a NaN");
    }

    // Sanity check: raw bit patterns differ
    if (Double.doubleToRawLongBits(Double.NaN) ==
        Double.doubleToRawLongBits(customNaN)) {
        throw new AssertionError("Expected different NaN bit patterns");
    }

    // ArrayList with 10 elements, only one NaN
    java.util.ArrayList<Double> values = new java.util.ArrayList<>();
    values.add(1.0);
    values.add(2.0);
    values.add(3.0);
    values.add(4.0);
    values.add(5.0);
    values.add(customNaN); // index 5
    values.add(6.0);
    values.add(7.0);
    values.add(8.0);
    values.add(9.0);

    // Act
    int index = values.indexOf(Double.NaN);

    // Assert
    if (index != 5) {
        throw new AssertionError("Expected index 5 but got " + index);
    }
}
  
  public void testIndexOf_DoesNotFindPositiveZero_WhenArrayContainsNegativeZero() {
    // Create negative zero explicitly via bit pattern
    long negativeZeroBits = 0x8000000000000000L;
    double negativeZero = Double.longBitsToDouble(negativeZeroBits);

    // Sanity check: bit pattern matches -0.0
    if (Double.doubleToRawLongBits(-0.0) != negativeZeroBits) {
        throw new AssertionError("Bit pattern for -0.0 should match expected");
    }

    // Sanity check: +0.0 and -0.0 have different raw bits
    if (Double.doubleToRawLongBits(0.0) ==
        Double.doubleToRawLongBits(negativeZero)) {
        throw new AssertionError("Expected different bit patterns for +0.0 and -0.0");
    }

    // ArrayList with 10 elements, only one zero (negative zero)
    java.util.ArrayList<Double> values = new java.util.ArrayList<>();
    values.add(1.0);
    values.add(2.0);
    values.add(3.0);
    values.add(4.0);
    values.add(5.0);
    values.add(negativeZero); // index 5
    values.add(6.0);
    values.add(7.0);
    values.add(8.0);
    values.add(9.0);

    // Act
    int index = values.indexOf(0.0);

    // Assert
    if (index != -1) {
        throw new AssertionError("Expected -1 (not found) but got " + index);
    }
```

</details>

<details>
  <summary>.NET Double Tests</summary>

```c#
            [Test]
            public void Test_IndexOf_Double_FindsNaN_WithDifferentBitPattern()
            {
                // Create a NaN with a non-default payload (different bit pattern)
                long customNaNBits = 0x7FF8000000000001L; // still a valid NaN
                Assert.IsTrue(double.IsNaN(BitConverter.Int64BitsToDouble(customNaNBits)), "Custom NaN bits should produce a NaN");
                double customNaN = BitConverter.Int64BitsToDouble(customNaNBits);

                // Sanity check: bit patterns differ
                Assert.AreNotEqual(
                    BitConverter.DoubleToInt64Bits(double.NaN),
                    BitConverter.DoubleToInt64Bits(customNaN),
                    "Expected different NaN bit patterns"
                );

                // List with 10 elements, only one NaN
                List<double> list = new List<double>
                {
                    1.0,
                    2.0,
                    3.0,
                    4.0,
                    5.0,
                    customNaN, // index 5
                    6.0,
                    7.0,
                    8.0,
                    9.0
                };

                // Act
                int index = list.IndexOf(double.NaN);

                // Assert
                Assert.AreEqual(5, index, "List.IndexOf should find NaN via Equals semantics"); // J2N: Confirmed this is the Java ArrayList<E> behavior
            }

            [Test] // This test fails
            public void Test_IndexOf_Double_FindsPositiveZero_WhenArrayContainsNegativeZero()
            {
                // Create negative zero explicitly via bit pattern
                long negativeZeroBits = unchecked((long)0x8000000000000000);
                Assert.AreEqual(negativeZeroBits, BitConverter.DoubleToInt64Bits(-0.0), "Bit pattern for -0.0 should match expected");
                double negativeZero = BitConverter.Int64BitsToDouble(negativeZeroBits);

                // Sanity check: bit patterns differ
                Assert.AreNotEqual(
                    BitConverter.DoubleToInt64Bits(0.0),
                    BitConverter.DoubleToInt64Bits(negativeZero),
                    "Expected different bit patterns for +0.0 and -0.0"
                );

                // List with 10 elements, only one zero (negative zero)
                List<double> list = new List<double>
                {
                    1.0,
                    2.0,
                    3.0,
                    4.0,
                    5.0,
                    negativeZero, // index 5
                    6.0,
                    7.0,
                    8.0,
                    9.0
                };

                // Act
                int index = list.IndexOf(0.0);

                // Assert
                Assert.AreEqual(-1, index, "List.IndexOf should treat +0.0 and -0.0 as unequal"); // J2N: Confirmed this is the Java ArrayList<E> behavior
            }
```

</details>

-----------------------------

This supersedes #154.

Unfortunately, my description of the issue left much to be desired, was a bit misleading, and made invalid assumptions that `NaN` equality behavior is consistent everywhere in the BCL. The BCL is in fact lying in the documentation about how the `System.Collections.Generic.List<T>.IndexOf()` method is implemented. However, at the end of the day, they replicated the *behavior* of the BCL `EqualityComparer<double>.Default` and `EqualityComparer<float>.Default` by making SIMD optimizations and direct byte comparisons rather than having high-level loops that a comparer would use.

Also, the idea of dropping this code into the `Arrays` class was a bit half-baked. This isn't array behavior in Java and there is no `indexOf()` overload on the `Arrays` class. This belongs in `CollectionUtil` because it applies to how Java collections behave, not arrays. These are different in Java because collections require reference type wrappers and arrays do not.  The only reason I can can come up with where we will need to reuse this behavior is if we make a wrapper around `LinkedList<T>` that implements `IList<T>` because oddly, the BCL implementation does not. Keeping the fix separate from the `List<T>` class is still a good idea, it just doesn't belong in `Arrays`.

-----------------------------

## Behavioral Impact

Although this is technically a breaking change from J2N 2.1.0, it aligns the behavior to what the documentation actually says it does (match the behavior of J2N's default equality comparer) and the exposure is quite low. So, we are calling it a bug fix instead of a breaking change. It only impacts users who meet all of the following conditions:

1. Use floating point numbers in `J2N.Collections.Generic.List<T>` (`double`, `double?`, `float`, or `float?`)
2. Some of those numbers include negative zero (`-0.0d` or `-0.0f` or their bitwise equivalent)
3. Calls are made to `IndexOf()`, `LastIndexOf()`, `Contains()` or `Remove()` overloads of `J2N.Collections.Generic.List<T>` that search for `0.0` or `-0.0`

Users who are using positive `0.0d` or `0.0f` (the typical way) in both the list and the value to look up will be unaffected. The behavior only changes if the list has mixed negative (`-0.0`) and positive (`0.0`) zeros and the value being looked up is a zero (whether negative or positive).

More specifically, the BCL list treats all zeros as matches to each other, and the J2N list treats negative and positive zero as two separate values, which matches the upstream JDK behavior.

-----------------------------

## Performance Impact

This implementation takes advantage of the JIT to optimize away the impact on all types except `float`, `float?`, `double`, and `double?`. Furthermore, the patch is only triggered when the value to search for is either negative or positive zero, otherwise we call the BCL implementation directly to take full advantage of all of the current and future optimizations of the BCL. The patch also uses the BCL implementation to check whether the first match has the right sign or if there is no match at all. The only case where we do our own scan is when the first match has the wrong sign. This is further optimized by starting the scan at the next element where the BCL left off.

Checks such as `typeof(T) == typeof(double)` checks get optimized away from the output of closed generics if the types do not match, so the patch adds no overhead for commonly used types like `int` or `long` in `List<T>`.

-----------------------------

## Design

The implementation uses the strategy design pattern at the *compiler level* using a trick that Microsoft sometimes uses to implement optimizations over open generic types with similar APIs but different underlying binary representations. The strategies are implemented as `readonly struct` that implement a generic interface. It relies on the compiler to choose the strategy based on the way the closed generics are configured, since the default value for a struct is an instance of itself.

To remain fully optimized for the JIT, the struct must be declared `readonly` and never be boxed to its underlying interface.

-----------------------------

## Tests

A test framework was added specifically for these operations and test behavior was confirmed against the JDK by observation directly. After ChatGPT suggested a design and a set of tests, the tests that were added in #154 were analyzed to fill in important gaps that it missed the first time. Since all 3 overloads of `IndexOf` have a separate implementation, the tests were written to include all possible overloads for the specific use case. The framework uses 2 common abstract class to ensure the same tests are run for both `float` and `double` and that nullable checks for `float?` and `double?` are added in addition to the other tests.

The tests cover both `NaN` and signed zero to confirm compatibility with the JDK `java.util.ArrayList<Double>` and `java.util.ArrayList<Float>` implementations of `indexOf()` and `lastIndexOf()`.

Since `IndexOf()` is used to implement `List<T>.Contains()` and `List<T>.Remove()`, regression tests were added to ensure that `NaN` matches different binary values that are `IsNaN(value) == true` and that `-0.0` and `0.0` are treated as separate values in these operations, as well.

## The Missing `System.Half` Support

I debated for a while whether it would be sensible to also support `-0.0` and `0.0` for [`System.Half`](https://learn.microsoft.com/en-us/dotnet/api/system.half?view=net-10.0), which implements the IEEE 754 binary16 standard. And while the test framework and strategy design make that a quick and easy thing to do, there is more to consider:

- `EqualityComparer<Half>.Default` does not have a special case for -0.0 and 0.0
- `Comparer<Half>.Default` does not have a special case for -0.0 and 0.0
- There is no implementation of `J2N.Numerics.Half`
- The former missing implementation means there are no APIs to format or parse Half using Java-like rules

To make things worse, we are using the Ryu implementation to format double and float and round it similarly to the way Java does. There is no 16 bit equivalent. Someday I hope to get into fixing the DiyFp implementation that the BCL uses to correctly round like Java does, but that isn't today.

This is a slippery slope to be consistent just for the sake of consistency with no real-world use case to justify the work. We are implementing a JDK compatibility layer, not a new type system. And no version of JDK currently supports the IEEE 754 binary16 standard.

Our docs say that `IndexOf()`, `LastIndexOf()`, `Contains()`, and `Remove()` behave like the `EqualityComparer<T>.Default` implementation. So, technically, if we add support for `System.Half` to our comparers later, we would have to fix the above methods to match. And if we support `System.Half` in `List<T>` but not in `EqualityComparer<Half>.Default`, our documentation is wrong, which is what this PR is intended to fix.

So, for now `System.Half` will behave differently for negative and positive zero in `List<T>` than `float` and `double`. This is by design.

## Documentation Update

This also aligns the docs for `IndexOf()`, `LastIndexOf()`, `Contains()`, and `Remove()` with the BCL to remove references to `IEquatable<T>`. I didn't investigate whether this means the BCL doesn't use it any longer, but removing it ensures that our documentation isn't wrong about it if they do not.