### PR TITLE
Added JDK-style `IndexOf()` and `LastIndexOf()` methods in new `SpanUtilities` class

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -55,7 +55,12 @@
 
   <!-- Features in .NET 7.x, .NET 8.x and .NET 9.x only -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
-    
+
+    <!-- J2N NOTE: This API exists on .NET Framework/.NET Standard, but only Ordinal is optimized. All other StringComparison values
+         allocate 2 strings to make the comparison. As such, it should be avoided on .NET Framework. -->
+    <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON</DefineConstants>
+    <!-- J2N NOTE: This is technically supported in .NET 6.0, but we don't have a target for it so we are testing .NET Standard 2.1, which doesn't support it -->
+    <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_REQUIRESDYNAMICCODEATTRIBUTE</DefineConstants>
     
   </PropertyGroup>

--- a/src/J2N/Character.cs
+++ b/src/J2N/Character.cs
@@ -2038,6 +2038,43 @@ namespace J2N
             return -1;
         }
 
+        // Return true for all characters below or equal U+007f, which is ASCII.
+
+        /// <summary>
+        /// Returns <see langword="true"/> if <paramref name="c"/> is an ASCII
+        /// character ([ U+0000..U+007F ]).
+        /// </summary>
+        /// <remarks>
+        /// Per http://www.unicode.org/glossary/#ASCII, ASCII is only U+0000..U+007F.
+        /// </remarks>
+        internal static bool IsAscii(char c) => (uint)c <= '\x007f'; // Cover .NET
+
+        /// <summary>Indicates whether a character is categorized as an ASCII letter.</summary>
+        /// <param name="c">The character to evaluate.</param>
+        /// <returns>true if <paramref name="c"/> is an ASCII letter; otherwise, false.</returns>
+        /// <remarks>
+        /// This determines whether the character is in the range 'A' through 'Z', inclusive,
+        /// or 'a' through 'z', inclusive.
+        /// </remarks>
+        internal static bool IsAsciiLetter(char c) => (uint)((c | 0x20) - 'a') <= 'z' - 'a';
+
+        /// <summary>Indicates whether a character is categorized as a lowercase ASCII letter.</summary>
+        /// <param name="c">The character to evaluate.</param>
+        /// <returns>true if <paramref name="c"/> is a lowercase ASCII letter; otherwise, false.</returns>
+        /// <remarks>
+        /// This determines whether the character is in the range 'a' through 'z', inclusive.
+        /// </remarks>
+        internal static bool IsAsciiLetterLower(char c) => IsBetween(c, 'a', 'z');
+
+        /// <summary>Indicates whether a character is categorized as an uppercase ASCII letter.</summary>
+        /// <param name="c">The character to evaluate.</param>
+        /// <returns>true if <paramref name="c"/> is an uppercase ASCII letter; otherwise, false.</returns>
+        /// <remarks>
+        /// This determines whether the character is in the range 'A' through 'Z', inclusive.
+        /// </remarks>
+        internal static bool IsAsciiLetterUpper(char c) => IsBetween(c, 'A', 'Z');
+
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool IsAsciiHexDigit(int c)
         {
@@ -2048,6 +2085,19 @@ namespace J2N
             }
             return false;
         }
+
+        /// <summary>Indicates whether a character is within the specified inclusive range.</summary>
+        /// <param name="c">The character to evaluate.</param>
+        /// <param name="minInclusive">The lower bound, inclusive.</param>
+        /// <param name="maxInclusive">The upper bound, inclusive.</param>
+        /// <returns>true if <paramref name="c"/> is within the specified range; otherwise, false.</returns>
+        /// <remarks>
+        /// The method does not validate that <paramref name="maxInclusive"/> is greater than or equal
+        /// to <paramref name="minInclusive"/>.  If <paramref name="maxInclusive"/> is less than
+        /// <paramref name="minInclusive"/>, the behavior is undefined.
+        /// </remarks>
+        internal static bool IsBetween(char c, char minInclusive, char maxInclusive) =>
+            (uint)(c - minInclusive) <= (uint)(maxInclusive - minInclusive);
 
         /// <summary>
         /// Search the sorted characters in the string and return the nearest index.

--- a/src/J2N/Globalization/Ordinal.cs
+++ b/src/J2N/Globalization/Ordinal.cs
@@ -16,578 +16,658 @@ namespace J2N.Globalization
 {
     internal static partial class Ordinal
     {
-//        internal static int CompareStringIgnoreCase(ref char strA, int lengthA, ref char strB, int lengthB)
-//        {
-//            int length = Math.Min(lengthA, lengthB);
-//            int range = length;
-
-//            ref char charA = ref strA;
-//            ref char charB = ref strB;
-
-//            const char maxChar = (char)0x7F;
-
-//            while (length != 0 && charA <= maxChar && charB <= maxChar)
-//            {
-//                // Ordinal equals or lowercase equals if the result ends up in the a-z range
-//                if (charA == charB ||
-//                    ((charA | 0x20) == (charB | 0x20) && char.IsAsciiLetter(charA)))
-//                {
-//                    length--;
-//                    charA = ref Unsafe.Add(ref charA, 1);
-//                    charB = ref Unsafe.Add(ref charB, 1);
-//                }
-//                else
-//                {
-//                    int currentA = charA;
-//                    int currentB = charB;
-
-//                    // Uppercase both chars if needed
-//                    if (char.IsAsciiLetterLower(charA))
-//                    {
-//                        currentA -= 0x20;
-//                    }
-//                    if (char.IsAsciiLetterLower(charB))
-//                    {
-//                        currentB -= 0x20;
-//                    }
-
-//                    // Return the (case-insensitive) difference between them.
-//                    return currentA - currentB;
-//                }
-//            }
-
-//            if (length == 0)
-//            {
-//                return lengthA - lengthB;
-//            }
-
-//            range -= length;
-
-//            return CompareStringIgnoreCaseNonAscii(ref charA, lengthA - range, ref charB, lengthB - range);
-//        }
-
-//        internal static int CompareStringIgnoreCaseNonAscii(ref char strA, int lengthA, ref char strB, int lengthB)
-//        {
-//            if (GlobalizationMode.Invariant)
-//            {
-//                return InvariantModeCasing.CompareStringIgnoreCase(ref strA, lengthA, ref strB, lengthB);
-//            }
-
-//            if (GlobalizationMode.UseNls)
-//            {
-//                return CompareInfo.NlsCompareStringOrdinalIgnoreCase(ref strA, lengthA, ref strB, lengthB);
-//            }
-
-//            return OrdinalCasing.CompareStringIgnoreCase(ref strA, lengthA, ref strB, lengthB);
-//        }
-
-//        private static bool EqualsIgnoreCase_Vector<TVector>(ref char charA, ref char charB, int length)
-//            where TVector : struct, ISimdVector<TVector, ushort>
-//        {
-//            Debug.Assert(length >= TVector.ElementCount);
-
-//            nuint lengthU = (nuint)length;
-//            nuint lengthToExamine = lengthU - (nuint)TVector.ElementCount;
-//            nuint i = 0;
-//            TVector vec1;
-//            TVector vec2;
-//            TVector loweringMask = TVector.Create(0x20);
-//            TVector vecA = TVector.Create('a');
-//            TVector vecZMinusA = TVector.Create('z' - 'a');
-//            do
-//            {
-//                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
-//                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
-
-//                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
-//                {
-//                    goto NON_ASCII;
-//                }
-
-//                TVector notEquals = ~TVector.Equals(vec1, vec2);
-//                if (!notEquals.Equals(TVector.Zero))
-//                {
-//                    // not exact match
-
-//                    vec1 |= loweringMask;
-//                    vec2 |= loweringMask;
-//                    if (TVector.GreaterThanAny((vec1 - vecA) & notEquals, vecZMinusA) || !vec1.Equals(vec2))
-//                    {
-//                        return false; // first input isn't in [A-Za-z], and not exact match of lowered
-//                    }
-//                }
-//                i += (nuint)TVector.ElementCount;
-//            } while (i <= lengthToExamine);
-
-//            // Handle trailing elements
-//            if (i != lengthU)
-//            {
-//                i = lengthU - (nuint)TVector.ElementCount;
-//                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
-//                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
-
-//                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
-//                {
-//                    goto NON_ASCII;
-//                }
-
-//                TVector notEquals = ~TVector.Equals(vec1, vec2);
-//                if (!notEquals.Equals(TVector.Zero))
-//                {
-//                    // not exact match
-
-//                    vec1 |= loweringMask;
-//                    vec2 |= loweringMask;
-//                    if (TVector.GreaterThanAny((vec1 - vecA) & notEquals, vecZMinusA) || !vec1.Equals(vec2))
-//                    {
-//                        return false; // first input isn't in [A-Za-z], and not exact match of lowered
-//                    }
-//                }
-//            }
-//            return true;
-
-//        NON_ASCII:
-//            if (Utf16Utility.AllCharsInVectorAreAscii(vec1) || Utf16Utility.AllCharsInVectorAreAscii(vec2))
-//            {
-//                // No need to use the fallback if one of the inputs is full-ASCII
-//                return false;
-//            }
-
-//            // Fallback for Non-ASCII inputs
-//            return CompareStringIgnoreCase(
-//                ref Unsafe.Add(ref charA, i), (int)(lengthU - i),
-//                ref Unsafe.Add(ref charB, i), (int)(lengthU - i)) == 0;
-//        }
-
-//        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//        internal static bool EqualsIgnoreCase(ref char charA, ref char charB, int length)
-//        {
-//            if (!Vector128.IsHardwareAccelerated || length < Vector128<ushort>.Count)
-//            {
-//                return EqualsIgnoreCase_Scalar(ref charA, ref charB, length);
-//            }
-//            if (Vector512.IsHardwareAccelerated && length >= Vector512<ushort>.Count)
-//            {
-//                return EqualsIgnoreCase_Vector<Vector512<ushort>>(ref charA, ref charB, length);
-//            }
-//            if (Vector256.IsHardwareAccelerated && length >= Vector256<ushort>.Count)
-//            {
-//                return EqualsIgnoreCase_Vector<Vector256<ushort>>(ref charA, ref charB, length);
-//            }
-//            return EqualsIgnoreCase_Vector<Vector128<ushort>>(ref charA, ref charB, length);
-//        }
-
-//        internal static bool EqualsIgnoreCase_Scalar(ref char charA, ref char charB, int length)
-//        {
-//            IntPtr byteOffset = IntPtr.Zero;
-
-//#if TARGET_64BIT
-//            ulong valueAu64 = 0;
-//            ulong valueBu64 = 0;
-//            // Read 4 chars (64 bits) at a time from each string
-//            while ((uint)length >= 4)
-//            {
-//                valueAu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
-//                valueBu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
-
-//                // A 32-bit test - even with the bit-twiddling here - is more efficient than a 64-bit test.
-//                ulong temp = valueAu64 | valueBu64;
-//                if (!Utf16Utility.AllCharsInUInt32AreAscii((uint)temp | (uint)(temp >> 32)))
-//                {
-//                    goto NonAscii64; // one of the inputs contains non-ASCII data
-//                }
-
-//                // Generally, the caller has likely performed a first-pass check that the input strings
-//                // are likely equal. Consider a dictionary which computes the hash code of its key before
-//                // performing a proper deep equality check of the string contents. We want to optimize for
-//                // the case where the equality check is likely to succeed, which means that we want to avoid
-//                // branching within this loop unless we're about to exit the loop, either due to failure or
-//                // due to us running out of input data.
-
-//                if (!Utf16Utility.UInt64OrdinalIgnoreCaseAscii(valueAu64, valueBu64))
-//                {
-//                    return false;
-//                }
-
-//                byteOffset += 8;
-//                length -= 4;
-//            }
-//#endif
-//            uint valueAu32 = 0;
-//            uint valueBu32 = 0;
-//            // Read 2 chars (32 bits) at a time from each string
-//#if TARGET_64BIT
-//            if ((uint)length >= 2)
-//#else
-//            while ((uint)length >= 2)
-//#endif
-//            {
-//                valueAu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
-//                valueBu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
-
-//                if (!Utf16Utility.AllCharsInUInt32AreAscii(valueAu32 | valueBu32))
-//                {
-//                    goto NonAscii32; // one of the inputs contains non-ASCII data
-//                }
-
-//                // Generally, the caller has likely performed a first-pass check that the input strings
-//                // are likely equal. Consider a dictionary which computes the hash code of its key before
-//                // performing a proper deep equality check of the string contents. We want to optimize for
-//                // the case where the equality check is likely to succeed, which means that we want to avoid
-//                // branching within this loop unless we're about to exit the loop, either due to failure or
-//                // due to us running out of input data.
-
-//                if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueAu32, valueBu32))
-//                {
-//                    return false;
-//                }
-
-//                byteOffset += 4;
-//                length -= 2;
-//            }
-
-//            if (length != 0)
-//            {
-//                Debug.Assert(length == 1);
-
-//                valueAu32 = Unsafe.AddByteOffset(ref charA, byteOffset);
-//                valueBu32 = Unsafe.AddByteOffset(ref charB, byteOffset);
-
-//                if ((valueAu32 | valueBu32) > 0x7Fu)
-//                {
-//                    goto NonAscii32; // one of the inputs contains non-ASCII data
-//                }
-
-//                if (valueAu32 == valueBu32)
-//                {
-//                    return true; // exact match
-//                }
-
-//                valueAu32 |= 0x20u;
-//                if ((uint)(valueAu32 - 'a') > (uint)('z' - 'a'))
-//                {
-//                    return false; // not exact match, and first input isn't in [A-Za-z]
-//                }
-
-//                return valueAu32 == (valueBu32 | 0x20u);
-//            }
-
-//            Debug.Assert(length == 0);
-//            return true;
-
-//        NonAscii32:
-//            // Both values have to be non-ASCII to use the slow fallback, in case if one of them is not we return false
-//            if (Utf16Utility.AllCharsInUInt32AreAscii(valueAu32) || Utf16Utility.AllCharsInUInt32AreAscii(valueBu32))
-//            {
-//                return false;
-//            }
-//            goto NonAscii;
-
-//#if TARGET_64BIT
-//        NonAscii64:
-//            // Both values have to be non-ASCII to use the slow fallback, in case if one of them is not we return false
-//            if (Utf16Utility.AllCharsInUInt64AreAscii(valueAu64) || Utf16Utility.AllCharsInUInt64AreAscii(valueBu64))
-//            {
-//                return false;
-//            }
-//#endif
-//        NonAscii:
-//            // The non-ASCII case is factored out into its own helper method so that the JIT
-//            // doesn't need to emit a complex prolog for its caller (this method).
-//            return CompareStringIgnoreCase(ref Unsafe.AddByteOffset(ref charA, byteOffset), length, ref Unsafe.AddByteOffset(ref charB, byteOffset), length) == 0;
-//        }
-
-//        internal static int IndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
-//        {
-//            if (source == null)
-//            {
-//                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
-//            }
-
-//            if (value == null)
-//            {
-//                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
-//            }
-
-//            if (!source.TryGetSpan(startIndex, count, out ReadOnlySpan<char> sourceSpan))
-//            {
-//                // Bounds check failed - figure out exactly what went wrong so that we can
-//                // surface the correct argument exception.
-
-//                if ((uint)startIndex > (uint)source.Length)
-//                {
-//                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_IndexMustBeLessOrEqual);
-//                }
-//                else
-//                {
-//                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
-//                }
-//            }
-
-//            int result = ignoreCase ? IndexOfOrdinalIgnoreCase(sourceSpan, value) : sourceSpan.IndexOf(value);
-
-//            return result >= 0 ? result + startIndex : result;
-//        }
-
-//        internal static int IndexOfOrdinalIgnoreCase(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
-//        {
-//            if (value.Length == 0)
-//            {
-//                return 0;
-//            }
-
-//            if (value.Length > source.Length)
-//            {
-//                // A non-linguistic search compares chars directly against one another, so large
-//                // target strings can never be found inside small search spaces. This check also
-//                // handles empty 'source' spans.
-//                return -1;
-//            }
-
-//            if (GlobalizationMode.Invariant)
-//            {
-//                return InvariantModeCasing.IndexOfIgnoreCase(source, value);
-//            }
-
-//            if (GlobalizationMode.UseNls)
-//            {
-//                return CompareInfo.NlsIndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: true);
-//            }
-
-//            // If value doesn't start with ASCII, fall back to a non-vectorized non-ASCII friendly version.
-//            ref char valueRef = ref MemoryMarshal.GetReference(value);
-//            char valueChar = valueRef;
-//            if (!char.IsAscii(valueChar))
-//            {
-//                return OrdinalCasing.IndexOf(source, value);
-//            }
-
-//            // Hoist some expressions from the loop
-//            int valueTailLength = value.Length - 1;
-//            int searchSpaceMinusValueTailLength = source.Length - valueTailLength;
-//            ref char searchSpace = ref MemoryMarshal.GetReference(source);
-//            char valueCharU = default;
-//            char valueCharL = default;
-//            nint offset = 0;
-//            bool isLetter = false;
-
-//            // If the input is long enough and the value ends with ASCII and is at least two characters,
-//            // we can take a special vectorized path that compares both the beginning and the end at the same time.
-//            if (Vector128.IsHardwareAccelerated &&
-//                valueTailLength != 0 &&
-//                searchSpaceMinusValueTailLength >= Vector128<ushort>.Count)
-//            {
-//                valueCharU = Unsafe.Add(ref valueRef, valueTailLength);
-//                if (char.IsAscii(valueCharU))
-//                {
-//                    goto SearchTwoChars;
-//                }
-//            }
-
-//            // We're searching for the first character and it's known to be ASCII. If it's not a letter,
-//            // then IgnoreCase doesn't impact what it matches and we just need to do a normal search
-//            // for that single character. If it is a letter, then we need to search for both its upper
-//            // and lower-case variants.
-//            if (char.IsAsciiLetter(valueChar))
-//            {
-//                valueCharU = (char)(valueChar & ~0x20);
-//                valueCharL = (char)(valueChar | 0x20);
-//                isLetter = true;
-//            }
-
-//            do
-//            {
-//                // Do a quick search for the first element of "value".
-//                int relativeIndex = isLetter ?
-//                    PackedSpanHelpers.PackedIndexOfIsSupported
-//                        ? PackedSpanHelpers.IndexOfAnyIgnoreCase(ref Unsafe.Add(ref searchSpace, offset), valueCharL, searchSpaceMinusValueTailLength)
-//                        : SpanHelpers.IndexOfAnyChar(ref Unsafe.Add(ref searchSpace, offset), valueCharU, valueCharL, searchSpaceMinusValueTailLength) :
-//                    SpanHelpers.IndexOfChar(ref Unsafe.Add(ref searchSpace, offset), valueChar, searchSpaceMinusValueTailLength);
-//                if (relativeIndex < 0)
-//                {
-//                    break;
-//                }
-
-//                searchSpaceMinusValueTailLength -= relativeIndex;
-//                if (searchSpaceMinusValueTailLength <= 0)
-//                {
-//                    break;
-//                }
-//                offset += relativeIndex;
-
-//                // Found the first element of "value". See if the tail matches.
-//                if (valueTailLength == 0 || // for single-char values we already matched first chars
-//                    EqualsIgnoreCase(
-//                        ref Unsafe.Add(ref searchSpace, (nuint)(offset + 1)),
-//                        ref Unsafe.Add(ref valueRef, 1), valueTailLength))
-//                {
-//                    return (int)offset;  // The tail matched. Return a successful find.
-//                }
-
-//                searchSpaceMinusValueTailLength--;
-//                offset++;
-//            }
-//            while (searchSpaceMinusValueTailLength > 0);
-
-//            return -1;
-
-//        // Based on SpanHelpers.IndexOf(ref char, int, ref char, int), which was in turn based on
-//        // http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd. This version has additional
-//        // modifications to support case-insensitive searches.
-//        SearchTwoChars:
-//            // Both the first character in value (valueChar) and the last character in value (valueCharU) are ASCII. Get their lowercase variants.
-//            valueChar = (char)(valueChar | 0x20);
-//            valueCharU = (char)(valueCharU | 0x20);
-
-//            // The search is more efficient if the two characters being searched for are different. As long as they are equal, walk backwards
-//            // from the last character in the search value until we find a character that's different. Since we're dealing with IgnoreCase,
-//            // we compare the lowercase variants, as that's what we'll be comparing against in the main loop.
-//            nint ch1ch2Distance = valueTailLength;
-//            while (valueCharU == valueChar && ch1ch2Distance > 1)
-//            {
-//                char tmp = Unsafe.Add(ref valueRef, ch1ch2Distance - 1);
-//                if (!char.IsAscii(tmp))
-//                {
-//                    break;
-//                }
-//                --ch1ch2Distance;
-//                valueCharU = (char)(tmp | 0x20);
-//            }
-
-//            // Use Vector256 if the input is long enough.
-//            if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
-//            {
-//                // Create a vector for each of the lowercase ASCII characters we're searching for.
-//                Vector256<ushort> ch1 = Vector256.Create((ushort)valueChar);
-//                Vector256<ushort> ch2 = Vector256.Create((ushort)valueCharU);
-
-//                nint searchSpaceMinusValueTailLengthAndVector = searchSpaceMinusValueTailLength - (nint)Vector256<ushort>.Count;
-//                do
-//                {
-//                    // Make sure we don't go out of bounds.
-//                    Debug.Assert(offset + ch1ch2Distance + Vector256<ushort>.Count <= source.Length);
-
-//                    // Load a vector from the current search space offset and another from the offset plus the distance between the two characters.
-//                    // For each, | with 0x20 so that letters are lowercased, then & those together to get a mask. If the mask is all zeros, there
-//                    // was no match.  If it wasn't, we have to do more work to check for a match.
-//                    Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.BitwiseOr(Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)), Vector256.Create((ushort)0x20)));
-//                    Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.BitwiseOr(Vector256.LoadUnsafe(ref searchSpace, (nuint)offset), Vector256.Create((ushort)0x20)));
-//                    Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
-//                    if (cmpAnd != Vector256<byte>.Zero)
-//                    {
-//                        goto CandidateFound;
-//                    }
-
-//                LoopFooter:
-//                    // No match. Advance to the next vector.
-//                    offset += Vector256<ushort>.Count;
-
-//                    // If we've reached the end of the search space, bail.
-//                    if (offset == searchSpaceMinusValueTailLength)
-//                    {
-//                        return -1;
-//                    }
-
-//                    // If we're within a vector's length of the end of the search space, adjust the offset
-//                    // to point to the last vector so that our next iteration will process it.
-//                    if (offset > searchSpaceMinusValueTailLengthAndVector)
-//                    {
-//                        offset = searchSpaceMinusValueTailLengthAndVector;
-//                    }
-
-//                    continue;
-
-//                CandidateFound:
-//                    // Possible matches at the current location. Extract the bits for each element.
-//                    // For each set bits, we'll check if it's a match at that location.
-//                    uint mask = cmpAnd.ExtractMostSignificantBits();
-//                    do
-//                    {
-//                        // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
-//                        // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
-//                        // the full string always.
-//                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
-//                        if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
-//                        {
-//                            // Match! Return the index.
-//                            return (int)(offset + charPos);
-//                        }
-
-//                        // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
-//                        // If any remain, we loop around to do the next comparison.
-//                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
-//                    } while (mask != 0);
-//                    goto LoopFooter;
-
-//                } while (true);
-//            }
-//            else // 128bit vector path (SSE2 or AdvSimd)
-//            {
-//                // Create a vector for each of the lowercase ASCII characters we're searching for.
-//                Vector128<ushort> ch1 = Vector128.Create((ushort)valueChar);
-//                Vector128<ushort> ch2 = Vector128.Create((ushort)valueCharU);
-
-//                nint searchSpaceMinusValueTailLengthAndVector = searchSpaceMinusValueTailLength - (nint)Vector128<ushort>.Count;
-//                do
-//                {
-//                    // Make sure we don't go out of bounds.
-//                    Debug.Assert(offset + ch1ch2Distance + Vector128<ushort>.Count <= source.Length);
-
-//                    // Load a vector from the current search space offset and another from the offset plus the distance between the two characters.
-//                    // For each, | with 0x20 so that letters are lowercased, then & those together to get a mask. If the mask is all zeros, there
-//                    // was no match.  If it wasn't, we have to do more work to check for a match.
-//                    Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.BitwiseOr(Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)), Vector128.Create((ushort)0x20)));
-//                    Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.BitwiseOr(Vector128.LoadUnsafe(ref searchSpace, (nuint)offset), Vector128.Create((ushort)0x20)));
-//                    Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
-//                    if (cmpAnd != Vector128<byte>.Zero)
-//                    {
-//                        goto CandidateFound;
-//                    }
-
-//                LoopFooter:
-//                    // No match. Advance to the next vector.
-//                    offset += Vector128<ushort>.Count;
-
-//                    // If we've reached the end of the search space, bail.
-//                    if (offset == searchSpaceMinusValueTailLength)
-//                    {
-//                        return -1;
-//                    }
-
-//                    // If we're within a vector's length of the end of the search space, adjust the offset
-//                    // to point to the last vector so that our next iteration will process it.
-//                    if (offset > searchSpaceMinusValueTailLengthAndVector)
-//                    {
-//                        offset = searchSpaceMinusValueTailLengthAndVector;
-//                    }
-
-//                    continue;
-
-//                CandidateFound:
-//                    // Possible matches at the current location. Extract the bits for each element.
-//                    // For each set bits, we'll check if it's a match at that location.
-//                    uint mask = cmpAnd.ExtractMostSignificantBits();
-//                    do
-//                    {
-//                        // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
-//                        // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
-//                        // the full string always.
-//                        nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
-//                        if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
-//                        {
-//                            // Match! Return the index.
-//                            return (int)(offset + charPos);
-//                        }
-
-//                        // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
-//                        // If any remain, we loop around to do the next comparison.
-//                        mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
-//                    } while (mask != 0);
-//                    goto LoopFooter;
-
-//                } while (true);
-//            }
-//        }
+        internal static int CompareStringIgnoreCase(ref char strA, int lengthA, ref char strB, int lengthB)
+        {
+            int length = Math.Min(lengthA, lengthB);
+            int range = length;
+
+            ref char charA = ref strA;
+            ref char charB = ref strB;
+
+            const char maxChar = (char)0x7F;
+
+            while (length != 0 && charA <= maxChar && charB <= maxChar)
+            {
+                // Ordinal equals or lowercase equals if the result ends up in the a-z range
+                if (charA == charB ||
+                    ((charA | 0x20) == (charB | 0x20) && Character.IsAsciiLetter(charA)))
+                {
+                    length--;
+                    charA = ref Unsafe.Add(ref charA, 1);
+                    charB = ref Unsafe.Add(ref charB, 1);
+                }
+                else
+                {
+                    int currentA = charA;
+                    int currentB = charB;
+
+                    // Uppercase both chars if needed
+                    if (Character.IsAsciiLetterLower(charA))
+                    {
+                        currentA -= 0x20;
+                    }
+                    if (Character.IsAsciiLetterLower(charB))
+                    {
+                        currentB -= 0x20;
+                    }
+
+                    // Return the (case-insensitive) difference between them.
+                    return currentA - currentB;
+                }
+            }
+
+            if (length == 0)
+            {
+                return lengthA - lengthB;
+            }
+
+            range -= length;
+
+            return CompareStringIgnoreCaseNonAscii(ref charA, lengthA - range, ref charB, lengthB - range);
+        }
+
+        internal static int CompareStringIgnoreCaseNonAscii(ref char strA, int lengthA, ref char strB, int lengthB)
+        {
+            // J2N: The invariant and NLS modes are handled automatically by
+            // OrdinalCasing, which calls into char.ToUpperInvariant() and
+            // System.MemoryExtensions.ToUpperInvariant() to use the char set of
+            // the underlying platform.
+
+            //if (GlobalizationMode.Invariant)
+            //{
+            //    return InvariantModeCasing.CompareStringIgnoreCase(ref strA, lengthA, ref strB, lengthB);
+            //}
+
+            //if (GlobalizationMode.UseNls)
+            //{
+            //    return CompareInfo.NlsCompareStringOrdinalIgnoreCase(ref strA, lengthA, ref strB, lengthB);
+            //}
+
+            return OrdinalCasing.CompareStringIgnoreCase(ref strA, lengthA, ref strB, lengthB);
+        }
+
+        //        private static bool EqualsIgnoreCase_Vector<TVector>(ref char charA, ref char charB, int length)
+        //            where TVector : struct, ISimdVector<TVector, ushort>
+        //        {
+        //            Debug.Assert(length >= TVector.ElementCount);
+
+        //            nuint lengthU = (nuint)length;
+        //            nuint lengthToExamine = lengthU - (nuint)TVector.ElementCount;
+        //            nuint i = 0;
+        //            TVector vec1;
+        //            TVector vec2;
+        //            TVector loweringMask = TVector.Create(0x20);
+        //            TVector vecA = TVector.Create('a');
+        //            TVector vecZMinusA = TVector.Create('z' - 'a');
+        //            do
+        //            {
+        //                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
+        //                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+
+        //                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
+        //                {
+        //                    goto NON_ASCII;
+        //                }
+
+        //                TVector notEquals = ~TVector.Equals(vec1, vec2);
+        //                if (!notEquals.Equals(TVector.Zero))
+        //                {
+        //                    // not exact match
+
+        //                    vec1 |= loweringMask;
+        //                    vec2 |= loweringMask;
+        //                    if (TVector.GreaterThanAny((vec1 - vecA) & notEquals, vecZMinusA) || !vec1.Equals(vec2))
+        //                    {
+        //                        return false; // first input isn't in [A-Za-z], and not exact match of lowered
+        //                    }
+        //                }
+        //                i += (nuint)TVector.ElementCount;
+        //            } while (i <= lengthToExamine);
+
+        //            // Handle trailing elements
+        //            if (i != lengthU)
+        //            {
+        //                i = lengthU - (nuint)TVector.ElementCount;
+        //                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
+        //                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+
+        //                if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
+        //                {
+        //                    goto NON_ASCII;
+        //                }
+
+        //                TVector notEquals = ~TVector.Equals(vec1, vec2);
+        //                if (!notEquals.Equals(TVector.Zero))
+        //                {
+        //                    // not exact match
+
+        //                    vec1 |= loweringMask;
+        //                    vec2 |= loweringMask;
+        //                    if (TVector.GreaterThanAny((vec1 - vecA) & notEquals, vecZMinusA) || !vec1.Equals(vec2))
+        //                    {
+        //                        return false; // first input isn't in [A-Za-z], and not exact match of lowered
+        //                    }
+        //                }
+        //            }
+        //            return true;
+
+        //        NON_ASCII:
+        //            if (Utf16Utility.AllCharsInVectorAreAscii(vec1) || Utf16Utility.AllCharsInVectorAreAscii(vec2))
+        //            {
+        //                // No need to use the fallback if one of the inputs is full-ASCII
+        //                return false;
+        //            }
+
+        //            // Fallback for Non-ASCII inputs
+        //            return CompareStringIgnoreCase(
+        //                ref Unsafe.Add(ref charA, i), (int)(lengthU - i),
+        //                ref Unsafe.Add(ref charB, i), (int)(lengthU - i)) == 0;
+        //        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool EqualsIgnoreCase(ref char charA, ref char charB, int length)
+        {
+            //if (!Vector128.IsHardwareAccelerated || length < Vector128<ushort>.Count)
+            //{
+                return EqualsIgnoreCase_Scalar(ref charA, ref charB, length);
+            //}
+            //if (Vector512.IsHardwareAccelerated && length >= Vector512<ushort>.Count)
+            //{
+            //    return EqualsIgnoreCase_Vector<Vector512<ushort>>(ref charA, ref charB, length);
+            //}
+            //if (Vector256.IsHardwareAccelerated && length >= Vector256<ushort>.Count)
+            //{
+            //    return EqualsIgnoreCase_Vector<Vector256<ushort>>(ref charA, ref charB, length);
+            //}
+            //return EqualsIgnoreCase_Vector<Vector128<ushort>>(ref charA, ref charB, length);
+        }
+
+        internal static bool EqualsIgnoreCase_Scalar(ref char charA, ref char charB, int length)
+        {
+            IntPtr byteOffset = IntPtr.Zero;
+
+            ulong valueAu64 = 0;
+            ulong valueBu64 = 0;
+
+            if (IntPtr.Size == 8) // 64 bit
+            {
+                // Read 4 chars (64 bits) at a time from each string
+                while ((uint)length >= 4)
+                {
+                    valueAu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                    valueBu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+
+                    // A 32-bit test - even with the bit-twiddling here - is more efficient than a 64-bit test.
+                    ulong temp = valueAu64 | valueBu64;
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii((uint)temp | (uint)(temp >> 32)))
+                    {
+                        goto NonAscii64; // one of the inputs contains non-ASCII data
+                    }
+
+                    // Generally, the caller has likely performed a first-pass check that the input strings
+                    // are likely equal. Consider a dictionary which computes the hash code of its key before
+                    // performing a proper deep equality check of the string contents. We want to optimize for
+                    // the case where the equality check is likely to succeed, which means that we want to avoid
+                    // branching within this loop unless we're about to exit the loop, either due to failure or
+                    // due to us running out of input data.
+
+                    if (!Utf16Utility.UInt64OrdinalIgnoreCaseAscii(valueAu64, valueBu64))
+                    {
+                        return false;
+                    }
+
+                    byteOffset += 8;
+                    length -= 4;
+                }
+            }
+            uint valueAu32 = 0;
+            uint valueBu32 = 0;
+            // Read 2 chars (32 bits) at a time from each string
+            if (IntPtr.Size == 8) // 64 bit
+            {
+                if ((uint)length >= 2) // J2N NOTE: This was a conditional compile on this line, but we duplicated the 32 bit loop below, which only differs if vs while
+                {
+                    valueAu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                    valueBu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(valueAu32 | valueBu32))
+                    {
+                        goto NonAscii32; // one of the inputs contains non-ASCII data
+                    }
+
+                    // Generally, the caller has likely performed a first-pass check that the input strings
+                    // are likely equal. Consider a dictionary which computes the hash code of its key before
+                    // performing a proper deep equality check of the string contents. We want to optimize for
+                    // the case where the equality check is likely to succeed, which means that we want to avoid
+                    // branching within this loop unless we're about to exit the loop, either due to failure or
+                    // due to us running out of input data.
+
+                    if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueAu32, valueBu32))
+                    {
+                        return false;
+                    }
+
+                    byteOffset += 4;
+                    length -= 2;
+                }
+            }
+            else
+            {
+                while ((uint)length >= 2)
+                {
+                    valueAu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                    valueBu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+
+                    if (!Utf16Utility.AllCharsInUInt32AreAscii(valueAu32 | valueBu32))
+                    {
+                        goto NonAscii32; // one of the inputs contains non-ASCII data
+                    }
+
+                    // Generally, the caller has likely performed a first-pass check that the input strings
+                    // are likely equal. Consider a dictionary which computes the hash code of its key before
+                    // performing a proper deep equality check of the string contents. We want to optimize for
+                    // the case where the equality check is likely to succeed, which means that we want to avoid
+                    // branching within this loop unless we're about to exit the loop, either due to failure or
+                    // due to us running out of input data.
+
+                    if (!Utf16Utility.UInt32OrdinalIgnoreCaseAscii(valueAu32, valueBu32))
+                    {
+                        return false;
+                    }
+
+                    byteOffset += 4;
+                    length -= 2;
+                }
+            }
+
+            if (length != 0)
+            {
+                Debug.Assert(length == 1);
+
+                valueAu32 = Unsafe.AddByteOffset(ref charA, byteOffset);
+                valueBu32 = Unsafe.AddByteOffset(ref charB, byteOffset);
+
+                if ((valueAu32 | valueBu32) > 0x7Fu)
+                {
+                    goto NonAscii32; // one of the inputs contains non-ASCII data
+                }
+
+                if (valueAu32 == valueBu32)
+                {
+                    return true; // exact match
+                }
+
+                valueAu32 |= 0x20u;
+                if ((uint)(valueAu32 - 'a') > (uint)('z' - 'a'))
+                {
+                    return false; // not exact match, and first input isn't in [A-Za-z]
+                }
+
+                return valueAu32 == (valueBu32 | 0x20u);
+            }
+
+            Debug.Assert(length == 0);
+            return true;
+
+        NonAscii32:
+            // Both values have to be non-ASCII to use the slow fallback, in case if one of them is not we return false
+            if (Utf16Utility.AllCharsInUInt32AreAscii(valueAu32) || Utf16Utility.AllCharsInUInt32AreAscii(valueBu32))
+            {
+                return false;
+            }
+            goto NonAscii;
+
+        NonAscii64: // 64 bit only
+            // Both values have to be non-ASCII to use the slow fallback, in case if one of them is not we return false
+            if (Utf16Utility.AllCharsInUInt64AreAscii(valueAu64) || Utf16Utility.AllCharsInUInt64AreAscii(valueBu64))
+            {
+                return false;
+            }
+
+        NonAscii:
+            // The non-ASCII case is factored out into its own helper method so that the JIT
+            // doesn't need to emit a complex prolog for its caller (this method).
+            return CompareStringIgnoreCase(ref Unsafe.AddByteOffset(ref charA, byteOffset), length, ref Unsafe.AddByteOffset(ref charB, byteOffset), length) == 0;
+        }
+
+        //internal static int IndexOf(string source, string value, int startIndex, int count, bool ignoreCase)
+        //{
+        //    if (source == null)
+        //    {
+        //        ThrowHelper.ThrowArgumentNullException(ExceptionArgument.source);
+        //    }
+
+        //    if (value == null)
+        //    {
+        //        ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+        //    }
+
+        //    if (!source.TryGetSpan(startIndex, count, out ReadOnlySpan<char> sourceSpan))
+        //    {
+        //        // Bounds check failed - figure out exactly what went wrong so that we can
+        //        // surface the correct argument exception.
+
+        //        if ((uint)startIndex > (uint)source.Length)
+        //        {
+        //            ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.startIndex, ExceptionResource.ArgumentOutOfRange_IndexMustBeLessOrEqual);
+        //        }
+        //        else
+        //        {
+        //            ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count, ExceptionResource.ArgumentOutOfRange_Count);
+        //        }
+        //    }
+
+        //    int result = ignoreCase ? IndexOfOrdinalIgnoreCase(sourceSpan, value) : sourceSpan.IndexOf(value);
+
+        //    return result >= 0 ? result + startIndex : result;
+        //}
+
+        internal static int IndexOfOrdinalIgnoreCase(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
+        {
+            if (value.Length == 0)
+            {
+                return 0;
+            }
+
+            if (value.Length > source.Length)
+            {
+                // A non-linguistic search compares chars directly against one another, so large
+                // target strings can never be found inside small search spaces. This check also
+                // handles empty 'source' spans.
+                return -1;
+            }
+
+            // J2N: The invariant and NLS modes are handled automatically by
+            // OrdinalCasing, which calls into char.ToUpperInvariant() and
+            // System.MemoryExtensions.ToUpperInvariant() to use the char set of
+            // the underlying platform.
+
+            //if (GlobalizationMode.Invariant)
+            //{
+            //    return InvariantModeCasing.IndexOfIgnoreCase(source, value);
+            //}
+
+            //if (GlobalizationMode.UseNls)
+            //{
+            //    return CompareInfo.NlsIndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: true);
+            //}
+
+            // If value doesn't start with ASCII, fall back to a non-vectorized non-ASCII friendly version.
+            ref char valueRef = ref MemoryMarshal.GetReference(value);
+            char valueChar = valueRef;
+            if (!Character.IsAscii(valueChar))
+            {
+                return OrdinalCasing.IndexOf(source, value);
+            }
+
+            // Hoist some expressions from the loop
+            int valueTailLength = value.Length - 1;
+            int searchSpaceMinusValueTailLength = source.Length - valueTailLength;
+            ref char searchSpace = ref MemoryMarshal.GetReference(source);
+            char valueCharU = default;
+            char valueCharL = default;
+            nint offset = 0;
+            bool isLetter = false;
+
+            //// If the input is long enough and the value ends with ASCII and is at least two characters,
+            //// we can take a special vectorized path that compares both the beginning and the end at the same time.
+            //if (Vector128.IsHardwareAccelerated &&
+            //    valueTailLength != 0 &&
+            //    searchSpaceMinusValueTailLength >= Vector128<ushort>.Count)
+            //{
+            //    valueCharU = Unsafe.Add(ref valueRef, valueTailLength);
+            //    if (char.IsAscii(valueCharU))
+            //    {
+            //        goto SearchTwoChars;
+            //    }
+            //}
+
+            // We're searching for the first character and it's known to be ASCII. If it's not a letter,
+            // then IgnoreCase doesn't impact what it matches and we just need to do a normal search
+            // for that single character. If it is a letter, then we need to search for both its upper
+            // and lower-case variants.
+            if (Character.IsAsciiLetter(valueChar))
+            {
+                valueCharU = (char)(valueChar & ~0x20);
+                valueCharL = (char)(valueChar | 0x20);
+                isLetter = true;
+            }
+
+            do
+            {
+                // Do a quick search for the first element of "value".
+                //int relativeIndex = isLetter ?
+                //    PackedSpanHelpers.PackedIndexOfIsSupported
+                //        ? PackedSpanHelpers.IndexOfAnyIgnoreCase(ref Unsafe.Add(ref searchSpace, offset), valueCharL, searchSpaceMinusValueTailLength)
+                //        : SpanHelpers.IndexOfAnyChar(ref Unsafe.Add(ref searchSpace, offset), valueCharU, valueCharL, searchSpaceMinusValueTailLength) :
+                //    SpanHelpers.IndexOfChar(ref Unsafe.Add(ref searchSpace, offset), valueChar, searchSpaceMinusValueTailLength);
+
+                // J2N: Simplified port of the above:
+
+                int relativeIndex;
+
+                if (isLetter)
+                {
+                    // We must search for either upper or lower form.
+                    relativeIndex = IndexOfAnyIgnoreCaseAscii(
+                        ref Unsafe.Add(ref searchSpace, offset),
+                        searchSpaceMinusValueTailLength,
+                        valueCharU, valueCharL);
+                }
+                else
+                {
+                    relativeIndex = IndexOfAscii(
+                        ref Unsafe.Add(ref searchSpace, offset),
+                        searchSpaceMinusValueTailLength,
+                        valueChar);
+                }
+
+                if (relativeIndex < 0)
+                {
+                    break;
+                }
+
+                searchSpaceMinusValueTailLength -= relativeIndex;
+                if (searchSpaceMinusValueTailLength <= 0)
+                {
+                    break;
+                }
+                offset += relativeIndex;
+
+                // Found the first element of "value". See if the tail matches.
+                if (valueTailLength == 0 || // for single-char values we already matched first chars
+                    EqualsIgnoreCase(
+                        ref Unsafe.Add(ref searchSpace, (nuint)(offset + 1)),
+                        ref Unsafe.Add(ref valueRef, 1), valueTailLength))
+                {
+                    return (int)offset;  // The tail matched. Return a successful find.
+                }
+
+                searchSpaceMinusValueTailLength--;
+                offset++;
+            }
+            while (searchSpaceMinusValueTailLength > 0);
+
+            return -1;
+
+            static int IndexOfAnyIgnoreCaseAscii(ref char searchRef, int length, char upper, char lower)
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    char c = Unsafe.Add(ref searchRef, i);
+                    if (c == upper || c == lower)
+                        return i;
+                }
+                return -1;
+            }
+
+            static int IndexOfAscii(ref char searchRef, int length, char value)
+            {
+                for (int i = 0; i < length; i++)
+                {
+                    if (Unsafe.Add(ref searchRef, i) == value)
+                        return i;
+                }
+                return -1;
+            }
+
+            //// Based on SpanHelpers.IndexOf(ref char, int, ref char, int), which was in turn based on
+            //// http://0x80.pl/articles/simd-strfind.html#algorithm-1-generic-simd. This version has additional
+            //// modifications to support case-insensitive searches.
+            //SearchTwoChars:
+            //    // Both the first character in value (valueChar) and the last character in value (valueCharU) are ASCII. Get their lowercase variants.
+            //    valueChar = (char)(valueChar | 0x20);
+            //    valueCharU = (char)(valueCharU | 0x20);
+
+            //    // The search is more efficient if the two characters being searched for are different. As long as they are equal, walk backwards
+            //    // from the last character in the search value until we find a character that's different. Since we're dealing with IgnoreCase,
+            //    // we compare the lowercase variants, as that's what we'll be comparing against in the main loop.
+            //    nint ch1ch2Distance = valueTailLength;
+            //    while (valueCharU == valueChar && ch1ch2Distance > 1)
+            //    {
+            //        char tmp = Unsafe.Add(ref valueRef, ch1ch2Distance - 1);
+            //        if (!char.IsAscii(tmp))
+            //        {
+            //            break;
+            //        }
+            //        --ch1ch2Distance;
+            //        valueCharU = (char)(tmp | 0x20);
+            //    }
+
+            //    // Use Vector256 if the input is long enough.
+            //    if (Vector256.IsHardwareAccelerated && searchSpaceMinusValueTailLength - Vector256<ushort>.Count >= 0)
+            //    {
+            //        // Create a vector for each of the lowercase ASCII characters we're searching for.
+            //        Vector256<ushort> ch1 = Vector256.Create((ushort)valueChar);
+            //        Vector256<ushort> ch2 = Vector256.Create((ushort)valueCharU);
+
+            //        nint searchSpaceMinusValueTailLengthAndVector = searchSpaceMinusValueTailLength - (nint)Vector256<ushort>.Count;
+            //        do
+            //        {
+            //            // Make sure we don't go out of bounds.
+            //            Debug.Assert(offset + ch1ch2Distance + Vector256<ushort>.Count <= source.Length);
+
+            //            // Load a vector from the current search space offset and another from the offset plus the distance between the two characters.
+            //            // For each, | with 0x20 so that letters are lowercased, then & those together to get a mask. If the mask is all zeros, there
+            //            // was no match.  If it wasn't, we have to do more work to check for a match.
+            //            Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.BitwiseOr(Vector256.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)), Vector256.Create((ushort)0x20)));
+            //            Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.BitwiseOr(Vector256.LoadUnsafe(ref searchSpace, (nuint)offset), Vector256.Create((ushort)0x20)));
+            //            Vector256<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+            //            if (cmpAnd != Vector256<byte>.Zero)
+            //            {
+            //                goto CandidateFound;
+            //            }
+
+            //        LoopFooter:
+            //            // No match. Advance to the next vector.
+            //            offset += Vector256<ushort>.Count;
+
+            //            // If we've reached the end of the search space, bail.
+            //            if (offset == searchSpaceMinusValueTailLength)
+            //            {
+            //                return -1;
+            //            }
+
+            //            // If we're within a vector's length of the end of the search space, adjust the offset
+            //            // to point to the last vector so that our next iteration will process it.
+            //            if (offset > searchSpaceMinusValueTailLengthAndVector)
+            //            {
+            //                offset = searchSpaceMinusValueTailLengthAndVector;
+            //            }
+
+            //            continue;
+
+            //        CandidateFound:
+            //            // Possible matches at the current location. Extract the bits for each element.
+            //            // For each set bits, we'll check if it's a match at that location.
+            //            uint mask = cmpAnd.ExtractMostSignificantBits();
+            //            do
+            //            {
+            //                // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
+            //                // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
+            //                // the full string always.
+            //                nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
+            //                if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
+            //                {
+            //                    // Match! Return the index.
+            //                    return (int)(offset + charPos);
+            //                }
+
+            //                // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
+            //                // If any remain, we loop around to do the next comparison.
+            //                mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
+            //            } while (mask != 0);
+            //            goto LoopFooter;
+
+            //        } while (true);
+            //    }
+            //    else // 128bit vector path (SSE2 or AdvSimd)
+            //    {
+            //        // Create a vector for each of the lowercase ASCII characters we're searching for.
+            //        Vector128<ushort> ch1 = Vector128.Create((ushort)valueChar);
+            //        Vector128<ushort> ch2 = Vector128.Create((ushort)valueCharU);
+
+            //        nint searchSpaceMinusValueTailLengthAndVector = searchSpaceMinusValueTailLength - (nint)Vector128<ushort>.Count;
+            //        do
+            //        {
+            //            // Make sure we don't go out of bounds.
+            //            Debug.Assert(offset + ch1ch2Distance + Vector128<ushort>.Count <= source.Length);
+
+            //            // Load a vector from the current search space offset and another from the offset plus the distance between the two characters.
+            //            // For each, | with 0x20 so that letters are lowercased, then & those together to get a mask. If the mask is all zeros, there
+            //            // was no match.  If it wasn't, we have to do more work to check for a match.
+            //            Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.BitwiseOr(Vector128.LoadUnsafe(ref searchSpace, (nuint)(offset + ch1ch2Distance)), Vector128.Create((ushort)0x20)));
+            //            Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.BitwiseOr(Vector128.LoadUnsafe(ref searchSpace, (nuint)offset), Vector128.Create((ushort)0x20)));
+            //            Vector128<byte> cmpAnd = (cmpCh1 & cmpCh2).AsByte();
+            //            if (cmpAnd != Vector128<byte>.Zero)
+            //            {
+            //                goto CandidateFound;
+            //            }
+
+            //        LoopFooter:
+            //            // No match. Advance to the next vector.
+            //            offset += Vector128<ushort>.Count;
+
+            //            // If we've reached the end of the search space, bail.
+            //            if (offset == searchSpaceMinusValueTailLength)
+            //            {
+            //                return -1;
+            //            }
+
+            //            // If we're within a vector's length of the end of the search space, adjust the offset
+            //            // to point to the last vector so that our next iteration will process it.
+            //            if (offset > searchSpaceMinusValueTailLengthAndVector)
+            //            {
+            //                offset = searchSpaceMinusValueTailLengthAndVector;
+            //            }
+
+            //            continue;
+
+            //        CandidateFound:
+            //            // Possible matches at the current location. Extract the bits for each element.
+            //            // For each set bits, we'll check if it's a match at that location.
+            //            uint mask = cmpAnd.ExtractMostSignificantBits();
+            //            do
+            //            {
+            //                // Do a full IgnoreCase equality comparison. SpanHelpers.IndexOf skips comparing the two characters in some cases,
+            //                // but we don't actually know that the two characters are equal, since we compared with | 0x20. So we just compare
+            //                // the full string always.
+            //                nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
+            //                if (EqualsIgnoreCase(ref Unsafe.Add(ref searchSpace, offset + charPos), ref valueRef, value.Length))
+            //                {
+            //                    // Match! Return the index.
+            //                    return (int)(offset + charPos);
+            //                }
+
+            //                // Clear the two lowest set bits in the mask. If there are no more set bits, we're done.
+            //                // If any remain, we loop around to do the next comparison.
+            //                mask = BitOperations.ResetLowestSetBit(BitOperations.ResetLowestSetBit(mask));
+            //            } while (mask != 0);
+            //            goto LoopFooter;
+
+            //        } while (true);
+            //    }
+        }
 
         //internal static int LastIndexOf(string source, string value, int startIndex, int count)
         //{
@@ -657,34 +737,39 @@ namespace J2N.Globalization
         //    return result;
         //}
 
-        //internal static int LastIndexOfOrdinalIgnoreCase(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
-        //{
-        //    if (value.Length == 0)
-        //    {
-        //        return source.Length;
-        //    }
+        internal static int LastIndexOfOrdinalIgnoreCase(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
+        {
+            if (value.Length == 0)
+            {
+                return source.Length;
+            }
 
-        //    if (value.Length > source.Length)
-        //    {
-        //        // A non-linguistic search compares chars directly against one another, so large
-        //        // target strings can never be found inside small search spaces. This check also
-        //        // handles empty 'source' spans.
+            if (value.Length > source.Length)
+            {
+                // A non-linguistic search compares chars directly against one another, so large
+                // target strings can never be found inside small search spaces. This check also
+                // handles empty 'source' spans.
 
-        //        return -1;
-        //    }
+                return -1;
+            }
 
-        //    if (GlobalizationMode.Invariant)
-        //    {
-        //        return InvariantModeCasing.LastIndexOfIgnoreCase(source, value);
-        //    }
+            // J2N: The invariant and NLS modes are handled automatically by
+            // OrdinalCasing, which calls into char.ToUpperInvariant() and
+            // System.MemoryExtensions.ToUpperInvariant() to use the char set of
+            // the underlying platform.
 
-        //    if (GlobalizationMode.UseNls)
-        //    {
-        //        return CompareInfo.NlsIndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: false);
-        //    }
+            //if (GlobalizationMode.Invariant)
+            //{
+            //    return InvariantModeCasing.LastIndexOfIgnoreCase(source, value);
+            //}
 
-        //    return OrdinalCasing.LastIndexOf(source, value);
-        //}
+            //if (GlobalizationMode.UseNls)
+            //{
+            //    return CompareInfo.NlsIndexOfOrdinalCore(source, value, ignoreCase: true, fromBeginning: false);
+            //}
+
+            return OrdinalCasing.LastIndexOf(source, value);
+        }
 
         internal static int ToUpperOrdinal(ReadOnlySpan<char> source, Span<char> destination)
         {

--- a/src/J2N/Globalization/OrdinalCasing.cs
+++ b/src/J2N/Globalization/OrdinalCasing.cs
@@ -126,26 +126,28 @@ namespace J2N.Globalization
         //    /* F800-FFFF */    0b11001000,
         //];
 
-        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //internal static char ToUpper(char c)
-        //{
-        //    int pageNumber = ((int)c) >> 8;
-        //    if (pageNumber == 0) // optimize for ASCII range
-        //    {
-        //        return (char)s_basicLatin[(int)c];
-        //    }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static char ToUpper(char c)
+        {
+            int pageNumber = ((int)c) >> 8;
+            if (pageNumber == 0) // optimize for ASCII range
+            {
+                return (char)s_basicLatin[(int)c];
+            }
 
-        //    ushort[]? casingTable = s_casingTable[pageNumber];
+            return char.ToUpperInvariant(c);
 
-        //    if (casingTable == NoCasingPage)
-        //    {
-        //        return c;
-        //    }
+            //ushort[]? casingTable = s_casingTable[pageNumber];
 
-        //    casingTable ??= InitOrdinalCasingPage(pageNumber);
+            //if (casingTable == NoCasingPage)
+            //{
+            //    return c;
+            //}
 
-        //    return (char)casingTable[((int)c) & 0xFF];
-        //}
+            //casingTable ??= InitOrdinalCasingPage(pageNumber);
+
+            //return (char)casingTable[((int)c) & 0xFF];
+        }
 
         //[MethodImpl(MethodImplOptions.AggressiveInlining)]
         //internal static char ToUpperInvariantMode(char c) => c <= '\u00FF' ? (char)s_basicLatin[(int)c] : c;
@@ -309,132 +311,132 @@ namespace J2N.Globalization
             return lengthA - lengthB;
         }
 
-        //internal static unsafe int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
-        //{
-        //    Debug.Assert(value.Length > 0);
-        //    Debug.Assert(value.Length <= source.Length);
+        internal static unsafe int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
+        {
+            Debug.Assert(value.Length > 0);
+            Debug.Assert(value.Length <= source.Length);
 
-        //    Debug.Assert(!GlobalizationMode.Invariant);
-        //    Debug.Assert(!GlobalizationMode.UseNls);
+            //Debug.Assert(!GlobalizationMode.Invariant);
+            //Debug.Assert(!GlobalizationMode.UseNls);
 
-        //    fixed (char* pSource = &MemoryMarshal.GetReference(source))
-        //    fixed (char* pValue = &MemoryMarshal.GetReference(value))
-        //    {
-        //        char* pSourceLimit = pSource + (source.Length - value.Length);
-        //        char* pValueLimit = pValue + value.Length - 1;
-        //        char* pCurrentSource = pSource;
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            fixed (char* pValue = &MemoryMarshal.GetReference(value))
+            {
+                char* pSourceLimit = pSource + (source.Length - value.Length);
+                char* pValueLimit = pValue + value.Length - 1;
+                char* pCurrentSource = pSource;
 
-        //        while (pCurrentSource <= pSourceLimit)
-        //        {
-        //            char* pVal = pValue;
-        //            char* pSrc = pCurrentSource;
+                while (pCurrentSource <= pSourceLimit)
+                {
+                    char* pVal = pValue;
+                    char* pSrc = pCurrentSource;
 
-        //            while (pVal <= pValueLimit)
-        //            {
-        //                if (!char.IsHighSurrogate(*pVal) || pVal == pValueLimit)
-        //                {
-        //                    if (*pVal != *pSrc && ToUpper(*pVal) != ToUpper(*pSrc))
-        //                        break; // no match
+                    while (pVal <= pValueLimit)
+                    {
+                        if (!char.IsHighSurrogate(*pVal) || pVal == pValueLimit)
+                        {
+                            if (*pVal != *pSrc && ToUpper(*pVal) != ToUpper(*pSrc))
+                                break; // no match
 
-        //                    pVal++;
-        //                    pSrc++;
-        //                    continue;
-        //                }
+                            pVal++;
+                            pSrc++;
+                            continue;
+                        }
 
-        //                if (char.IsHighSurrogate(*pSrc) && char.IsLowSurrogate(*(pSrc + 1)) && char.IsLowSurrogate(*(pVal + 1)))
-        //                {
-        //                    // Well formed surrogates
-        //                    // both the source and the Value have well-formed surrogates.
-        //                    if (!SurrogateCasing.Equal(*pSrc, *(pSrc + 1), *pVal, *(pVal + 1)))
-        //                        break; // no match
+                        if (char.IsHighSurrogate(*pSrc) && char.IsLowSurrogate(*(pSrc + 1)) && char.IsLowSurrogate(*(pVal + 1)))
+                        {
+                            // Well formed surrogates
+                            // both the source and the Value have well-formed surrogates.
+                            if (!SurrogateCasing.Equal(*pSrc, *(pSrc + 1), *pVal, *(pVal + 1)))
+                                break; // no match
 
-        //                    pSrc += 2;
-        //                    pVal += 2;
-        //                    continue;
-        //                }
+                            pSrc += 2;
+                            pVal += 2;
+                            continue;
+                        }
 
-        //                if (*pVal != *pSrc)
-        //                    break; // no match
+                        if (*pVal != *pSrc)
+                            break; // no match
 
-        //                pSrc++;
-        //                pVal++;
-        //            }
+                        pSrc++;
+                        pVal++;
+                    }
 
-        //            if (pVal > pValueLimit)
-        //            {
-        //                // Found match.
-        //                return (int)(pCurrentSource - pSource);
-        //            }
+                    if (pVal > pValueLimit)
+                    {
+                        // Found match.
+                        return (int)(pCurrentSource - pSource);
+                    }
 
-        //            pCurrentSource++;
-        //        }
+                    pCurrentSource++;
+                }
 
-        //        return -1;
-        //    }
-        //}
+                return -1;
+            }
+        }
 
-        //internal static unsafe int LastIndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
-        //{
-        //    Debug.Assert(value.Length > 0);
-        //    Debug.Assert(value.Length <= source.Length);
+        internal static unsafe int LastIndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value)
+        {
+            Debug.Assert(value.Length > 0);
+            Debug.Assert(value.Length <= source.Length);
 
-        //    Debug.Assert(!GlobalizationMode.Invariant);
-        //    Debug.Assert(!GlobalizationMode.UseNls);
+            //Debug.Assert(!GlobalizationMode.Invariant);
+            //Debug.Assert(!GlobalizationMode.UseNls);
 
-        //    fixed (char* pSource = &MemoryMarshal.GetReference(source))
-        //    fixed (char* pValue = &MemoryMarshal.GetReference(value))
-        //    {
-        //        char* pValueLimit = pValue + value.Length - 1;
-        //        char* pCurrentSource = pSource + (source.Length - value.Length);
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            fixed (char* pValue = &MemoryMarshal.GetReference(value))
+            {
+                char* pValueLimit = pValue + value.Length - 1;
+                char* pCurrentSource = pSource + (source.Length - value.Length);
 
-        //        while (pCurrentSource >= pSource)
-        //        {
-        //            char* pVal = pValue;
-        //            char* pSrc = pCurrentSource;
+                while (pCurrentSource >= pSource)
+                {
+                    char* pVal = pValue;
+                    char* pSrc = pCurrentSource;
 
-        //            while (pVal <= pValueLimit)
-        //            {
-        //                if (!char.IsHighSurrogate(*pVal) || pVal == pValueLimit)
-        //                {
-        //                    if (*pVal != *pSrc && ToUpper(*pVal) != ToUpper(*pSrc))
-        //                        break; // no match
+                    while (pVal <= pValueLimit)
+                    {
+                        if (!char.IsHighSurrogate(*pVal) || pVal == pValueLimit)
+                        {
+                            if (*pVal != *pSrc && ToUpper(*pVal) != ToUpper(*pSrc))
+                                break; // no match
 
-        //                    pVal++;
-        //                    pSrc++;
-        //                    continue;
-        //                }
+                            pVal++;
+                            pSrc++;
+                            continue;
+                        }
 
-        //                if (char.IsHighSurrogate(*pSrc) && char.IsLowSurrogate(*(pSrc + 1)) && char.IsLowSurrogate(*(pVal + 1)))
-        //                {
-        //                    // Well formed surrogates
-        //                    // both the source and the Value have well-formed surrogates.
-        //                    if (!SurrogateCasing.Equal(*pSrc, *(pSrc + 1), *pVal, *(pVal + 1)))
-        //                        break; // no match
+                        if (char.IsHighSurrogate(*pSrc) && char.IsLowSurrogate(*(pSrc + 1)) && char.IsLowSurrogate(*(pVal + 1)))
+                        {
+                            // Well formed surrogates
+                            // both the source and the Value have well-formed surrogates.
+                            if (!SurrogateCasing.Equal(*pSrc, *(pSrc + 1), *pVal, *(pVal + 1)))
+                                break; // no match
 
-        //                    pSrc += 2;
-        //                    pVal += 2;
-        //                    continue;
-        //                }
+                            pSrc += 2;
+                            pVal += 2;
+                            continue;
+                        }
 
-        //                if (*pVal != *pSrc)
-        //                    break; // no match
+                        if (*pVal != *pSrc)
+                            break; // no match
 
-        //                pSrc++;
-        //                pVal++;
-        //            }
+                        pSrc++;
+                        pVal++;
+                    }
 
-        //            if (pVal > pValueLimit)
-        //            {
-        //                // Found match.
-        //                return (int)(pCurrentSource - pSource);
-        //            }
+                    if (pVal > pValueLimit)
+                    {
+                        // Found match.
+                        return (int)(pCurrentSource - pSource);
+                    }
 
-        //            pCurrentSource--;
-        //        }
+                    pCurrentSource--;
+                }
 
-        //        return -1;
-        //    }
-        //}
+                return -1;
+            }
+        }
 
         //private static ushort[]?[] InitCasingTable()
         //{

--- a/src/J2N/SpanUtilities.Searching.cs
+++ b/src/J2N/SpanUtilities.Searching.cs
@@ -947,7 +947,7 @@ namespace J2N
         private static void CheckStringComparison(StringComparison comparisonType)
         {
             if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.OrdinalIgnoreCase)
-                throw new ArgumentOutOfRangeException(nameof(comparisonType));
+                ThrowHelper.ThrowArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
         }
     }
 }

--- a/src/J2N/SpanUtilities.Searching.cs
+++ b/src/J2N/SpanUtilities.Searching.cs
@@ -1,0 +1,953 @@
+﻿#region Copyright 2019-2026 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using J2N.Globalization;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace J2N
+{
+    /// <summary>
+    /// Provides specialized operations on <see cref="Span{T}"/> and <see cref="ReadOnlySpan{T}"/> instances that
+    /// are not good candidates for extension methods.
+    /// </summary>
+    public static partial class SpanUtilities
+    {
+        #region IndexOf
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
+        /// the current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is <see cref="string.Empty"/>, the return value
+        /// is 0.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, string value)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return 0;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            return System.MemoryExtensions.IndexOf(span, value.AsSpan()); // J2N: Hardware optimized, where possible
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
+        /// the current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>, the return value
+        /// is 0.</returns>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty span, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return 0;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            return System.MemoryExtensions.IndexOf(span, value); // J2N: Hardware optimized, where possible
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
+        /// the current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is empty, the return value is the effective start index
+        /// after clamping.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return <paramref name="startIndex"/>. This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
+        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(ReadOnlySpan<char> span, string value, int startIndex)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            return IndexOf(span, value.AsSpan(), startIndex);
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is empty, the return value is the effective start index
+        /// after clamping.</returns>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty span, which will
+        /// always return <paramref name="startIndex"/>. This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
+        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex)
+        {
+            if (startIndex < 0)
+                startIndex = 0;
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            // J2N: Hardware optimized, where possible
+            int actualIndex = System.MemoryExtensions.IndexOf(span.Slice(startIndex, span.Length - startIndex), value);
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is <see cref="string.Empty"/>, the return value
+        /// is 0.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return 0;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.IndexOf(span, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return System.MemoryExtensions.IndexOf(span, value.AsSpan());
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.IndexOfOrdinalIgnoreCase(span, value.AsSpan());
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return IndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>, the return value
+        /// is 0.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty span, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return 0;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.IndexOf(span, value, comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return System.MemoryExtensions.IndexOf(span, value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.IndexOfOrdinalIgnoreCase(span, value);
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return IndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is empty, the return value is the effective start index
+        /// after clamping.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
+        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, string value, int startIndex, StringComparison comparisonType)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            if (startIndex < 0)
+                startIndex = 0;
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            ReadOnlySpan<char> toSearch = span.Slice(startIndex, span.Length - startIndex);
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            // J2N: Hardware optimized, where possible
+            int actualIndex = System.MemoryExtensions.IndexOf(toSearch, value, comparisonType);
+#else
+            CheckStringComparison(comparisonType);
+            int actualIndex;
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                actualIndex = System.MemoryExtensions.IndexOf(toSearch, value.AsSpan());
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                actualIndex = Ordinal.IndexOfOrdinalIgnoreCase(toSearch, value.AsSpan());
+            }
+            else
+            {
+                // Hack for platforms older than .NET Core, since this overload didn't exist.
+                // J2N TODO: Optimize (this is rarely used)
+                actualIndex = IndexOfSlow(toSearch, value, comparisonType);
+            }
+#endif
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is empty, the return value is the effective start index
+        /// after clamping.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
+        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
+        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
+        {
+            if (startIndex < 0)
+                startIndex = 0;
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            ReadOnlySpan<char> toSearch = span.Slice(startIndex, span.Length - startIndex);
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            // J2N: Hardware optimized, where possible
+            int actualIndex = System.MemoryExtensions.IndexOf(toSearch, value, comparisonType);
+#else
+            CheckStringComparison(comparisonType);
+            int actualIndex;
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                actualIndex = System.MemoryExtensions.IndexOf(toSearch, value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                actualIndex = Ordinal.IndexOfOrdinalIgnoreCase(toSearch, value);
+            }
+            else
+            {
+                // Hack for platforms older than .NET Core, since this overload didn't exist.
+                // J2N TODO: Optimize (this is rarely used)
+                actualIndex = IndexOfSlow(toSearch, value, comparisonType);
+            }
+#endif
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int IndexOfSlow(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+            => span.ToString().IndexOf(value.ToString(), comparisonType);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int IndexOfSlow(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
+            => span.ToString().IndexOf(value, comparisonType);
+
+        #endregion IndexOf
+
+        #region LastIndexOf
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
+        /// it returns the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, string value)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return span.Length;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            return System.MemoryExtensions.LastIndexOf(span, value.AsSpan()); // J2N: Hardware optimized, where possible
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
+        /// it returns the length of <paramref name="span"/>.</returns>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return span.Length;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            return System.MemoryExtensions.LastIndexOf(span, value); // J2N: Hardware optimized, where possible
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
+        /// beginning of this instance.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise,
+        /// if <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it
+        /// returns the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
+        /// the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int LastIndexOf(ReadOnlySpan<char> span, string value, int startIndex)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            return LastIndexOf(span, value.AsSpan(), startIndex);
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
+        /// beginning of this instance.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
+        /// the length of <paramref name="span"/>.</returns>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
+        /// the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex)
+        {
+            if (startIndex < 0)
+                return -1; // JDK behavior
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            // Last valid starting position
+            int maxStart = span.Length - value.Length;
+
+            if (startIndex > maxStart)
+                startIndex = maxStart;
+
+            if (startIndex < 0)
+                return -1;
+
+            // J2N: Hardware optimized, where possible
+            return System.MemoryExtensions.LastIndexOf(span.Slice(0, startIndex + value.Length), value); // Overflow prevented by guard clause and maxStart logic
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
+        /// it returns the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return span.Length;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.LastIndexOf(span, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return span.LastIndexOf(value.AsSpan());
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(span, value.AsSpan());
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return LastIndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
+        /// it returns the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return span.Length;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.LastIndexOf(span, value, comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return span.LastIndexOf(value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(span, value);
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return LastIndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
+        /// beginning of this instance.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
+        /// the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
+        /// the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, string value, int startIndex, StringComparison comparisonType)
+        {
+            if (value is null)
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+
+            if (startIndex < 0)
+                return -1; // JDK behavior
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.Length == 0)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            // Last valid starting position
+            int maxStart = span.Length - value.Length;
+
+            if (startIndex > maxStart)
+                startIndex = maxStart;
+
+            if (startIndex < 0)
+                return -1;
+
+            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by guard clause and maxStart logic
+#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.LastIndexOf(toSearch, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return toSearch.LastIndexOf(value.AsSpan());
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(toSearch, value.AsSpan());
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return LastIndexOfSlow(toSearch, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
+        /// current <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
+        /// beginning of this instance.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
+        /// the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of this instance
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// <para/>
+        /// This method performs an ordinal (culture-insensitive) search, where a character is
+        /// considered equivalent to another character only if their Unicode scalar values are
+        /// the same.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
+        /// the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
+        {
+            if (startIndex < 0)
+                return -1; // JDK behavior
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return startIndex;
+
+            // If value is longer than the allowed search prefix, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+            // Last valid starting position
+            int maxStart = span.Length - value.Length;
+
+            if (startIndex > maxStart)
+                startIndex = maxStart;
+
+            if (startIndex < 0)
+                return -1;
+
+            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by guard clause and maxStart logic
+#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.LastIndexOf(toSearch, value, comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return toSearch.LastIndexOf(value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(toSearch, value);
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return LastIndexOfSlow(toSearch, value, comparisonType);
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int LastIndexOfSlow(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+            => span.ToString().LastIndexOf(value.ToString(), comparisonType);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int LastIndexOfSlow(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
+            => span.ToString().LastIndexOf(value, comparisonType);
+
+        #endregion LastIndexOf
+
+        private static void CheckStringComparison(StringComparison comparisonType)
+        {
+            if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.OrdinalIgnoreCase)
+                throw new ArgumentOutOfRangeException(nameof(comparisonType));
+        }
+    }
+}

--- a/src/J2N/SpanUtilities.Searching.cs
+++ b/src/J2N/SpanUtilities.Searching.cs
@@ -18,6 +18,7 @@
 
 using J2N.Globalization;
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace J2N
@@ -31,13 +32,13 @@ namespace J2N
         #region IndexOf
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
-        /// the current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/> in
+        /// the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// the specified <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is <see cref="string.Empty"/>, the return value
         /// is 0.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
@@ -59,21 +60,21 @@ namespace J2N
             if (value.Length == 0)
                 return 0;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
-            return System.MemoryExtensions.IndexOf(span, value.AsSpan()); // J2N: Hardware optimized, where possible
+            return System.MemoryExtensions.IndexOf(span, value); // J2N: Hardware optimized, where possible
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
-        /// the current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/> in
+        /// the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// the specified <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>, the return value
         /// is 0.</returns>
         /// <remarks>
@@ -91,7 +92,7 @@ namespace J2N
             if (value.IsEmpty)
                 return 0;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -99,19 +100,24 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in
-        /// the current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified <paramref name="startIndex"/> in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="startIndex">The search starting position.</param>
-        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// <returns>The zero-based index position of <paramref name="value"/> from the specified index of
+        /// <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is empty, the return value is the effective start index
         /// after clamping.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
         /// <remarks>
-        /// Index numbering starts from zero.
+        /// Index numbering starts from zero. The <paramref name="startIndex"/> parameter is clamped to
+        /// the valid range of <paramref name="span"/>. Values less than zero are treated as zero, and values
+        /// greater than the length of <paramref name="span"/> are treated as equal to the length of <paramref name="span"/>.
+        /// If <paramref name="startIndex"/> equals the length of <paramref name="span"/>, this method
+        /// returns -1 for non-empty searches. If <paramref name="value"/> is empty, this method returns
+        /// the effective start index after clamping. The search is case-sensitive.
         /// <para/>
         /// This method performs an ordinal (culture-insensitive) search, where a character is considered
         /// equivalent to another character only if their Unicode scalar values are the same.
@@ -132,18 +138,23 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="startIndex">The search starting position.</param>
         /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// the <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is empty, the return value is the effective start index
         /// after clamping.</returns>
         /// <remarks>
-        /// Index numbering starts from zero.
+        /// Index numbering starts from zero. The <paramref name="startIndex"/> parameter is clamped to
+        /// the valid range of <paramref name="span"/>. Values less than zero are treated as zero, and values
+        /// greater than the length of <paramref name="span"/> are treated as equal to the length of <paramref name="span"/>.
+        /// If <paramref name="startIndex"/> equals the length of <paramref name="span"/>, this method
+        /// returns -1 for non-empty searches. If <paramref name="value"/> is empty, this method returns
+        /// the effective start index after clamping. The search is case-sensitive.
         /// <para/>
         /// This method performs an ordinal (culture-insensitive) search, where a character is considered
         /// equivalent to another character only if their Unicode scalar values are the same.
@@ -165,25 +176,29 @@ namespace J2N
             if (value.IsEmpty)
                 return startIndex;
 
-            // If value is longer than the allowed search prefix, impossible to match
-            if (value.Length > span.Length)
+            // Once clamped to Length, there is no searchable content remaining.
+            if (startIndex == span.Length)
+                return -1;
+
+            // If value is longer than the remaining searchable range, impossible to match
+            if (value.Length > span.Length - startIndex)
                 return -1;
 
             // J2N: Hardware optimized, where possible
-            int actualIndex = System.MemoryExtensions.IndexOf(span.Slice(startIndex, span.Length - startIndex), value);
-            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
+            int actualIndex = System.MemoryExtensions.IndexOf(span.Slice(startIndex), value);
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by clamping
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
         /// and <paramref name="value"/> are compared.</param>
         /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// the <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is <see cref="string.Empty"/>, the return value
         /// is 0.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
@@ -192,8 +207,9 @@ namespace J2N
         /// <remarks>
         /// Index numbering starts from zero.
         /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
-        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
         /// always return 0. This method also allows searches within an empty span.
@@ -210,64 +226,7 @@ namespace J2N
             if (value.Length == 0)
                 return 0;
 
-            // If value is longer than the allowed search prefix, impossible to match
-            if (value.Length > span.Length)
-                return -1;
-
-#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
-            return System.MemoryExtensions.IndexOf(span, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
-#else
-            CheckStringComparison(comparisonType);
-
-            if (comparisonType == StringComparison.Ordinal)
-            {
-                return System.MemoryExtensions.IndexOf(span, value.AsSpan());
-            }
-            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
-            {
-                // Allocation-free common case for .NET Framework.
-                return Ordinal.IndexOfOrdinalIgnoreCase(span, value.AsSpan());
-            }
-
-            // Hack for platforms older than .NET Core, since this overload didn't exist.
-            // J2N TODO: Optimize (this is rarely used)
-            return IndexOfSlow(span, value, comparisonType);
-#endif
-        }
-
-        /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
-        /// </summary>
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
-        /// and <paramref name="value"/> are compared.</param>
-        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
-        /// If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>, the return value
-        /// is 0.</returns>
-        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
-        /// <see cref="StringComparison"/> value.</exception>
-        /// <remarks>
-        /// Index numbering starts from zero.
-        /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
-        /// equivalent to another character only if their Unicode scalar values are the same.
-        /// <para/>
-        /// To match the behavior of the JDK, this method allows searches for the empty span, which will
-        /// always return 0. This method also allows searches within an empty span.
-        /// <para/>
-        /// On older platforms than .NET Core, this overload provides optimizations for
-        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
-        /// </remarks>
-        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
-        {
-            // To match the JDK, allow search for empty string
-            if (value.IsEmpty)
-                return 0;
-
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -293,8 +252,66 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// in the specified <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>, the return value
+        /// is 0.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero.
+        /// <para/>
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty span, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return 0;
+
+            // If value is longer than the remaining searchable range, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.IndexOf(span, value, comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return System.MemoryExtensions.IndexOf(span, value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.IndexOfOrdinalIgnoreCase(span, value);
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return IndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
@@ -302,17 +319,23 @@ namespace J2N
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
         /// and <paramref name="value"/> are compared.</param>
         /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
+        /// <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
         /// If <paramref name="value"/> is empty, the return value is the effective start index
         /// after clamping.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
         /// <see cref="StringComparison"/> value.</exception>
         /// <remarks>
-        /// Index numbering starts from zero.
+        /// Index numbering starts from zero. The <paramref name="startIndex"/> parameter is clamped to
+        /// the valid range of the <paramref name="span"/>. Values less than zero are treated as zero, and values
+        /// greater than the length of <paramref name="span"/> are treated as equal to the length of <paramref name="span"/>.
+        /// If <paramref name="startIndex"/> equals the length of <paramref name="span"/>, this method
+        /// returns -1 for non-empty searches. If <paramref name="value"/> is empty, this method returns
+        /// the effective start index after clamping.
         /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
-        /// equivalent to another character only if their Unicode scalar values are the same.
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
         /// always return 0. This method also allows searches within an empty span.
@@ -337,83 +360,15 @@ namespace J2N
             if (value.Length == 0)
                 return startIndex;
 
-            // If value is longer than the allowed search prefix, impossible to match
-            if (value.Length > span.Length)
+            // Once clamped to Length, there is no searchable content remaining.
+            if (startIndex == span.Length)
                 return -1;
 
-            ReadOnlySpan<char> toSearch = span.Slice(startIndex, span.Length - startIndex);
-#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
-            // J2N: Hardware optimized, where possible
-            int actualIndex = System.MemoryExtensions.IndexOf(toSearch, value, comparisonType);
-#else
-            CheckStringComparison(comparisonType);
-            int actualIndex;
-
-            if (comparisonType == StringComparison.Ordinal)
-            {
-                actualIndex = System.MemoryExtensions.IndexOf(toSearch, value.AsSpan());
-            }
-            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
-            {
-                // Allocation-free common case for .NET Framework.
-                actualIndex = Ordinal.IndexOfOrdinalIgnoreCase(toSearch, value.AsSpan());
-            }
-            else
-            {
-                // Hack for platforms older than .NET Core, since this overload didn't exist.
-                // J2N TODO: Optimize (this is rarely used)
-                actualIndex = IndexOfSlow(toSearch, value, comparisonType);
-            }
-#endif
-            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
-        }
-
-        /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
-        /// </summary>
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="startIndex">The search starting position.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
-        /// and <paramref name="value"/> are compared.</param>
-        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
-        /// the current instance if that sequence of characters is found, or -1 if it is not.
-        /// If <paramref name="value"/> is empty, the return value is the effective start index
-        /// after clamping.</returns>
-        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
-        /// <see cref="StringComparison"/> value.</exception>
-        /// <remarks>
-        /// Index numbering starts from zero.
-        /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is considered
-        /// equivalent to another character only if their Unicode scalar values are the same.
-        /// <para/>
-        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return 0. This method also allows searches within an empty span.
-        /// <para/>
-        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
-        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
-        /// <para/>
-        /// On older platforms than .NET Core, this overload provides optimizations for
-        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
-        /// </remarks>
-        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
-        {
-            if (startIndex < 0)
-                startIndex = 0;
-            if (startIndex > span.Length)
-                startIndex = span.Length;
-
-            // To match the JDK, allow search for empty string
-            if (value.IsEmpty)
-                return startIndex;
-
-            // If value is longer than the allowed search prefix, impossible to match
-            if (value.Length > span.Length)
+            // If value is longer than the remaining searchable range, impossible to match
+            if (value.Length > span.Length - startIndex)
                 return -1;
 
-            ReadOnlySpan<char> toSearch = span.Slice(startIndex, span.Length - startIndex);
+            ReadOnlySpan<char> toSearch = span.Slice(startIndex);
 #if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
             // J2N: Hardware optimized, where possible
             int actualIndex = System.MemoryExtensions.IndexOf(toSearch, value, comparisonType);
@@ -437,9 +392,92 @@ namespace J2N
                 actualIndex = IndexOfSlow(toSearch, value, comparisonType);
             }
 #endif
-            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by guard clause
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by clamping
         }
 
+        /// <summary>
+        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based index position of <paramref name="value"/> from the start of
+        /// the <paramref name="span"/> if that sequence of characters is found, or -1 if it is not.
+        /// If <paramref name="value"/> is empty, the return value is the effective start index
+        /// after clamping.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. The <paramref name="startIndex"/> parameter is clamped to
+        /// the valid range of the <paramref name="span"/>. Values less than zero are treated as zero, and values
+        /// greater than the length of <paramref name="span"/> are treated as equal to the length of <paramref name="span"/>.
+        /// If <paramref name="startIndex"/> equals the length of <paramref name="span"/>, this method
+        /// returns -1 for non-empty searches. If <paramref name="value"/> is empty, this method returns
+        /// the effective start index after clamping.
+        /// <para/>
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return 0. This method also allows searches within an empty span.
+        /// <para/>
+        /// If <paramref name="startIndex"/> is less than zero, it is treated as zero. If it is greater
+        /// than the length of <paramref name="span"/>, it is treated as equal to the length.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
+        {
+            if (startIndex < 0)
+                startIndex = 0;
+            if (startIndex > span.Length)
+                startIndex = span.Length;
+
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return startIndex;
+
+            // Once clamped to Length, there is no searchable content remaining.
+            if (startIndex == span.Length)
+                return -1;
+
+            // If value is longer than the remaining searchable range, impossible to match
+            if (value.Length > span.Length - startIndex)
+                return -1;
+
+            ReadOnlySpan<char> toSearch = span.Slice(startIndex);
+#if FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
+            // J2N: Hardware optimized, where possible
+            int actualIndex = System.MemoryExtensions.IndexOf(toSearch, value, comparisonType);
+#else
+            CheckStringComparison(comparisonType);
+            int actualIndex;
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                actualIndex = System.MemoryExtensions.IndexOf(toSearch, value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                actualIndex = Ordinal.IndexOfOrdinalIgnoreCase(toSearch, value);
+            }
+            else
+            {
+                // Hack for platforms older than .NET Core, since this overload didn't exist.
+                // J2N TODO: Optimize (this is rarely used)
+                actualIndex = IndexOfSlow(toSearch, value, comparisonType);
+            }
+#endif
+            return actualIndex >= 0 ? startIndex + actualIndex : -1; // Overflow prevented by clamping
+        }
+
+#if !FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int IndexOfSlow(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
             => span.ToString().IndexOf(value.ToString(), comparisonType);
@@ -447,14 +485,14 @@ namespace J2N
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int IndexOfSlow(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
             => span.ToString().IndexOf(value, comparisonType);
-
+#endif
         #endregion IndexOf
 
         #region LastIndexOf
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
@@ -466,7 +504,7 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
+        /// This method begins searching at the last character position of the <paramref name="span"/>
         /// and proceeds backward toward the beginning until either <paramref name="value"/>
         /// is found or the first character position has been examined. The search is case-sensitive.
         /// <para/>
@@ -486,7 +524,7 @@ namespace J2N
             if (value.Length == 0)
                 return span.Length;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -495,7 +533,7 @@ namespace J2N
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
@@ -506,7 +544,7 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
+        /// This method begins searching at the last character position of the <paramref name="span"/>
         /// and proceeds backward toward the beginning until either <paramref name="value"/>
         /// is found or the first character position has been examined. The search is case-sensitive.
         /// <para/>
@@ -523,7 +561,7 @@ namespace J2N
             if (value.IsEmpty)
                 return span.Length;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -531,13 +569,13 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
-        /// beginning of this instance.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from
+        /// <paramref name="startIndex"/> toward the beginning of the specified <paramref name="span"/>.</param>
         /// <returns>The zero-based starting index position of value if that string is found, or -1
         /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
         /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise,
@@ -548,16 +586,20 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
-        /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// The search begins at the effective starting position and proceeds backward until either
+        /// <paramref name="value"/> is found or the first character position has been examined.
+        /// The effective starting position is the lesser of <paramref name="startIndex"/> and
+        /// <paramref name="span"/>.Length - <paramref name="value"/>.Length. For example, if
+        /// <paramref name="startIndex"/> is <paramref name="span"/>.Length - 1 and <paramref name="value"/>
+        /// contains a single character, the method searches every character from the last
+        /// character in the <paramref name="span"/> to the beginning. The search is case-sensitive.
         /// <para/>
         /// This method performs an ordinal (culture-insensitive) search, where a character is
         /// considered equivalent to another character only if their Unicode scalar values are
         /// the same.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// always return the lesser of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
         /// This method also allows searches within an empty span.
         /// <para/>
         /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
@@ -573,32 +615,36 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
-        /// beginning of this instance.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from <paramref name="startIndex"/> toward the
+        /// beginning of the <paramref name="span"/>.</param>
         /// <returns>The zero-based starting index position of value if that string is found, or -1
         /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
-        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the <paramref name="span"/>; otherwise, if
         /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
         /// the length of <paramref name="span"/>.</returns>
         /// <remarks>
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
-        /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// The search begins at the effective starting position and proceeds backward until either
+        /// <paramref name="value"/> is found or the first character position has been examined.
+        /// The effective starting position is the lesser of <paramref name="startIndex"/> and
+        /// <paramref name="span"/>.Length - <paramref name="value"/>.Length. For example, if
+        /// <paramref name="startIndex"/> is <paramref name="span"/>.Length - 1 and <paramref name="value"/>
+        /// contains a single character, the method searches every character from the last
+        /// character in the <paramref name="span"/> to the beginning. The search is case-sensitive.
         /// <para/>
         /// This method performs an ordinal (culture-insensitive) search, where a character is
         /// considered equivalent to another character only if their Unicode scalar values are
         /// the same.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// always return the lesser of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
         /// This method also allows searches within an empty span.
         /// <para/>
         /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
@@ -615,7 +661,7 @@ namespace J2N
             if (value.IsEmpty)
                 return startIndex;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -625,16 +671,15 @@ namespace J2N
             if (startIndex > maxStart)
                 startIndex = maxStart;
 
-            if (startIndex < 0)
-                return -1;
+            Debug.Assert(startIndex >= 0);
 
             // J2N: Hardware optimized, where possible
-            return System.MemoryExtensions.LastIndexOf(span.Slice(0, startIndex + value.Length), value); // Overflow prevented by guard clause and maxStart logic
+            return System.MemoryExtensions.LastIndexOf(span.Slice(0, startIndex + value.Length), value); // Overflow prevented by clamping and maxStart logic
         }
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
@@ -650,13 +695,13 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
+        /// This method begins searching at the last character position of the <paramref name="span"/>
         /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// is found or the first character position has been examined.
         /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is
-        /// considered equivalent to another character only if their Unicode scalar values are
-        /// the same.
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
         /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
@@ -673,69 +718,7 @@ namespace J2N
             if (value.Length == 0)
                 return span.Length;
 
-            // If value is longer than the allowed search prefix, impossible to match
-            if (value.Length > span.Length)
-                return -1;
-
-#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
-            return System.MemoryExtensions.LastIndexOf(span, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
-#else
-            CheckStringComparison(comparisonType);
-
-            if (comparisonType == StringComparison.Ordinal)
-            {
-                return span.LastIndexOf(value.AsSpan());
-            }
-            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
-            {
-                // Allocation-free common case for .NET Framework.
-                return Ordinal.LastIndexOfOrdinalIgnoreCase(span, value.AsSpan());
-            }
-
-            // Hack for platforms older than .NET Core, since this overload didn't exist.
-            // J2N TODO: Optimize (this is rarely used)
-            return LastIndexOfSlow(span, value, comparisonType);
-#endif
-        }
-
-        /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
-        /// </summary>
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
-        /// and <paramref name="value"/> are compared.</param>
-        /// <returns>The zero-based starting index position of value if that string is found, or -1
-        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
-        /// it returns the length of <paramref name="span"/>.</returns>
-        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
-        /// <see cref="StringComparison"/> value.</exception>
-        /// <remarks>
-        /// Index numbering starts from zero. That is, the first character in the string
-        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
-        /// <para/>
-        /// This method begins searching at the last character position of this instance
-        /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
-        /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is
-        /// considered equivalent to another character only if their Unicode scalar values are
-        /// the same.
-        /// <para/>
-        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
-        /// <para/>
-        /// On older platforms than .NET Core, this overload provides optimizations for
-        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
-        /// </remarks>
-        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
-        {
-            // To match the JDK, allow search for empty string
-            if (value.IsEmpty)
-                return span.Length;
-
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -762,17 +745,79 @@ namespace J2N
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
-        /// beginning of this instance.</param>
+        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
+        /// and <paramref name="value"/> are compared.</param>
+        /// <returns>The zero-based starting index position of value if that string is found, or -1
+        /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
+        /// it returns the length of <paramref name="span"/>.</returns>
+        /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
+        /// <see cref="StringComparison"/> value.</exception>
+        /// <remarks>
+        /// Index numbering starts from zero. That is, the first character in the string
+        /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
+        /// <para/>
+        /// This method begins searching at the last character position of the <paramref name="span"/>
+        /// and proceeds backward toward the beginning until either <paramref name="value"/>
+        /// is found or the first character position has been examined.
+        /// <para/>
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
+        /// <para/>
+        /// To match the behavior of the JDK, this method allows searches for the empty string, which will
+        /// always return the length of <paramref name="span"/>. This method also allows searches within an empty span.
+        /// <para/>
+        /// On older platforms than .NET Core, this overload provides optimizations for
+        /// <see cref="StringComparison.OrdinalIgnoreCase"/> over and above the System.Memory package.
+        /// </remarks>
+        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
+        {
+            // To match the JDK, allow search for empty string
+            if (value.IsEmpty)
+                return span.Length;
+
+            // If value is longer than the remaining searchable range, impossible to match
+            if (value.Length > span.Length)
+                return -1;
+
+#if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
+            return System.MemoryExtensions.LastIndexOf(span, value, comparisonType); // J2N: Hardware optimized, where possible
+#else
+            CheckStringComparison(comparisonType);
+
+            if (comparisonType == StringComparison.Ordinal)
+            {
+                return span.LastIndexOf(value);
+            }
+            else if (comparisonType == StringComparison.OrdinalIgnoreCase)
+            {
+                // Allocation-free common case for .NET Framework.
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(span, value);
+            }
+
+            // Hack for platforms older than .NET Core, since this overload didn't exist.
+            // J2N TODO: Optimize (this is rarely used)
+            return LastIndexOfSlow(span, value, comparisonType);
+#endif
+        }
+
+        /// <summary>
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
+        /// </summary>
+        /// <param name="span">The source span.</param>
+        /// <param name="value">The value to seek within the source span.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from <paramref name="startIndex"/> toward the
+        /// beginning of the <paramref name="span"/>.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
         /// and <paramref name="value"/> are compared.</param>
         /// <returns>The zero-based starting index position of value if that string is found, or -1
         /// if it is not found. If <paramref name="value"/> is <see cref="string.Empty"/>,
-        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the <paramref name="span"/>; otherwise, if
         /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
         /// the length of <paramref name="span"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="value"/> is <c>null</c>.</exception>
@@ -782,16 +827,20 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
-        /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// The search begins at the effective starting position and proceeds backward until either
+        /// <paramref name="value"/> is found or the first character position has been examined.
+        /// The effective starting position is the lesser of <paramref name="startIndex"/> and
+        /// <paramref name="span"/>.Length - <paramref name="value"/>.Length. For example, if
+        /// <paramref name="startIndex"/> is <paramref name="span"/>.Length - 1 and <paramref name="value"/>
+        /// contains a single character, the method searches every character from the last
+        /// character in the string to the beginning.
         /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is
-        /// considered equivalent to another character only if their Unicode scalar values are
-        /// the same.
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// always return the lesser of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
         /// This method also allows searches within an empty span.
         /// <para/>
         /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
@@ -814,7 +863,7 @@ namespace J2N
             if (value.Length == 0)
                 return startIndex;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -824,10 +873,9 @@ namespace J2N
             if (startIndex > maxStart)
                 startIndex = maxStart;
 
-            if (startIndex < 0)
-                return -1;
+            Debug.Assert(startIndex >= 0);
 
-            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by guard clause and maxStart logic
+            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by clamping and maxStart logic
 #if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
             return System.MemoryExtensions.LastIndexOf(toSearch, value.AsSpan(), comparisonType); // J2N: Hardware optimized, where possible
 #else
@@ -835,12 +883,12 @@ namespace J2N
 
             if (comparisonType == StringComparison.Ordinal)
             {
-                return toSearch.LastIndexOf(value.AsSpan());
+                return toSearch.LastIndexOf(value);
             }
             else if (comparisonType == StringComparison.OrdinalIgnoreCase)
             {
                 // Allocation-free common case for .NET Framework.
-                return Ordinal.LastIndexOfOrdinalIgnoreCase(toSearch, value.AsSpan());
+                return Ordinal.LastIndexOfOrdinalIgnoreCase(toSearch, value);
             }
 
             // Hack for platforms older than .NET Core, since this overload didn't exist.
@@ -850,18 +898,18 @@ namespace J2N
         }
 
         /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the
-        /// current <paramref name="span"/>.
+        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/>
+        /// beginning at the specified index in the specified <paramref name="span"/>.
         /// </summary>
         /// <param name="span">The source span.</param>
         /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="startIndex">The search starting position. The search proceeds from startIndex toward the
-        /// beginning of this instance.</param>
+        /// <param name="startIndex">The search starting position. The search proceeds from <paramref name="startIndex"/> toward the
+        /// beginning of the <paramref name="span"/>.</param>
         /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/>
         /// and <paramref name="value"/> are compared.</param>
         /// <returns>The zero-based starting index position of value if that string is found, or -1
         /// if it is not found. If <paramref name="value"/> is <see cref="ReadOnlySpan{T}.Empty"/>,
-        /// it returns <paramref name="startIndex"/> if it is within the bounds of the span; otherwise, if
+        /// it returns <paramref name="startIndex"/> if it is within the bounds of the <paramref name="span"/>; otherwise, if
         /// <paramref name="startIndex"/> is greater than the length of <paramref name="span"/>, it returns
         /// the length of <paramref name="span"/>.</returns>
         /// <exception cref="ArgumentException"><paramref name="comparisonType"/> is not a
@@ -870,16 +918,20 @@ namespace J2N
         /// Index numbering starts from zero. That is, the first character in the string
         /// is at index zero and the last is at <paramref name="span"/>.Length - 1.
         /// <para/>
-        /// This method begins searching at the last character position of this instance
-        /// and proceeds backward toward the beginning until either <paramref name="value"/>
-        /// is found or the first character position has been examined. The search is case-sensitive.
+        /// The search begins at the effective starting position and proceeds backward until either
+        /// <paramref name="value"/> is found or the first character position has been examined.
+        /// The effective starting position is the lesser of <paramref name="startIndex"/> and
+        /// <paramref name="span"/>.Length - <paramref name="value"/>.Length. For example, if
+        /// <paramref name="startIndex"/> is <paramref name="span"/>.Length - 1 and <paramref name="value"/>
+        /// contains a single character, the method searches every character from the last
+        /// character in the string to the beginning.
         /// <para/>
-        /// This method performs an ordinal (culture-insensitive) search, where a character is
-        /// considered equivalent to another character only if their Unicode scalar values are
-        /// the same.
+        /// The <paramref name="comparisonType"/> parameter specifies to search for the <paramref name="value"/>
+        /// parameter using the current or invariant culture, using a case-sensitive or case-insensitive search,
+        /// and using word or ordinal comparison rules.
         /// <para/>
         /// To match the behavior of the JDK, this method allows searches for the empty string, which will
-        /// always return lesser value of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
+        /// always return the lesser of <paramref name="startIndex"/> or the length of <paramref name="span"/>.
         /// This method also allows searches within an empty span.
         /// <para/>
         /// If <paramref name="startIndex"/> is less than zero, the method returns -1. If it is greater than
@@ -899,7 +951,7 @@ namespace J2N
             if (value.IsEmpty)
                 return startIndex;
 
-            // If value is longer than the allowed search prefix, impossible to match
+            // If value is longer than the remaining searchable range, impossible to match
             if (value.Length > span.Length)
                 return -1;
 
@@ -909,10 +961,9 @@ namespace J2N
             if (startIndex > maxStart)
                 startIndex = maxStart;
 
-            if (startIndex < 0)
-                return -1;
+            Debug.Assert(startIndex >= 0);
 
-            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by guard clause and maxStart logic
+            ReadOnlySpan<char> toSearch = span.Slice(0, startIndex + value.Length); // Overflow prevented by clamping and maxStart logic
 #if FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_STRINGCOMPARISON
             return System.MemoryExtensions.LastIndexOf(toSearch, value, comparisonType); // J2N: Hardware optimized, where possible
 #else
@@ -934,6 +985,7 @@ namespace J2N
 #endif
         }
 
+#if !FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int LastIndexOfSlow(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType)
             => span.ToString().LastIndexOf(value.ToString(), comparisonType);
@@ -941,13 +993,16 @@ namespace J2N
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int LastIndexOfSlow(ReadOnlySpan<char> span, string value, StringComparison comparisonType)
             => span.ToString().LastIndexOf(value, comparisonType);
+#endif
 
         #endregion LastIndexOf
 
+#if !FEATURE_MEMORYEXTENSIONS_INDEXOF_STRINGCOMPARISON
         private static void CheckStringComparison(StringComparison comparisonType)
         {
             if (comparisonType < StringComparison.CurrentCulture || comparisonType > StringComparison.OrdinalIgnoreCase)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.NotSupported_StringComparison, ExceptionArgument.comparisonType);
         }
+#endif
     }
 }

--- a/src/J2N/ThrowHelper.cs
+++ b/src/J2N/ThrowHelper.cs
@@ -1092,6 +1092,8 @@ namespace J2N
                     return "comparer";
                 case ExceptionArgument.comparison:
                     return "comparison";
+                case ExceptionArgument.comparisonType:
+                    return "comparisonType";
                 case ExceptionArgument.converter:
                     return "converter";
                 case ExceptionArgument.count:
@@ -1305,9 +1307,6 @@ namespace J2N
                 //case ExceptionArgument.comparable:
                 //    return "comparable";
 
-
-                //case ExceptionArgument.comparisonType:
-                //    return "comparisonType";
                 //case ExceptionArgument.manager:
                 //    return "manager";
                 //case ExceptionArgument.sourceBytesToCopy:

--- a/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
+++ b/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
@@ -229,7 +229,7 @@ namespace J2N
 
         [Test]
         public void Test_IndexOf_InvalidComparison()
-            => Assert.Throws<ArgumentOutOfRangeException>(() =>
+            => Assert.Throws<ArgumentException>(() =>
                 SpanUtilities.IndexOf("abc".AsSpan(), "a", (StringComparison)999));
     }
 }

--- a/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
+++ b/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
@@ -46,6 +46,33 @@ namespace J2N
 
             // Overlapping
             new object[] { "ababa", "aba", 0 },
+
+            // Exact full-length
+            new object[] { "abcde", "abcde", 0 },
+
+            // Longer than source
+            new object[] { "abc", "abcd", -1 },
+
+            // Single-char
+            new object[] { "abcde", "e", 4 },
+
+            // Repeated overlap
+            new object[] { "aaaaaa", "aaa", 0 },
+
+            // Multiple occurrences
+            new object[] { "abcabcabc", "abc", 0 },
+
+            // Tail occurrence
+            new object[] { "abcxxx", "xxx", 3 },
+
+            // No partial-tail match
+            new object[] { "abcxx", "xxx", -1 },
+
+            // Unicode ordinal
+            new object[] { "Straße", "ß", 4 },
+
+            // Case-sensitive ordinal
+            new object[] { "ABCDE", "abc", -1 },
         };
 
         // --- IndexOf (3-arg) ---
@@ -70,10 +97,48 @@ namespace J2N
             new object[] { "", "", -5, 0 },
             new object[] { "", "", 100, 0 },
             new object[] { "", "a", 0, -1 },
+            new object[] { "", "abc", 100, -1 },
 
             // Overlapping
             new object[] { "ababa", "aba", 0, 0 },
             new object[] { "ababa", "aba", 1, 2 },
+
+            // Exact boundary match
+            new object[] { "abcde", "de", 3, 3 },
+
+            // Boundary miss
+            new object[] { "abcde", "de", 4, -1 },
+
+            // startIndex == Length
+            new object[] { "abcde", "e", 5, -1 },
+            new object[] { "abcde", "", 5, 5 },
+
+            // value longer than searchable tail
+            new object[] { "abcde", "cde", 3, -1 },
+
+            // Full-length
+            new object[] { "abcde", "abcde", 0, 0 },
+            new object[] { "abcde", "abcde", 1, -1 },
+
+            // Repeated overlap
+            new object[] { "aaaaaa", "aaa", 1, 1 },
+            new object[] { "aaaaaa", "aaa", 2, 2 },
+            new object[] { "aaaaaa", "aaa", 3, 3 },
+            new object[] { "aaaaaa", "aaa", 4, -1 },
+
+            // Multiple occurrences
+            new object[] { "abcabcabc", "abc", 1, 3 },
+            new object[] { "abcabcabc", "abc", 4, 6 },
+
+            // Tail search
+            new object[] { "abcxxx", "xxx", 3, 3 },
+            new object[] { "abcxxx", "xxx", 4, -1 },
+
+            // Single-char
+            new object[] { "abcde", "e", 4, 4 },
+
+            // value longer than source
+            new object[] { "abc", "abcd", 0, -1 },
         };
 
         // --- LastIndexOf (2-arg) ---
@@ -92,6 +157,33 @@ namespace J2N
 
             // Overlapping
             new object[] { "ababa", "aba", 2 },
+
+            // Exact full-length
+            new object[] { "abcde", "abcde", 0 },
+
+            // Longer than source
+            new object[] { "abc", "abcd", -1 },
+
+            // Single-char
+            new object[] { "abcde", "e", 4 },
+
+            // Repeated overlap
+            new object[] { "aaaaaa", "aaa", 3 },
+
+            // Multiple occurrences
+            new object[] { "abcabcabc", "abc", 6 },
+
+            // Tail occurrence
+            new object[] { "abcxxx", "xxx", 3 },
+
+            // No partial-tail match
+            new object[] { "abcxx", "xxx", -1 },
+
+            // Unicode ordinal
+            new object[] { "Straße", "ß", 4 },
+
+            // Case-sensitive ordinal
+            new object[] { "ABCDE", "abc", -1 },
         };
 
         // --- LastIndexOf (3-arg) ---
@@ -121,23 +213,163 @@ namespace J2N
             new object[] { "", "", -5, -1 },
             new object[] { "", "", 100, 0 },
             new object[] { "", "a", 0, -1 },
+            new object[] { "", "abc", 100, -1 },
 
             // Overlapping
             new object[] { "ababa", "aba", 10, 2 },
             new object[] { "ababa", "aba", 1, 0 },
+
+            // Exact boundary match
+            new object[] { "abcde", "ab", 0, 0 },
+
+            // Boundary inclusion
+            new object[] { "abcde", "de", 4, 3 },
+
+            // Boundary exclusion
+            new object[] { "abcde", "de", 2, -1 },
+
+            // value longer than searchable window
+            new object[] { "abcde", "cde", 1, -1 },
+
+            // Full-length
+            new object[] { "abcde", "abcde", 5, 0 },
+            new object[] { "abcde", "abcde", 0, 0 },
+
+            // Repeated overlap
+            new object[] { "aaaaaa", "aaa", 5, 3 },
+            new object[] { "aaaaaa", "aaa", 4, 3 },
+            new object[] { "aaaaaa", "aaa", 3, 3 },
+            new object[] { "aaaaaa", "aaa", 2, 2 },
+            new object[] { "aaaaaa", "aaa", 1, 1 },
+            new object[] { "aaaaaa", "aaa", 0, 0 },
+
+            // Multiple occurrences
+            new object[] { "abcabcabc", "abc", 8, 6 },
+            new object[] { "abcabcabc", "abc", 5, 3 },
+            new object[] { "abcabcabc", "abc", 2, 0 },
+
+            // Tail window semantics
+            new object[] { "abcxxx", "xxx", 2, -1 },
+            new object[] { "abcxxx", "xxx", 3, 3 },
+            new object[] { "abcxxx", "xxx", 4, 3 },
+            new object[] { "abcxxx", "xxx", 5, 3 },
+
+            // Single-char
+            new object[] { "abcde", "a", 0, 0 },
+
+            // value longer than source
+            new object[] { "abc", "abcd", 100, -1 },
         };
 
         // --- StringComparison ---
-        private static object[] ComparisonCases =
-        {
-            new object[] { "AbCd", "ab", StringComparison.OrdinalIgnoreCase, 0 },
-            new object[] { "AbCd", "CD", StringComparison.OrdinalIgnoreCase, 2 },
-            new object[] { "AbCd", "ab", StringComparison.Ordinal, -1 },
 
-            // Culture-sensitive
-            // Turkish dotted/dotless I
-            new object[] { "I", "ı", StringComparison.CurrentCultureIgnoreCase, 0 }, // in tr-TR
-            new object[] { "straße", "STRASSE", StringComparison.OrdinalIgnoreCase, -1 },
+        // --- IndexOf (3-arg) + StringComparison ---
+        private static object[] IndexOf_3ArgComparisonCases =
+        {
+            // fixture, value, comparison, culture, expected
+
+            // OrdinalIgnoreCase
+            new object[] { "AbCd", "ab", StringComparison.OrdinalIgnoreCase, null, 0 },
+            new object[] { "AbCd", "CD", StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "AaAaA", "aaa", StringComparison.OrdinalIgnoreCase, null, 0 },
+            new object[] { "abc", "ABC", StringComparison.OrdinalIgnoreCase, null, 0 },
+
+            // Ordinal
+            new object[] { "AbCd", "ab", StringComparison.Ordinal, null, -1 },
+            new object[] { "abcDEF", "DEF", StringComparison.Ordinal, null, 3 },
+            new object[] { "abcDEF", "def", StringComparison.Ordinal, null, -1 },
+
+            // Unicode ordinal behavior
+            new object[] { "Straße", "ß", StringComparison.Ordinal, null, 4 },
+            new object[] { "straße", "STRASSE", StringComparison.OrdinalIgnoreCase, null, -1 },
+
+            // CurrentCultureIgnoreCase smoke test
+            new object[] { "I", "ı", StringComparison.CurrentCultureIgnoreCase, "tr-TR", 0 },
+
+            // Empty
+            new object[] { "", "", StringComparison.Ordinal, null, 0 },
+
+            // Full-length
+            new object[] { "ABC", "abc", StringComparison.OrdinalIgnoreCase, null, 0 },
+        };
+
+        // --- IndexOf (4-arg) + StringComparison ---
+        private static object[] IndexOf_4ArgComparisonCases =
+        {
+            // fixture, value, startIndex, comparison, culture, expected
+
+            // OrdinalIgnoreCase
+            new object[] { "AbCd", "cd", 0, StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "AaAaA", "aaa", 1, StringComparison.OrdinalIgnoreCase, null, 1 },
+            new object[] { "AaAaA", "aaa", 3, StringComparison.OrdinalIgnoreCase, null, -1 },
+
+            // Boundary behavior
+            new object[] { "abcDEF", "DEF", 3, StringComparison.Ordinal, null, 3 },
+            new object[] { "abcDEF", "DEF", 4, StringComparison.Ordinal, null, -1 },
+
+            // Empty
+            new object[] { "abc", "", 2, StringComparison.Ordinal, null, 2 },
+
+            // CurrentCultureIgnoreCase smoke test
+            new object[] { "I", "ı", 0, StringComparison.CurrentCultureIgnoreCase, "tr-TR", 0 },
+
+            // Full-length
+            new object[] { "ABC", "abc", 0, StringComparison.OrdinalIgnoreCase, null, 0 },
+            new object[] { "ABC", "abc", 1, StringComparison.OrdinalIgnoreCase, null, -1 },
+        };
+
+        // --- LastIndexOf (3-arg) + StringComparison ---
+        private static object[] LastIndexOf_3ArgComparisonCases =
+        {
+            // fixture, value, comparison, culture, expected
+
+            // OrdinalIgnoreCase
+            new object[] { "AbCd", "ab", StringComparison.OrdinalIgnoreCase, null, 0 },
+            new object[] { "AbCd", "CD", StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "AaAaA", "aaa", StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "abc", "ABC", StringComparison.OrdinalIgnoreCase, null, 0 },
+
+            // Ordinal
+            new object[] { "AbCd", "ab", StringComparison.Ordinal, null, -1 },
+            new object[] { "abcDEFabc", "DEF", StringComparison.Ordinal, null, 3 },
+            new object[] { "abcDEF", "def", StringComparison.Ordinal, null, -1 },
+
+            // Unicode ordinal behavior
+            new object[] { "Straße", "ß", StringComparison.Ordinal, null, 4 },
+            new object[] { "straßeSTRASSE", "STRASSE", StringComparison.OrdinalIgnoreCase, null, 6 },
+
+            // CurrentCultureIgnoreCase smoke test
+            new object[] { "I", "ı", StringComparison.CurrentCultureIgnoreCase, "tr-TR", 0 },
+
+            // Empty
+            new object[] { "", "", StringComparison.Ordinal, null, 0 },
+
+            // Full-length
+            new object[] { "ABC", "abc", StringComparison.OrdinalIgnoreCase, null, 0 },
+        };
+
+        // --- LastIndexOf (4-arg) + StringComparison ---
+        private static object[] LastIndexOf_4ArgComparisonCases =
+        {
+            // fixture, value, startIndex, comparison, culture, expected
+
+            // OrdinalIgnoreCase
+            new object[] { "AaAaA", "aaa", 4, StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "AaAaA", "aaa", 2, StringComparison.OrdinalIgnoreCase, null, 2 },
+            new object[] { "AaAaA", "aaa", 1, StringComparison.OrdinalIgnoreCase, null, 1 },
+
+            // Boundary behavior
+            new object[] { "abcDEF", "DEF", 5, StringComparison.Ordinal, null, 3 },
+            new object[] { "abcDEF", "DEF", 2, StringComparison.Ordinal, null, -1 },
+
+            // Empty
+            new object[] { "abc", "", 2, StringComparison.Ordinal, null, 2 },
+
+            // CurrentCultureIgnoreCase smoke test
+            new object[] { "I", "ı", 0, StringComparison.CurrentCultureIgnoreCase, "tr-TR", 0 },
+
+            // Full-length
+            new object[] { "ABC", "abc", 3, StringComparison.OrdinalIgnoreCase, null, 0 },
         };
 
         // ============================
@@ -152,6 +384,14 @@ namespace J2N
         public void Test_IndexOf_ReadOnlySpan(string fixture, string value, int expected)
             => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan()));
 
+        [TestCaseSource(nameof(IndexOf_2ArgCases))]
+        public void Test_IndexOf_String_StringComparison_Ordinal(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(IndexOf_2ArgCases))]
+        public void Test_IndexOf_ReadOnlySpan_StringComparison_Ordinal(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), StringComparison.Ordinal));
+
         [TestCaseSource(nameof(IndexOf_3ArgCases))]
         public void Test_IndexOf_String_Int32(string fixture, string value, int startIndex, int expected)
             => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, startIndex));
@@ -160,18 +400,40 @@ namespace J2N
         public void Test_IndexOf_ReadOnlySpan_Int32(string fixture, string value, int startIndex, int expected)
             => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), startIndex));
 
-        [TestCaseSource(nameof(ComparisonCases))]
-        public void Test_IndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        [TestCaseSource(nameof(IndexOf_3ArgCases))]
+        public void Test_IndexOf_String_Int32_StringComparison_Ordinal(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, startIndex, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(IndexOf_3ArgCases))]
+        public void Test_IndexOf_ReadOnlySpan_Int32_StringComparison_Ordinal(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), startIndex, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(IndexOf_3ArgComparisonCases))]
+        public void Test_IndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, string culture, int expected)
         {
-            using var context = new CultureContext("tr-TR");
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
             Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, cmp));
         }
 
-        [TestCaseSource(nameof(ComparisonCases))]
-        public void Test_IndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        [TestCaseSource(nameof(IndexOf_3ArgComparisonCases))]
+        public void Test_IndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, string culture, int expected)
         {
-            using var context = new CultureContext("tr-TR");
-            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), cmp)); 
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
+            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), cmp));
+        }
+
+        [TestCaseSource(nameof(IndexOf_4ArgComparisonCases))]
+        public void Test_IndexOf_String_Int32_StringComparison(string fixture, string value, int startIndex, StringComparison cmp, string culture, int expected)
+        {
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
+            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, startIndex, cmp));
+        }
+
+        [TestCaseSource(nameof(IndexOf_4ArgComparisonCases))]
+        public void Test_IndexOf_ReadOnlySpan_StringComparison(string fixture, string value, int startIndex, StringComparison cmp, string culture, int expected)
+        {
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
+            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), startIndex, cmp));
         }
 
         // ============================
@@ -186,6 +448,14 @@ namespace J2N
         public void Test_LastIndexOf_ReadOnlySpan(string fixture, string value, int expected)
             => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan()));
 
+        [TestCaseSource(nameof(LastIndexOf_2ArgCases))]
+        public void Test_LastIndexOf_String_StringComparison_Ordinal(string fixture, string value, int expected)
+           => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(LastIndexOf_2ArgCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_StringComparison_Ordinal(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), StringComparison.Ordinal));
+
         [TestCaseSource(nameof(LastIndexOf_3ArgCases))]
         public void Test_LastIndexOf_String_Int32(string fixture, string value, int startIndex, int expected)
             => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, startIndex));
@@ -194,21 +464,44 @@ namespace J2N
         public void Test_LastIndexOf_ReadOnlySpan_Int32(string fixture, string value, int startIndex, int expected)
             => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), startIndex));
 
-        [TestCaseSource(nameof(ComparisonCases))]
-        public void Test_LastIndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        [TestCaseSource(nameof(LastIndexOf_3ArgCases))]
+        public void Test_LastIndexOf_String_Int32_StringComparison_Ordinal(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, startIndex, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(LastIndexOf_3ArgCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32_StringComparison_Ordinal(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), startIndex, StringComparison.Ordinal));
+
+        [TestCaseSource(nameof(LastIndexOf_3ArgComparisonCases))]
+        public void Test_LastIndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, string culture, int expected)
         {
-            using var context = new CultureContext("tr-TR");
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
             Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, cmp));
         }
 
-        [TestCaseSource(nameof(ComparisonCases))]
-        public void Test_LastIndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        [TestCaseSource(nameof(LastIndexOf_3ArgComparisonCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, string culture, int expected)
         {
-            using var context = new CultureContext("tr-TR");
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
             Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), cmp));
         }
+
+        [TestCaseSource(nameof(LastIndexOf_4ArgComparisonCases))]
+        public void Test_LastIndexOf_String_Int32_StringComparison(string fixture, string value, int startIndex, StringComparison cmp, string culture, int expected)
+        {
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
+            Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, startIndex, cmp));
+        }
+
+        [TestCaseSource(nameof(LastIndexOf_4ArgComparisonCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32_StringComparison(string fixture, string value, int startIndex, StringComparison cmp, string culture, int expected)
+        {
+            using IDisposable context = culture is not null ? new CultureContext(culture) : new DummyDisposable();
+            Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), startIndex, cmp));
+        }
+
         // ============================
-        // ERROR TESTS (SEPARATE)
+        // ERROR TESTS
         // ============================
 
         [Test]
@@ -220,6 +513,14 @@ namespace J2N
             => Assert.Throws<ArgumentNullException>(() => SpanUtilities.IndexOf("abc".AsSpan(), (string)null, 0));
 
         [Test]
+        public void Test_IndexOf_String_StringComparison_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.IndexOf("abc".AsSpan(), (string)null, StringComparison.Ordinal));
+
+        [Test]
+        public void Test_IndexOf_String_Int32_StringComparison_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.IndexOf("abc".AsSpan(), (string)null, 0, StringComparison.Ordinal));
+
+        [Test]
         public void Test_LastIndexOf_String_Null()
             => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null));
 
@@ -228,8 +529,56 @@ namespace J2N
             => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null, 0));
 
         [Test]
-        public void Test_IndexOf_InvalidComparison()
+        public void Test_LastIndexOf_String_StringComparison_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null, StringComparison.Ordinal));
+
+        [Test]
+        public void Test_LastIndexOf_String_Int32_StringComparison_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null, 0, StringComparison.Ordinal));
+
+        [Test]
+        public void Test_IndexOf_String_StringComparison_InvalidComparison()
             => Assert.Throws<ArgumentException>(() =>
                 SpanUtilities.IndexOf("abc".AsSpan(), "a", (StringComparison)999));
+
+        [Test]
+        public void Test_IndexOf_ReadOnlySpan_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.IndexOf("abc".AsSpan(), "a".AsSpan(), (StringComparison)999));
+
+        [Test]
+        public void Test_IndexOf_String_Int32_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.IndexOf("abc".AsSpan(), "a", 0, (StringComparison)999));
+
+        [Test]
+        public void Test_IndexOf_ReadOnlySpan_Int32_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.IndexOf("abc".AsSpan(), "a".AsSpan(), 0, (StringComparison)999));
+
+        [Test]
+        public void Test_LastIndexOf_String_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.LastIndexOf("abc".AsSpan(), "a", (StringComparison)999));
+
+        [Test]
+        public void Test_LastIndexOf_ReadOnlySpan_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.LastIndexOf("abc".AsSpan(), "a".AsSpan(), (StringComparison)999));
+
+        [Test]
+        public void Test_LastIndexOf_String_Int32_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.LastIndexOf("abc".AsSpan(), "a", 0, (StringComparison)999));
+
+        [Test]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32_StringComparison_InvalidComparison()
+            => Assert.Throws<ArgumentException>(() =>
+                SpanUtilities.LastIndexOf("abc".AsSpan(), "a".AsSpan(), 0, (StringComparison)999));
+
+        private sealed class DummyDisposable : IDisposable
+        {
+            public void Dispose() { }
+        }
     }
 }

--- a/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
+++ b/tests/NUnit/J2N.Tests/TestSpanUtilities.cs
@@ -1,0 +1,235 @@
+﻿#region Copyright 2019-2026 by Shad Storhaug, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+using J2N.Globalization;
+using NUnit.Framework;
+using System;
+
+namespace J2N
+{
+    public class TestSpanUtilities : TestCase
+    {
+        // ============================
+        // DATA SOURCES
+        // ============================
+
+        // --- IndexOf (2-arg) ---
+        private static object[] IndexOf_2ArgCases =
+        {
+            // fixture, value, expected
+
+            // Basic (Apache Harmony parity)
+            new object[] { "0123456789", "0", 0 },
+            new object[] { "0123456789", "012", 0 },
+            new object[] { "0123456789", "02", -1 },
+            new object[] { "0123456789", "89", 8 },
+
+            // Empty value
+            new object[] { "0123456789", "", 0 },
+            new object[] { "", "foo", -1 },
+            new object[] { "", "", 0 },
+
+            // Overlapping
+            new object[] { "ababa", "aba", 0 },
+        };
+
+        // --- IndexOf (3-arg) ---
+        private static object[] IndexOf_3ArgCases =
+        {
+            // fixture, value, startIndex, expected
+
+            new object[] { "0123456789", "89", 5, 8 },
+            new object[] { "0123456789", "0", 5, -1 },
+
+            // Empty value
+            new object[] { "0123456789", "", 5, 5 },
+
+            // Clamping (JDK-style)
+            new object[] { "0123456789", "0", -5, 0 },
+            new object[] { "0123456789", "0", 100, -1 },
+            new object[] { "0123456789", "", -5, 0 },
+            new object[] { "0123456789", "", 100, 10 },
+
+            // Empty span
+            new object[] { "", "", 0, 0 },
+            new object[] { "", "", -5, 0 },
+            new object[] { "", "", 100, 0 },
+            new object[] { "", "a", 0, -1 },
+
+            // Overlapping
+            new object[] { "ababa", "aba", 0, 0 },
+            new object[] { "ababa", "aba", 1, 2 },
+        };
+
+        // --- LastIndexOf (2-arg) ---
+        private static object[] LastIndexOf_2ArgCases =
+        {
+            // Basic (Apache Harmony parity)
+            new object[] { "0123456789", "0", 0 },
+            new object[] { "0123456789", "012", 0 },
+            new object[] { "0123456789", "02", -1 },
+            new object[] { "0123456789", "89", 8 },
+
+            // Empty value
+            new object[] { "0123456789", "", 10 },
+            new object[] { "", "", 0 },
+            new object[] { "", "a", -1 },
+
+            // Overlapping
+            new object[] { "ababa", "aba", 2 },
+        };
+
+        // --- LastIndexOf (3-arg) ---
+        private static object[] LastIndexOf_3ArgCases =
+        {
+            // Basic (Apache Harmony parity)
+            new object[] { "0123456789", "0", 10, 0 },
+            new object[] { "0123456789", "012", 10, 0 },
+            new object[] { "0123456789", "02", 10, -1 },
+            new object[] { "0123456789", "89", 10, 8 },
+
+            // startIndex behavior
+            new object[] { "0123456789", "0", 5, 0 },
+            new object[] { "0123456789", "89", 5, -1 },
+
+            // Empty value
+            new object[] { "0123456789", "", 5, 5 },
+
+            // Clamping
+            new object[] { "0123456789", "0", -1, -1 },
+            new object[] { "0123456789", "0", 100, 0 },
+            new object[] { "0123456789", "", -1, -1 },
+            new object[] { "0123456789", "", 100, 10 },
+
+            // Empty span
+            new object[] { "", "", 0, 0 },
+            new object[] { "", "", -5, -1 },
+            new object[] { "", "", 100, 0 },
+            new object[] { "", "a", 0, -1 },
+
+            // Overlapping
+            new object[] { "ababa", "aba", 10, 2 },
+            new object[] { "ababa", "aba", 1, 0 },
+        };
+
+        // --- StringComparison ---
+        private static object[] ComparisonCases =
+        {
+            new object[] { "AbCd", "ab", StringComparison.OrdinalIgnoreCase, 0 },
+            new object[] { "AbCd", "CD", StringComparison.OrdinalIgnoreCase, 2 },
+            new object[] { "AbCd", "ab", StringComparison.Ordinal, -1 },
+
+            // Culture-sensitive
+            // Turkish dotted/dotless I
+            new object[] { "I", "ı", StringComparison.CurrentCultureIgnoreCase, 0 }, // in tr-TR
+            new object[] { "straße", "STRASSE", StringComparison.OrdinalIgnoreCase, -1 },
+        };
+
+        // ============================
+        // INDEXOF TESTS
+        // ============================
+
+        [TestCaseSource(nameof(IndexOf_2ArgCases))]
+        public void Test_IndexOf_String(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value));
+
+        [TestCaseSource(nameof(IndexOf_2ArgCases))]
+        public void Test_IndexOf_ReadOnlySpan(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan()));
+
+        [TestCaseSource(nameof(IndexOf_3ArgCases))]
+        public void Test_IndexOf_String_Int32(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, startIndex));
+
+        [TestCaseSource(nameof(IndexOf_3ArgCases))]
+        public void Test_IndexOf_ReadOnlySpan_Int32(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), startIndex));
+
+        [TestCaseSource(nameof(ComparisonCases))]
+        public void Test_IndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        {
+            using var context = new CultureContext("tr-TR");
+            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value, cmp));
+        }
+
+        [TestCaseSource(nameof(ComparisonCases))]
+        public void Test_IndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        {
+            using var context = new CultureContext("tr-TR");
+            Assert.AreEqual(expected, SpanUtilities.IndexOf(fixture.AsSpan(), value.AsSpan(), cmp)); 
+        }
+
+        // ============================
+        // LASTINDEXOF TESTS
+        // ============================
+
+        [TestCaseSource(nameof(LastIndexOf_2ArgCases))]
+        public void Test_LastIndexOf_String(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value));
+
+        [TestCaseSource(nameof(LastIndexOf_2ArgCases))]
+        public void Test_LastIndexOf_ReadOnlySpan(string fixture, string value, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan()));
+
+        [TestCaseSource(nameof(LastIndexOf_3ArgCases))]
+        public void Test_LastIndexOf_String_Int32(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, startIndex));
+
+        [TestCaseSource(nameof(LastIndexOf_3ArgCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_Int32(string fixture, string value, int startIndex, int expected)
+            => Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), startIndex));
+
+        [TestCaseSource(nameof(ComparisonCases))]
+        public void Test_LastIndexOf_String_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        {
+            using var context = new CultureContext("tr-TR");
+            Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value, cmp));
+        }
+
+        [TestCaseSource(nameof(ComparisonCases))]
+        public void Test_LastIndexOf_ReadOnlySpan_StringComparison(string fixture, string value, StringComparison cmp, int expected)
+        {
+            using var context = new CultureContext("tr-TR");
+            Assert.AreEqual(expected, SpanUtilities.LastIndexOf(fixture.AsSpan(), value.AsSpan(), cmp));
+        }
+        // ============================
+        // ERROR TESTS (SEPARATE)
+        // ============================
+
+        [Test]
+        public void Test_IndexOf_String_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.IndexOf("abc".AsSpan(), (string)null));
+
+        [Test]
+        public void Test_IndexOf_String_Int32_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.IndexOf("abc".AsSpan(), (string)null, 0));
+
+        [Test]
+        public void Test_LastIndexOf_String_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null));
+
+        [Test]
+        public void Test_LastIndexOf_String_Int32_Null()
+            => Assert.Throws<ArgumentNullException>(() => SpanUtilities.LastIndexOf("abc".AsSpan(), (string)null, 0));
+
+        [Test]
+        public void Test_IndexOf_InvalidComparison()
+            => Assert.Throws<ArgumentOutOfRangeException>(() =>
+                SpanUtilities.IndexOf("abc".AsSpan(), "a", (StringComparison)999));
+    }
+}


### PR DESCRIPTION
Closes #171.

J2N: Added SpanUtilities class with `IndexOf()` and `LastIndexOf()` methods that implement JDK behavior of `java.lang.StringBuilder`, such as clamping and special-case return values.

These methods are intentionally placed in a static class, `SpanUtilties` and are not implemented as extension methods. The reason for this is because these are Java-centric implementations that precisely match `indexOf(), and `lastIndexOf() behavior of `java.util.StringBuilder`.

The purpose of making these methods public is to share them between `J2N.Text.OpenStringBuilder` and `ValueStringBuilder` which will be autogenerated with SpanTools.

In addition, this PR also ports the `OrdinalIgnoreCase` functionality from the BCL so it is available on .NET Standard and .NET Framework.

## New API

```c#
namespace J2N
{
    public static partial class SpanUtilities
    {
        public static int IndexOf(ReadOnlySpan<char> span, string value);
        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value);
        public static int IndexOf(ReadOnlySpan<char> span, string value, int startIndex);
        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex);
        public static int IndexOf(ReadOnlySpan<char> span, string value, StringComparison comparisonType);
        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType);
        public static int IndexOf(ReadOnlySpan<char> span, string value, int startIndex, StringComparison comparisonType);
        public static int IndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType);
        public static int LastIndexOf(ReadOnlySpan<char> span, string value);
        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value);
        public static int LastIndexOf(ReadOnlySpan<char> span, string value, int startIndex);
        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex);
        public static int LastIndexOf(ReadOnlySpan<char> span, string value, StringComparison comparisonType);
        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, StringComparison comparisonType);
        public static int LastIndexOf(ReadOnlySpan<char> span, string value, int startIndex, StringComparison comparisonType);
        public static int LastIndexOf(ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType);
    }
}
```