### PR TITLE
Simplified implementation of `DoubleComparer` and `SingleComparer` (fixes #183)

### DIFF
--- a/src/J2N/Collections/Generic/EqualityComparer.cs
+++ b/src/J2N/Collections/Generic/EqualityComparer.cs
@@ -197,28 +197,11 @@ namespace J2N.Collections.Generic
 
         public override bool Equals(double x, double y)
         {
-            if (x < y || x > y)
-                return false;
-
-            if (0.0d != x && x == y)
-                return true;
-
-            if (double.IsNaN(x) && double.IsNaN(y))
-                return true;
-
-            // Deal with +0.0 and -0.0
-            long d1 = BitConversion.DoubleToRawInt64Bits(x); // NaN already dealt with, so we can use "raw" here
-            long d2 = BitConversion.DoubleToRawInt64Bits(y);
-            // The below expression is equivalent to:
-            // (d1 == d2) ? 0 : (d1 < d2) ? -1 : 1
-            return (int)((d1 >> 63) - (d2 >> 63)) == 0;
+            return BitConversion.DoubleToInt64Bits(x) == BitConversion.DoubleToInt64Bits(y);
         }
 
         public override int GetHashCode(double obj)
         {
-            if (obj != 0 && !double.IsNaN(obj))
-                return obj.GetHashCode();
-
             // Make positive zero and negative zero have different hash codes,
             // and NaN always have the same hash code.
             // We intentionlly call the non "raw" overload here to get that behavior.
@@ -276,28 +259,11 @@ namespace J2N.Collections.Generic
 
         public override bool Equals(float x, float y)
         {
-            if (x < y || x > y)
-                return false;
-
-            if (0.0f != x && x == y)
-                return true;
-
-            if (float.IsNaN(x) && float.IsNaN(y))
-                return true;
-
-            // Deal with +0.0 and -0.0
-            int f1 = BitConversion.SingleToRawInt32Bits(x); // NaN already dealt with, so we can use "raw" here
-            int f2 = BitConversion.SingleToRawInt32Bits(y);
-            // The below expression is equivalent to:
-            // (f1 == f2) ? 0 : (f1 < f2) ? -1 : 1
-            return (f1 >> 31) - (f2 >> 31) == 0;
+            return BitConversion.SingleToInt32Bits(x) == BitConversion.SingleToInt32Bits(y);
         }
 
         public override int GetHashCode(float obj)
         {
-            if (obj != 0 && !float.IsNaN(obj))
-                return obj.GetHashCode();
-
             // Make positive zero and negative zero have different hash codes,
             // and NaN always have the same hash code.
             // We intentionlly call the non "raw" overload here to get that behavior.

--- a/tests/NUnit/J2N.Tests/Collections/Generic/TestEqualityComparer.cs
+++ b/tests/NUnit/J2N.Tests/Collections/Generic/TestEqualityComparer.cs
@@ -18,5 +18,163 @@ namespace J2N.Collections.Generic
             assertEquals(typeof(DoubleComparer), EqualityComparer<double>.Default.GetType());
             assertEquals(typeof(SingleComparer), EqualityComparer<float>.Default.GetType());
         }
+
+        [Test]
+        public void Double_Equals_Basic()
+        {
+            var eq = DoubleComparer.Default;
+
+            Assert.IsTrue(eq.Equals(1.0, 1.0));
+            Assert.IsFalse(eq.Equals(1.0, 2.0));
+        }
+
+        [Test]
+        public void Double_Equals_NaN()
+        {
+            var eq = DoubleComparer.Default;
+
+            Assert.IsTrue(eq.Equals(double.NaN, double.NaN));
+
+            // Different NaN payloads
+            double nan1 = BitConversion.Int64BitsToDouble(0x7ff8000000000001L);
+            double nan2 = BitConversion.Int64BitsToDouble(0x7ff8000000000002L);
+
+            Assert.IsTrue(eq.Equals(nan1, nan2));
+        }
+
+        [Test]
+        public void Double_Equals_Zero()
+        {
+            var eq = DoubleComparer.Default;
+
+            Assert.IsFalse(eq.Equals(+0.0, -0.0));
+            Assert.IsTrue(eq.Equals(+0.0, +0.0));
+            Assert.IsTrue(eq.Equals(-0.0, -0.0));
+        }
+
+        [Test]
+        public void Double_Equals_Cross()
+        {
+            var eq = DoubleComparer.Default;
+
+            Assert.IsFalse(eq.Equals(double.NaN, 0.0));
+            Assert.IsFalse(eq.Equals(double.NaN, double.PositiveInfinity));
+        }
+
+        [Test]
+        public void Double_GetHashCode()
+        {
+            var eq = DoubleComparer.Default;
+
+            // NaN canonicalization
+            double nan1 = BitConversion.Int64BitsToDouble(0x7ff8000000000001L);
+            double nan2 = BitConversion.Int64BitsToDouble(0x7ff8000000000002L);
+
+            Assert.AreEqual(eq.GetHashCode(nan1), eq.GetHashCode(nan2));
+
+            // Zero distinction
+            Assert.AreNotEqual(eq.GetHashCode(+0.0), eq.GetHashCode(-0.0));
+        }
+
+        [Test]
+        public void NullableDouble_Equals()
+        {
+            var eq = DoubleComparer.Default;
+
+            double? a = 1.0;
+            double? b = 1.0;
+            double? c = null;
+
+            Assert.IsTrue(eq.Equals(a.Value, b.Value));
+            Assert.IsFalse(c.HasValue && eq.Equals(c.Value, 0.0));
+        }
+
+        [Test]
+        public void Single_Equals_NaN()
+        {
+            var eq = SingleComparer.Default;
+
+            Assert.IsTrue(eq.Equals(float.NaN, float.NaN));
+
+            int nan1 = 0x7fc00001;
+            int nan2 = 0x7fc00002;
+
+            float f1 = BitConversion.Int32BitsToSingle(nan1);
+            float f2 = BitConversion.Int32BitsToSingle(nan2);
+
+            Assert.IsTrue(eq.Equals(f1, f2));
+        }
+
+        [Test]
+        public void Float_GetHashCode()
+        {
+            var eq = SingleComparer.Default;
+
+            float nan1 = BitConversion.Int32BitsToSingle(0x7fc00001);
+            float nan2 = BitConversion.Int32BitsToSingle(0x7fc00002);
+
+            Assert.AreEqual(eq.GetHashCode(nan1), eq.GetHashCode(nan2));
+
+            Assert.AreNotEqual(eq.GetHashCode(+0.0f), eq.GetHashCode(-0.0f));
+        }
+
+        [Test]
+        public void Double_Equals_Matches_JDK_Semantics()
+        {
+            var eq = DoubleComparer.Default;
+
+            foreach (var bitsX in TestBitPatterns)
+                foreach (var bitsY in TestBitPatterns)
+                {
+                    double x = BitConversion.Int64BitsToDouble(bitsX);
+                    double y = BitConversion.Int64BitsToDouble(bitsY);
+
+                    bool expected =
+                        BitConversion.DoubleToInt64Bits(x) ==
+                        BitConversion.DoubleToInt64Bits(y);
+
+                    Assert.AreEqual(expected, eq.Equals(x, y));
+                }
+        }
+
+        private static readonly long[] TestBitPatterns = new long[]
+        {
+            // Zeros
+            0x0000000000000000L, // +0.0
+            unchecked((long)0x8000000000000000UL), // -0.0
+
+            // Infinities
+            0x7ff0000000000000L, // +inf
+            unchecked((long)0xfff0000000000000UL), // -inf
+
+            // Canonical NaN
+            0x7ff8000000000000L,
+
+            // Non-canonical NaNs (payload variations)
+            0x7ff8000000000001L,
+            0x7ff8000000000002L,
+            0x7fffffffffffffffL,
+
+            unchecked((long)0xfff8000000000000UL),
+            unchecked((long)0xfff8000000000001UL),
+
+            // Smallest/largest subnormals
+            0x0000000000000001L,
+            0x000fffffffffffffL,
+            unchecked((long)0x8000000000000001UL),
+            unchecked((long)0x800fffffffffffffUL),
+
+            // Smallest/largest normals
+            0x0010000000000000L,
+            0x7fefffffffffffffL,
+            unchecked((long)0x8010000000000000UL),
+            unchecked((long)0xffefffffffffffffUL),
+
+            // Some arbitrary normals
+            BitConverter.DoubleToInt64Bits(1.0),
+            BitConverter.DoubleToInt64Bits(-1.0),
+            BitConverter.DoubleToInt64Bits(123.456),
+            BitConverter.DoubleToInt64Bits(-9876.54321),
+        };
     }
 }


### PR DESCRIPTION
Fixes #183.

`J2N.Collections.Generic.EqualityComparer<T>`: Simplified implementation to match the upstream Harmony code (minus the null check because it doesn't apply to value types).