### PR TITLE
Fixed overflow calculation bug in `StringBuilderExtensions.Delete()`

### DIFF
--- a/src/J2N/Text/StringBuilderExtensions.cs
+++ b/src/J2N/Text/StringBuilderExtensions.cs
@@ -858,7 +858,7 @@ namespace J2N.Text
             if (count < 0)
                 ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(count, ExceptionArgument.count);
 
-            if (startIndex + count > text.Length)
+            if ((uint)startIndex + (uint)count > text.Length)
                 count = text.Length - startIndex;
             if (count > 0)
                 text.Remove(startIndex, count);

--- a/tests/NUnit/J2N.Tests/Text/TestStringBuilderExtensions.cs
+++ b/tests/NUnit/J2N.Tests/Text/TestStringBuilderExtensions.cs
@@ -309,6 +309,22 @@ namespace J2N.Text
             assertEquals("YY", sb.ToString());
         }
 
+        // J2N: Regression for overflow bug in clamping logic
+        [Test]
+        public void StringBuilder_Delete_WhenCountOverflows_ShouldClampToEnd()
+        {
+            // Arrange
+            var text = new StringBuilder("abcdef");
+
+            // Act + Assert
+            Assert.DoesNotThrow(() =>
+            {
+                text.Delete(1, int.MaxValue);
+            });
+
+            Assert.That(text.ToString(), Is.EqualTo("a"));
+        }
+
         /**
          * @tests java.lang.StringBuilder.replace(int, int, String)'
          */


### PR DESCRIPTION
`J2N.Text.StringBuilderExtensions::Delete()`: Fixed overflow bug in calculation logic that caused clamping bypass