### PR TITLE
Add `CountdownLatch` type, a port of `java.util.concurrent.CountDownLatch` (fixes #187)

### DIFF
--- a/src/J2N/Threading/CountdownLatch.cs
+++ b/src/J2N/Threading/CountdownLatch.cs
@@ -1,0 +1,386 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+// Some code adapted from Apache Harmony: https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/concurrent/src/main/java/java/util/concurrent/CountDownLatch.java
+// Other aspects adapted from .NET's CountdownEvent: https://github.com/dotnet/runtime/blob/38496302e54e1b6fb11a998b297492f3fdfbfd0c/src/libraries/System.Threading/src/System/Threading/CountdownEvent.cs
+
+using System;
+using System.Threading;
+
+namespace J2N.Threading
+{
+    /// <summary>
+    /// A synchronization aid that allows one or more threads to wait until
+    /// a set of operations being performed in other threads completes.
+    /// <para/>
+    /// A <see cref="CountdownLatch"/> is initialized with a given <i>count</i>.
+    /// The <see cref="Await()"/> methods block until the current count reaches
+    /// zero due to invocations of the <see cref="CountDown()"/> method, after which
+    /// all waiting threads are released and any subsequent invocations of
+    /// <see cref="Await()"/> return immediately. This is a one-shot phenomenon:
+    /// the count cannot be reset.
+    /// <para/>
+    /// A <see cref="CountdownLatch"/> is a versatile synchronization tool
+    /// and can be used for a number of purposes. A <see cref="CountdownLatch"/>
+    /// initialized with a count of one serves as a simple on/off latch, or gate:
+    /// all threads invoking <see cref="Await()"/> wait at the gate until it is
+    /// opened by a thread invoking <see cref="CountDown()"/>. A
+    /// <see cref="CountdownLatch"/> initialized to <i>N</i> can be used to make
+    /// one thread wait until <i>N</i> threads have completed some action, or
+    /// some action has been completed N times.
+    /// <para/>
+    /// A useful property of a <see cref="CountdownLatch"/> is that it
+    /// doesn't require that threads calling <see cref="CountDown()"/> wait for
+    /// the count to reach zero before proceeding, it simply prevents any
+    /// thread from proceeding past an <see cref="Await()"/> until all
+    /// threads could pass.
+    /// <para/>
+    /// Usage Note: This type is similar to <see cref="CountdownEvent"/>,
+    /// but unlike <see cref="CountdownEvent.Signal()"/>, <see cref="CountDown()"/>
+    /// can be called any number of times after the count reaches zero without
+    /// throwing. This matches the semantics of Java's <c>CountDownLatch.countDown()</c>
+    /// method, so Java code that counts down past zero can be ported without adding
+    /// guard clauses.
+    /// </summary>
+    /// <remarks>
+    /// Memory consistency effects: actions in a thread prior to calling
+    /// <see cref="CountDown()"/> happen before actions following a successful
+    /// return from a corresponding <see cref="Await()"/> in another thread.
+    /// <para/>
+    /// Unlike Java's <c>java.util.concurrent.CountDownLatch</c>, which is not
+    /// <c>AutoCloseable</c>, this type implements <see cref="IDisposable"/>
+    /// because it wraps a <see cref="ManualResetEventSlim"/>, which is itself
+    /// disposable. Callers should dispose instances when they are no longer
+    /// needed, typically via a <c>using</c> statement. <see cref="Dispose()"/>
+    /// is not thread-safe: only dispose the latch once no threads are waiting
+    /// on it or counting it down.
+    /// </remarks>
+    public class CountdownLatch : IDisposable
+    {
+        // The current count and ManualResetEventSlim for signaling, instead of Java's Sync class
+        private volatile int _currentCount;
+        private readonly ManualResetEventSlim _event;
+        private volatile bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CountdownLatch"/> class
+        /// with the given <paramref name="count"/>.
+        /// </summary>
+        /// <param name="count">The number of times <see cref="CountDown()"/> must be invoked
+        /// before threads can pass through <see cref="Await()"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
+        public CountdownLatch(int count)
+        {
+            if (count < 0)
+                ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(count, ExceptionArgument.count);
+
+            _currentCount = count;
+            _event = new ManualResetEventSlim(count == 0);
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted.
+        /// <para/>
+        /// If the current count is zero then this method returns immediately.
+        /// <para/>
+        /// If the current count is greater than zero then the current
+        /// thread becomes disabled for thread scheduling purposes and lies
+        /// dormant until one of two things happen:
+        /// <list type="bullet">
+        ///     <item><description>The count reaches zero due to invocations of the
+        ///         <see cref="CountDown()"/> method; or</description></item>
+        ///     <item><description>Some other thread interrupts the current thread.</description></item>
+        /// </list>
+        /// <para/>
+        /// If the current thread is interrupted while waiting, a
+        /// <see cref="ThreadInterruptedException"/> is thrown.
+        /// </summary>
+        /// <remarks>
+        /// Unlike Java's <c>await()</c>, a pending thread interrupt does not cause
+        /// this method to throw when the count has already reached zero; the
+        /// interrupt surfaces at the thread's next blocking operation.
+        /// </remarks>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        public void Await()
+        {
+            _event.Wait();
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted, while observing a
+        /// <see cref="CancellationToken"/>.
+        /// <para/>
+        /// If <paramref name="cancellationToken"/> is already canceled when this
+        /// method is called, an <see cref="OperationCanceledException"/> is thrown
+        /// even if the count has already reached zero, matching
+        /// <see cref="CountdownEvent.Wait(CancellationToken)"/>.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/>
+        /// has been canceled.</exception>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        /// <seealso cref="Await()"/>
+        public void Await(CancellationToken cancellationToken)
+        {
+            _event.Wait(cancellationToken);
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted, or the specified waiting time
+        /// elapses.
+        /// <para/>
+        /// If the current count is zero then this method returns immediately
+        /// with the value <c>true</c>.
+        /// <para/>
+        /// If the current count is greater than zero then the current
+        /// thread becomes disabled for thread scheduling purposes and lies
+        /// dormant until one of three things happen:
+        /// <list type="bullet">
+        ///     <item><description>The count reaches zero due to invocations of the
+        ///         <see cref="CountDown()"/> method; or</description></item>
+        ///     <item><description>Some other thread interrupts the current thread; or</description></item>
+        ///     <item><description>The specified waiting time elapses.</description></item>
+        /// </list>
+        /// <para/>
+        /// If the count reaches zero then the method returns with the
+        /// value <c>true</c>.
+        /// <para/>
+        /// If the current thread is interrupted while waiting, a
+        /// <see cref="ThreadInterruptedException"/> is thrown.
+        /// <para/>
+        /// If the specified waiting time elapses then the value <c>false</c>
+        /// is returned. If the time is zero, the method does not block: it
+        /// returns <c>true</c> if the count has already reached zero, or
+        /// <c>false</c> otherwise. Note that negative timeouts are handled
+        /// differently from Java: Java treats any non-positive timeout as an
+        /// immediate poll, while this method follows
+        /// <see cref="CountdownEvent.Wait(TimeSpan)"/> semantics, where -1
+        /// milliseconds means an infinite wait and other negative values throw
+        /// <see cref="ArgumentOutOfRangeException"/>.
+        /// </summary>
+        /// <param name="timeout">The maximum time to wait, or a <see cref="TimeSpan"/> that
+        /// represents -1 milliseconds to wait indefinitely.</param>
+        /// <returns><c>true</c> if the count reached zero, or <c>false</c>
+        /// if the waiting time elapsed before the count reached zero.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
+        /// number other than -1 milliseconds, which represents an infinite time-out, or
+        /// <paramref name="timeout"/> is greater than <see cref="int.MaxValue"/> milliseconds.</exception>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        public bool Await(TimeSpan timeout)
+        {
+            return _event.Wait(timeout);
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted, or the specified waiting time
+        /// elapses, while observing a <see cref="CancellationToken"/>.
+        /// <para/>
+        /// If <paramref name="cancellationToken"/> is already canceled when this
+        /// method is called, an <see cref="OperationCanceledException"/> is thrown
+        /// even if the count has already reached zero, matching
+        /// <see cref="CountdownEvent.Wait(TimeSpan, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="timeout">The maximum time to wait, or a <see cref="TimeSpan"/> that
+        /// represents -1 milliseconds to wait indefinitely.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns><c>true</c> if the count reached zero, or <c>false</c>
+        /// if the waiting time elapsed before the count reached zero.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="timeout"/> is a negative
+        /// number other than -1 milliseconds, which represents an infinite time-out, or
+        /// <paramref name="timeout"/> is greater than <see cref="int.MaxValue"/> milliseconds.</exception>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/>
+        /// has been canceled.</exception>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        /// <seealso cref="Await(TimeSpan)"/>
+        public bool Await(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            return _event.Wait(timeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted, or the specified waiting time
+        /// elapses.
+        /// <para/>
+        /// Note that unlike Java, where a non-positive timeout means an immediate
+        /// poll, <see cref="Timeout.Infinite"/> (-1) means an infinite wait and
+        /// other negative values throw <see cref="ArgumentOutOfRangeException"/>.
+        /// </summary>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or
+        /// <see cref="Timeout.Infinite"/> (-1) to wait indefinitely.</param>
+        /// <returns><c>true</c> if the count reached zero, or <c>false</c>
+        /// if the waiting time elapsed before the count reached zero.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// negative number other than -1, which represents an infinite time-out.</exception>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        /// <seealso cref="Await(TimeSpan)"/>
+        public bool Await(int millisecondsTimeout)
+        {
+            return _event.Wait(millisecondsTimeout);
+        }
+
+        /// <summary>
+        /// Causes the current thread to wait until the latch has counted down to
+        /// zero, unless the thread is interrupted, or the specified waiting time
+        /// elapses, while observing a <see cref="CancellationToken"/>.
+        /// <para/>
+        /// If <paramref name="cancellationToken"/> is already canceled when this
+        /// method is called, an <see cref="OperationCanceledException"/> is thrown
+        /// even if the count has already reached zero, matching
+        /// <see cref="CountdownEvent.Wait(int, CancellationToken)"/>.
+        /// </summary>
+        /// <param name="millisecondsTimeout">The number of milliseconds to wait, or
+        /// <see cref="Timeout.Infinite"/> (-1) to wait indefinitely.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to observe.</param>
+        /// <returns><c>true</c> if the count reached zero, or <c>false</c>
+        /// if the waiting time elapsed before the count reached zero.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="millisecondsTimeout"/> is a
+        /// negative number other than -1, which represents an infinite time-out.</exception>
+        /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/>
+        /// has been canceled.</exception>
+        /// <exception cref="ThreadInterruptedException">The current thread is
+        /// interrupted while waiting.</exception>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        /// <seealso cref="Await(TimeSpan)"/>
+        public bool Await(int millisecondsTimeout, CancellationToken cancellationToken)
+        {
+            return _event.Wait(millisecondsTimeout, cancellationToken);
+        }
+
+        /// <summary>
+        /// Decrements the count of the latch, releasing all waiting threads if
+        /// the count reaches zero.
+        /// <para/>
+        /// If the current count is greater than zero then it is decremented.
+        /// If the new count is zero then all waiting threads are re-enabled for
+        /// thread scheduling purposes.
+        /// <para/>
+        /// If the current count equals zero then nothing happens.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">The current instance has
+        /// already been disposed.</exception>
+        public void CountDown()
+        {
+            if (_disposed)
+                ThrowHelper.ThrowObjectDisposedException(this);
+
+            if (_currentCount <= 0)
+            {
+                // Try to avoid unnecessary decrementing of the count below zero,
+                // but a couple concurrent races below zero are fine
+                return;
+            }
+
+            int newCount = Interlocked.Decrement(ref _currentCount);
+            if (newCount <= 0)
+            {
+                _event.Set();
+            }
+        }
+
+        /// <summary>
+        /// Returns the current count.
+        /// <para/>
+        /// This property is typically used for debugging and testing purposes.
+        /// </summary>
+        /// <remarks>
+        /// In Java, <c>getCount()</c> returns <c>long</c>, but internally it's
+        /// always an int. Here we retain the Java return type. There is no need
+        /// to make the internal count 64-bit.
+        /// <para/>
+        /// The returned value is clamped at zero. The internal counter may
+        /// briefly drop below zero under concurrent <see cref="CountDown()"/>
+        /// calls that race past the early-return guard, but that detail is
+        /// hidden here to match Java's <c>getCount()</c> semantics, which never
+        /// returns a negative value.
+        /// <para/>
+        /// The count reaching zero and the release of waiting threads are not a
+        /// single atomic transition: a thread may briefly observe this property
+        /// as zero before waiters are released. <see cref="CountdownEvent"/>
+        /// exhibits the same behavior.
+        /// </remarks>
+        public long Count => Math.Max(0, _currentCount);
+
+        /// <summary>
+        /// Returns a string identifying this latch, as well as its state.
+        /// The state, in brackets, includes the string <c>"Count ="</c>
+        /// followed by the current count.
+        /// </summary>
+        /// <returns>A string identifying this latch, as well as its state.</returns>
+        public override string ToString() => $"{base.ToString()}[Count = {Count}]";
+
+        /// <summary>
+        /// Releases all resources used by the current instance of <see cref="CountdownLatch"/>.
+        /// </summary>
+        /// <remarks>
+        /// Java's <c>CountDownLatch</c> is not <c>AutoCloseable</c>
+        /// and does not need to be closed. This .NET port wraps a
+        /// <see cref="ManualResetEventSlim"/>, which is disposable, so the latch
+        /// must be disposed when no longer needed.
+        /// <para/>
+        /// This method is not thread-safe with respect to the other members of
+        /// this class. Only call it once all threads have finished waiting on
+        /// and counting down the latch: disposing while a thread is blocked in
+        /// one of the <see cref="Await()"/> overloads leaves that thread waiting
+        /// indefinitely.
+        /// </remarks>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// When overridden in a subclass, releases the unmanaged resources used by the
+        /// <see cref="CountdownLatch"/>, and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> indicates to dispose both managed and
+        /// unmanaged resources. <c>false</c> indicates to dispose only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _disposed = true;
+                _event.Dispose();
+            }
+        }
+    }
+}

--- a/src/J2N/Threading/CountdownLatch.cs
+++ b/src/J2N/Threading/CountdownLatch.cs
@@ -23,6 +23,7 @@
 // Other aspects adapted from .NET's CountdownEvent: https://github.com/dotnet/runtime/blob/38496302e54e1b6fb11a998b297492f3fdfbfd0c/src/libraries/System.Threading/src/System/Threading/CountdownEvent.cs
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace J2N.Threading
@@ -32,29 +33,29 @@ namespace J2N.Threading
     /// a set of operations being performed in other threads completes.
     /// <para/>
     /// A <see cref="CountdownLatch"/> is initialized with a given <i>count</i>.
-    /// The <see cref="Await()"/> methods block until the current count reaches
-    /// zero due to invocations of the <see cref="CountDown()"/> method, after which
+    /// The <see cref="Wait()"/> methods block until the current count reaches
+    /// zero due to invocations of the <see cref="Signal()"/> method, after which
     /// all waiting threads are released and any subsequent invocations of
-    /// <see cref="Await()"/> return immediately. This is a one-shot phenomenon:
+    /// <see cref="Wait()"/> return immediately. This is a one-shot phenomenon:
     /// the count cannot be reset.
     /// <para/>
     /// A <see cref="CountdownLatch"/> is a versatile synchronization tool
     /// and can be used for a number of purposes. A <see cref="CountdownLatch"/>
     /// initialized with a count of one serves as a simple on/off latch, or gate:
-    /// all threads invoking <see cref="Await()"/> wait at the gate until it is
-    /// opened by a thread invoking <see cref="CountDown()"/>. A
+    /// all threads invoking <see cref="Wait()"/> wait at the gate until it is
+    /// opened by a thread invoking <see cref="Signal()"/>. A
     /// <see cref="CountdownLatch"/> initialized to <i>N</i> can be used to make
     /// one thread wait until <i>N</i> threads have completed some action, or
     /// some action has been completed N times.
     /// <para/>
     /// A useful property of a <see cref="CountdownLatch"/> is that it
-    /// doesn't require that threads calling <see cref="CountDown()"/> wait for
+    /// doesn't require that threads calling <see cref="Signal()"/> wait for
     /// the count to reach zero before proceeding, it simply prevents any
-    /// thread from proceeding past an <see cref="Await()"/> until all
+    /// thread from proceeding past an <see cref="Wait()"/> until all
     /// threads could pass.
     /// <para/>
     /// Usage Note: This type is similar to <see cref="CountdownEvent"/>,
-    /// but unlike <see cref="CountdownEvent.Signal()"/>, <see cref="CountDown()"/>
+    /// but unlike <see cref="CountdownEvent.Signal()"/>, <see cref="Signal()"/>
     /// can be called any number of times after the count reaches zero without
     /// throwing. This matches the semantics of Java's <c>CountDownLatch.countDown()</c>
     /// method, so Java code that counts down past zero can be ported without adding
@@ -62,8 +63,8 @@ namespace J2N.Threading
     /// </summary>
     /// <remarks>
     /// Memory consistency effects: actions in a thread prior to calling
-    /// <see cref="CountDown()"/> happen before actions following a successful
-    /// return from a corresponding <see cref="Await()"/> in another thread.
+    /// <see cref="Signal()"/> happen before actions following a successful
+    /// return from a corresponding <see cref="Wait()"/> in another thread.
     /// <para/>
     /// Unlike Java's <c>java.util.concurrent.CountDownLatch</c>, which is not
     /// <c>AutoCloseable</c>, this type implements <see cref="IDisposable"/>
@@ -73,10 +74,12 @@ namespace J2N.Threading
     /// is not thread-safe: only dispose the latch once no threads are waiting
     /// on it or counting it down.
     /// </remarks>
-    public class CountdownLatch : IDisposable
+    [DebuggerDisplay("Initial Count={InitialCount}, Current Count={CurrentCount}")]
+    public sealed class CountdownLatch : IDisposable
     {
         // The current count and ManualResetEventSlim for signaling, instead of Java's Sync class
         private volatile int _currentCount;
+        private readonly int _initialCount;
         private readonly ManualResetEventSlim _event;
         private volatile bool _disposed;
 
@@ -84,8 +87,8 @@ namespace J2N.Threading
         /// Initializes a new instance of the <see cref="CountdownLatch"/> class
         /// with the given <paramref name="count"/>.
         /// </summary>
-        /// <param name="count">The number of times <see cref="CountDown()"/> must be invoked
-        /// before threads can pass through <see cref="Await()"/>.</param>
+        /// <param name="count">The number of times <see cref="Signal()"/> must be invoked
+        /// before threads can pass through <see cref="Wait()"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is negative.</exception>
         public CountdownLatch(int count)
         {
@@ -93,6 +96,7 @@ namespace J2N.Threading
                 ThrowHelper.ThrowArgumentOutOfRange_MustBeNonNegative(count, ExceptionArgument.count);
 
             _currentCount = count;
+            _initialCount = count;
             _event = new ManualResetEventSlim(count == 0);
         }
 
@@ -107,23 +111,18 @@ namespace J2N.Threading
         /// dormant until one of two things happen:
         /// <list type="bullet">
         ///     <item><description>The count reaches zero due to invocations of the
-        ///         <see cref="CountDown()"/> method; or</description></item>
+        ///         <see cref="Signal()"/> method; or</description></item>
         ///     <item><description>Some other thread interrupts the current thread.</description></item>
         /// </list>
         /// <para/>
         /// If the current thread is interrupted while waiting, a
         /// <see cref="ThreadInterruptedException"/> is thrown.
         /// </summary>
-        /// <remarks>
-        /// Unlike Java's <c>await()</c>, a pending thread interrupt does not cause
-        /// this method to throw when the count has already reached zero; the
-        /// interrupt surfaces at the thread's next blocking operation.
-        /// </remarks>
         /// <exception cref="ThreadInterruptedException">The current thread is
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        public void Await()
+        public void Wait()
         {
             _event.Wait();
         }
@@ -145,8 +144,8 @@ namespace J2N.Threading
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        /// <seealso cref="Await()"/>
-        public void Await(CancellationToken cancellationToken)
+        /// <seealso cref="Wait()"/>
+        public void Wait(CancellationToken cancellationToken)
         {
             _event.Wait(cancellationToken);
         }
@@ -164,7 +163,7 @@ namespace J2N.Threading
         /// dormant until one of three things happen:
         /// <list type="bullet">
         ///     <item><description>The count reaches zero due to invocations of the
-        ///         <see cref="CountDown()"/> method; or</description></item>
+        ///         <see cref="Signal()"/> method; or</description></item>
         ///     <item><description>Some other thread interrupts the current thread; or</description></item>
         ///     <item><description>The specified waiting time elapses.</description></item>
         /// </list>
@@ -196,7 +195,7 @@ namespace J2N.Threading
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        public bool Await(TimeSpan timeout)
+        public bool Wait(TimeSpan timeout)
         {
             return _event.Wait(timeout);
         }
@@ -225,8 +224,8 @@ namespace J2N.Threading
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        /// <seealso cref="Await(TimeSpan)"/>
-        public bool Await(TimeSpan timeout, CancellationToken cancellationToken)
+        /// <seealso cref="Wait(TimeSpan)"/>
+        public bool Wait(TimeSpan timeout, CancellationToken cancellationToken)
         {
             return _event.Wait(timeout, cancellationToken);
         }
@@ -250,8 +249,8 @@ namespace J2N.Threading
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        /// <seealso cref="Await(TimeSpan)"/>
-        public bool Await(int millisecondsTimeout)
+        /// <seealso cref="Wait(TimeSpan)"/>
+        public bool Wait(int millisecondsTimeout)
         {
             return _event.Wait(millisecondsTimeout);
         }
@@ -279,8 +278,8 @@ namespace J2N.Threading
         /// interrupted while waiting.</exception>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        /// <seealso cref="Await(TimeSpan)"/>
-        public bool Await(int millisecondsTimeout, CancellationToken cancellationToken)
+        /// <seealso cref="Wait(TimeSpan)"/>
+        public bool Wait(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             return _event.Wait(millisecondsTimeout, cancellationToken);
         }
@@ -297,7 +296,7 @@ namespace J2N.Threading
         /// </summary>
         /// <exception cref="ObjectDisposedException">The current instance has
         /// already been disposed.</exception>
-        public void CountDown()
+        public void Signal()
         {
             if (_disposed)
                 ThrowHelper.ThrowObjectDisposedException(this);
@@ -317,6 +316,11 @@ namespace J2N.Threading
         }
 
         /// <summary>
+        /// Gets the number of signals initially required to release the latch.
+        /// </summary>
+        public int InitialCount => _initialCount;
+
+        /// <summary>
         /// Returns the current count.
         /// <para/>
         /// This property is typically used for debugging and testing purposes.
@@ -327,7 +331,7 @@ namespace J2N.Threading
         /// to make the internal count 64-bit.
         /// <para/>
         /// The returned value is clamped at zero. The internal counter may
-        /// briefly drop below zero under concurrent <see cref="CountDown()"/>
+        /// briefly drop below zero under concurrent <see cref="Signal()"/>
         /// calls that race past the early-return guard, but that detail is
         /// hidden here to match Java's <c>getCount()</c> semantics, which never
         /// returns a negative value.
@@ -337,7 +341,7 @@ namespace J2N.Threading
         /// as zero before waiters are released. <see cref="CountdownEvent"/>
         /// exhibits the same behavior.
         /// </remarks>
-        public long Count => Math.Max(0, _currentCount);
+        public long CurrentCount => Math.Max(0, _currentCount);
 
         /// <summary>
         /// Returns a string identifying this latch, as well as its state.
@@ -345,7 +349,7 @@ namespace J2N.Threading
         /// followed by the current count.
         /// </summary>
         /// <returns>A string identifying this latch, as well as its state.</returns>
-        public override string ToString() => $"{base.ToString()}[Count = {Count}]";
+        public override string ToString() => $"{base.ToString()}[Count = {CurrentCount}]";
 
         /// <summary>
         /// Releases all resources used by the current instance of <see cref="CountdownLatch"/>.
@@ -359,28 +363,13 @@ namespace J2N.Threading
         /// This method is not thread-safe with respect to the other members of
         /// this class. Only call it once all threads have finished waiting on
         /// and counting down the latch: disposing while a thread is blocked in
-        /// one of the <see cref="Await()"/> overloads leaves that thread waiting
+        /// one of the <see cref="Wait()"/> overloads leaves that thread waiting
         /// indefinitely.
         /// </remarks>
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// When overridden in a subclass, releases the unmanaged resources used by the
-        /// <see cref="CountdownLatch"/>, and optionally releases the managed resources.
-        /// </summary>
-        /// <param name="disposing"><c>true</c> indicates to dispose both managed and
-        /// unmanaged resources. <c>false</c> indicates to dispose only unmanaged resources.</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _disposed = true;
-                _event.Dispose();
-            }
+            _disposed = true;
+            _event.Dispose();
         }
     }
 }

--- a/tests/NUnit/J2N.Tests/Threading/JSR166TestCase.cs
+++ b/tests/NUnit/J2N.Tests/Threading/JSR166TestCase.cs
@@ -1,0 +1,167 @@
+﻿#region Copyright by Doug Lea (JSR-166), released to the public domain
+/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/licenses/publicdomain
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+#endregion
+
+// Adapted from Apache Lucene.NET's port of the JSR-166 test suite:
+// https://github.com/apache/lucenenet/blob/8c57a0f389f1afa783b73a05328e052dea0b768b/src/Lucene.Net.Tests/Support/Threading/JSR166TestCase.cs
+// Only the thread-failure propagation helpers are brought over (not the delay
+// constants or TaskScheduler executor support; no J2N use yet).
+
+using System;
+
+namespace J2N.Threading
+{
+    /// <summary>
+    /// Base class for J2N tests ported from the JSR-166 / Apache Harmony suite.
+    /// Holds the <c>threadAssert</c> helpers, which flag a failure on a worker
+    /// thread so it surfaces from the main thread in <see cref="TearDown"/>.
+    /// </summary>
+    public abstract class JSR166TestCase : TestCase
+    {
+        /**
+         * Flag set true if any threadAssert methods fail
+         */
+        private volatile bool threadFailed;
+
+        /**
+         * Initializes test to indicate that no thread assertions have failed
+         */
+        public override void SetUp()
+        {
+            base.SetUp();
+            threadFailed = false;
+        }
+
+        /**
+         * Triggers test case failure if any thread assertions have failed
+         */
+        public override void TearDown()
+        {
+            assertFalse(threadFailed);
+            base.TearDown();
+        }
+
+        /**
+         * Fail, also setting status to indicate current testcase should fail
+         */
+        public void threadFail(string reason)
+        {
+            threadFailed = true;
+            fail(reason);
+        }
+
+        /**
+         * If expression not true, set status to indicate current testcase
+         * should fail
+         */
+        public void threadAssertTrue(bool b)
+        {
+            if (!b)
+            {
+                threadFailed = true;
+                assertTrue(b);
+            }
+        }
+
+        /**
+         * If expression not false, set status to indicate current testcase
+         * should fail
+         */
+        public void threadAssertFalse(bool b)
+        {
+            if (b)
+            {
+                threadFailed = true;
+                assertFalse(b);
+            }
+        }
+
+        /**
+         * If argument not null, set status to indicate current testcase
+         * should fail
+         */
+        public void threadAssertNull(object x)
+        {
+            if (x != null)
+            {
+                threadFailed = true;
+                assertNull(x);
+            }
+        }
+
+        /**
+         * If arguments not equal, set status to indicate current testcase
+         * should fail
+         */
+        public void threadAssertEquals(long x, long y)
+        {
+            if (x != y)
+            {
+                threadFailed = true;
+                assertEquals(x, y);
+            }
+        }
+
+        /**
+         * If arguments not equal, set status to indicate current testcase
+         * should fail
+         */
+        public void threadAssertEquals(object x, object y)
+        {
+            if (!Equals(x, y))
+            {
+                threadFailed = true;
+                assertEquals(x, y);
+            }
+        }
+
+        /**
+         * threadFail with message "should throw exception"
+         */
+        public void threadShouldThrow()
+        {
+            threadFailed = true;
+            fail("should throw exception");
+        }
+
+        /**
+         * threadFail with message "Unexpected exception"
+         */
+        public void threadUnexpectedException()
+        {
+            threadFailed = true;
+            fail("Unexpected exception");
+        }
+
+        /**
+         * threadFail with message "Unexpected exception", with argument
+         */
+        public void threadUnexpectedException(Exception ex)
+        {
+            threadFailed = true;
+            fail("Unexpected exception: " + ex);
+        }
+
+        /**
+         * fail with message "should throw exception"
+         */
+        public void shouldThrow()
+        {
+            fail("Should throw exception");
+        }
+
+        /**
+         * fail with message "Unexpected exception"
+         */
+        public void unexpectedException()
+        {
+            fail("Unexpected exception");
+        }
+    }
+}

--- a/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
+++ b/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
@@ -1,0 +1,504 @@
+﻿#region Copyright 2010 by Apache Harmony, Licensed under the Apache License, Version 2.0
+/*  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#endregion
+
+// Some tests adapted from Apache Harmony: https://github.com/apache/harmony/blob/02970cb7227a335edd2c8457ebdde0195a735733/classlib/modules/concurrent/src/test/java/CountDownLatchTest.java
+
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace J2N.Threading
+{
+    public class TestCountdownLatch : TestCase
+    {
+        // Delay in milliseconds for waits that are expected to time out, or for
+        // giving a background thread a chance to block.
+        private const int ShortDelayMilliseconds = 50;
+
+        // Generous upper bound in milliseconds for waits that are expected to complete,
+        // so a regression fails within a bounded time instead of hanging the runner.
+        private const int MaxWaitMilliseconds = 30000;
+
+        // Joins a worker with a bounded wait so a regression fails instead of hanging;
+        // ThreadJob.Join also rethrows any exception the worker stored.
+        private static void JoinAndAssertCompleted(ThreadJob thread)
+        {
+            thread.Join(MaxWaitMilliseconds);
+            assertFalse("Worker thread did not complete in time", thread.IsAlive);
+        }
+
+        /**
+         * negative constructor argument throws ArgumentOutOfRangeException
+         */
+        [Test]
+        public void TestConstructor()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CountdownLatch(-1));
+        }
+
+        /**
+         * a latch constructed with count zero starts open: Await does not block
+         * and CountDown has no effect
+         */
+        [Test]
+        public void TestConstructor_ZeroCount()
+        {
+            using CountdownLatch latch = new CountdownLatch(0);
+            assertEquals(0, latch.Count);
+            latch.Await(); // returns immediately, the count is already zero
+            assertTrue(latch.Await(0));
+            assertTrue(latch.Await(TimeSpan.Zero));
+            latch.CountDown(); // no-op
+            assertEquals(0, latch.Count);
+        }
+
+        /**
+         * Count returns initial count and decreases after CountDown
+         */
+        [Test]
+        public void TestCount()
+        {
+            using CountdownLatch latch = new CountdownLatch(2);
+            assertEquals(2, latch.Count);
+            latch.CountDown();
+            assertEquals(1, latch.Count);
+        }
+
+        /**
+         * CountDown decrements count when positive and has no effect when zero
+         */
+        [Test]
+        public void TestCountDown()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            assertEquals(1, latch.Count);
+            latch.CountDown();
+            assertEquals(0, latch.Count);
+            // Unlike CountdownEvent.Signal(), which throws InvalidOperationException
+            // once the count reaches zero, counting down past zero is a no-op,
+            // matching Java's CountDownLatch.countDown() semantics.
+            latch.CountDown();
+            assertEquals(0, latch.Count);
+        }
+
+        /**
+         * Await returns after CountDown to zero, but not before
+         */
+        [Test]
+        public void TestAwait()
+        {
+            using CountdownLatch latch = new CountdownLatch(2);
+            using ManualResetEventSlim started = new ManualResetEventSlim(false);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                started.Set();
+                latch.Await();
+                assertEquals(0, latch.Count);
+            });
+            t.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds); // give the worker a chance to block in Await()
+            assertEquals(2, latch.Count);
+            latch.CountDown();
+            assertEquals(1, latch.Count);
+            latch.CountDown();
+            assertEquals(0, latch.Count);
+            JoinAndAssertCompleted(t);
+        }
+
+        /**
+         * timed Await returns after CountDown to zero
+         */
+        [Test]
+        public void TestTimedAwait()
+        {
+            using CountdownLatch latch = new CountdownLatch(2);
+            using ManualResetEventSlim started = new ManualResetEventSlim(false);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                started.Set();
+                assertTrue(latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
+            });
+            t.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            assertEquals(2, latch.Count);
+            latch.CountDown();
+            assertEquals(1, latch.Count);
+            latch.CountDown();
+            assertEquals(0, latch.Count);
+            JoinAndAssertCompleted(t);
+        }
+
+        /**
+         * Await throws ThreadInterruptedException if interrupted before counted down
+         */
+        [Test]
+        public void TestAwait_InterruptedException()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            using ManualResetEventSlim started = new ManualResetEventSlim(false);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                try
+                {
+                    assertTrue(latch.Count > 0);
+                    started.Set();
+                    latch.Await();
+                    fail("Should throw ThreadInterruptedException");
+                }
+                catch (ThreadInterruptedException)
+                {
+                    // expected
+                }
+            });
+            t.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            assertEquals(1, latch.Count);
+            t.Interrupt();
+            JoinAndAssertCompleted(t);
+        }
+
+        /**
+         * timed Await throws ThreadInterruptedException if interrupted before counted down
+         */
+        [Test]
+        public void TestTimedAwait_InterruptedException()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            using ManualResetEventSlim started = new ManualResetEventSlim(false);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                try
+                {
+                    assertTrue(latch.Count > 0);
+                    started.Set();
+                    latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds));
+                    fail("Should throw ThreadInterruptedException");
+                }
+                catch (ThreadInterruptedException)
+                {
+                    // expected
+                }
+            });
+            t.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            assertEquals(1, latch.Count);
+            t.Interrupt();
+            JoinAndAssertCompleted(t);
+        }
+
+        /**
+         * timed Await times out if not counted down before timeout, leaving the count unchanged
+         */
+        [Test]
+        public void TestAwaitTimeout()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            assertFalse(latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
+            assertEquals(1, latch.Count);
+        }
+
+        /**
+         * the millisecond overload observes the same timeout and completion semantics
+         * as the TimeSpan overload, including zero and infinite timeouts
+         */
+        [Test]
+        public void TestAwait_MillisecondsTimeout()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            assertFalse(latch.Await(0));
+            assertFalse(latch.Await(ShortDelayMilliseconds));
+            assertEquals(1, latch.Count);
+            latch.CountDown();
+            assertTrue(latch.Await(0));
+            assertTrue(latch.Await(ShortDelayMilliseconds));
+            assertTrue(latch.Await(Timeout.Infinite));
+            assertTrue(latch.Await(Timeout.InfiniteTimeSpan));
+        }
+
+        /**
+         * timeouts that are neither non-negative nor -1 milliseconds (infinite) are rejected
+         */
+        [Test]
+        public void TestAwait_OutOfRangeTimeout()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(-2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(TimeSpan.FromMilliseconds(-2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(TimeSpan.MaxValue));
+        }
+
+        /**
+         * Await(CancellationToken) throws OperationCanceledException when the token
+         * is canceled while waiting, leaving the latch closed
+         */
+        [Test]
+        public void TestAwait_CancellationToken_Canceled()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            using ManualResetEventSlim started = new ManualResetEventSlim(false);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                try
+                {
+                    started.Set();
+                    latch.Await(cts.Token);
+                    fail("Should throw OperationCanceledException");
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected
+                }
+            });
+            t.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            cts.Cancel();
+            JoinAndAssertCompleted(t);
+            assertEquals(1, latch.Count);
+        }
+
+        /**
+         * the timed token overloads throw OperationCanceledException when the token
+         * is canceled while waiting
+         */
+        [Test]
+        public void TestTimedAwait_CancellationToken_Canceled()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            using CountdownEvent started = new CountdownEvent(2);
+            ThreadJob timeSpanWaiter = new ThreadJob(() =>
+            {
+                try
+                {
+                    started.Signal();
+                    latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds), cts.Token);
+                    fail("Should throw OperationCanceledException");
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected
+                }
+            });
+            ThreadJob millisecondsWaiter = new ThreadJob(() =>
+            {
+                try
+                {
+                    started.Signal();
+                    latch.Await(MaxWaitMilliseconds, cts.Token);
+                    fail("Should throw OperationCanceledException");
+                }
+                catch (OperationCanceledException)
+                {
+                    // expected
+                }
+            });
+            timeSpanWaiter.Start();
+            millisecondsWaiter.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            cts.Cancel();
+            JoinAndAssertCompleted(timeSpanWaiter);
+            JoinAndAssertCompleted(millisecondsWaiter);
+            assertEquals(1, latch.Count);
+        }
+
+        /**
+         * token-observing waits complete normally when the latch is counted down
+         * and the token is never canceled
+         */
+        [Test]
+        public void TestAwait_CancellationToken_NotCanceled()
+        {
+            using CountdownLatch latch = new CountdownLatch(1);
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            using CountdownEvent started = new CountdownEvent(2);
+            ThreadJob untimedWaiter = new ThreadJob(() =>
+            {
+                started.Signal();
+                latch.Await(cts.Token); // completes normally when the count reaches zero
+            });
+            ThreadJob timedWaiter = new ThreadJob(() =>
+            {
+                started.Signal();
+                assertTrue(latch.Await(MaxWaitMilliseconds, cts.Token));
+            });
+            untimedWaiter.Start();
+            timedWaiter.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            latch.CountDown();
+            JoinAndAssertCompleted(untimedWaiter);
+            JoinAndAssertCompleted(timedWaiter);
+            assertEquals(0, latch.Count);
+        }
+
+        /**
+         * an already-canceled token throws OperationCanceledException even when
+         * the count is zero, matching CountdownEvent.Wait
+         */
+        [Test]
+        public void TestAwait_PreCanceledToken()
+        {
+            using CountdownLatch latch = new CountdownLatch(0);
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+            Assert.Throws<OperationCanceledException>(() => latch.Await(cts.Token));
+            Assert.Throws<OperationCanceledException>(() => latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds), cts.Token));
+            Assert.Throws<OperationCanceledException>(() => latch.Await(ShortDelayMilliseconds, cts.Token));
+        }
+
+        /**
+         * Count never goes negative and never increases, even when concurrent
+         * CountDown calls race past the early-return guard
+         */
+        [Test]
+        public void TestCount_NeverNegative()
+        {
+            const int ThreadCount = 8;
+            const int CountDownsPerThread = 25;
+
+            using CountdownLatch latch = new CountdownLatch(4);
+            using ManualResetEventSlim startGate = new ManualResetEventSlim(false);
+            ThreadJob[] threads = new ThreadJob[ThreadCount];
+            for (int i = 0; i < ThreadCount; i++)
+            {
+                threads[i] = new ThreadJob(() =>
+                {
+                    startGate.Wait();
+                    long previous = long.MaxValue;
+                    for (int j = 0; j < CountDownsPerThread; j++)
+                    {
+                        latch.CountDown();
+                        long current = latch.Count;
+                        // Count is clamped at zero and the internal counter is
+                        // decrement-only, so each thread must observe a
+                        // non-negative, non-increasing sequence.
+                        assertTrue(current >= 0);
+                        assertTrue(current <= previous);
+                        previous = current;
+                    }
+                });
+            }
+            foreach (ThreadJob thread in threads)
+                thread.Start();
+            startGate.Set();
+            foreach (ThreadJob thread in threads)
+                JoinAndAssertCompleted(thread);
+
+            assertEquals(0, latch.Count);
+            assertTrue(latch.Await(0));
+            assertTrue(latch.ToString().IndexOf("Count = 0", StringComparison.Ordinal) >= 0);
+        }
+
+        /**
+         * all waiting threads are released together when the count reaches zero
+         */
+        [Test]
+        public void TestMultipleWaiters()
+        {
+            const int WaiterCount = 5;
+
+            using CountdownLatch latch = new CountdownLatch(1);
+            using CountdownEvent started = new CountdownEvent(WaiterCount);
+            int released = 0;
+            ThreadJob[] waiters = new ThreadJob[WaiterCount];
+            for (int i = 0; i < WaiterCount; i++)
+            {
+                waiters[i] = new ThreadJob(() =>
+                {
+                    started.Signal();
+                    // bounded so a release regression fails the test instead of hanging it
+                    assertTrue(latch.Await(MaxWaitMilliseconds));
+                    Interlocked.Increment(ref released);
+                });
+            }
+            foreach (ThreadJob waiter in waiters)
+                waiter.Start();
+            assertTrue(started.Wait(MaxWaitMilliseconds));
+            Thread.Sleep(ShortDelayMilliseconds);
+            assertEquals(0, Volatile.Read(ref released));
+            latch.CountDown();
+            foreach (ThreadJob waiter in waiters)
+                JoinAndAssertCompleted(waiter);
+            assertEquals(WaiterCount, released);
+        }
+
+        /**
+         * a single waiter is released once the count is exhausted by multiple
+         * threads each counting down once
+         */
+        [Test]
+        public void TestManyCountersOneWaiter()
+        {
+            const int CounterCount = 5;
+
+            using CountdownLatch latch = new CountdownLatch(CounterCount);
+            ThreadJob[] counters = new ThreadJob[CounterCount];
+            for (int i = 0; i < CounterCount; i++)
+            {
+                counters[i] = new ThreadJob(() => latch.CountDown());
+            }
+            foreach (ThreadJob counter in counters)
+                counter.Start();
+            assertTrue(latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
+            assertEquals(0, latch.Count);
+            foreach (ThreadJob counter in counters)
+                JoinAndAssertCompleted(counter);
+        }
+
+        /**
+         * ToString indicates current count
+         */
+        [Test]
+        public void TestToString()
+        {
+            using CountdownLatch latch = new CountdownLatch(2);
+            string s0 = latch.ToString();
+            assertTrue(s0.IndexOf("Count = 2", StringComparison.Ordinal) >= 0);
+            latch.CountDown();
+            string s1 = latch.ToString();
+            assertTrue(s1.IndexOf("Count = 1", StringComparison.Ordinal) >= 0);
+            latch.CountDown();
+            string s2 = latch.ToString();
+            assertTrue(s2.IndexOf("Count = 0", StringComparison.Ordinal) >= 0);
+        }
+
+        /**
+         * Dispose is idempotent; waiting on or counting down a disposed latch
+         * throws ObjectDisposedException, while Count remains readable
+         */
+        [Test]
+        public void TestDispose()
+        {
+            CountdownLatch latch = new CountdownLatch(1);
+            latch.Dispose();
+            latch.Dispose(); // double dispose is a no-op
+            Assert.Throws<ObjectDisposedException>(() => latch.Await());
+            Assert.Throws<ObjectDisposedException>(() => latch.Await(ShortDelayMilliseconds));
+            Assert.Throws<ObjectDisposedException>(() => latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
+            Assert.Throws<ObjectDisposedException>(() => latch.CountDown());
+            assertEquals(1, latch.Count); // Count stays readable, like CountdownEvent.CurrentCount
+        }
+    }
+}

--- a/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
+++ b/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
@@ -103,13 +103,11 @@ namespace J2N.Threading
         public void TestAwait()
         {
             using CountdownLatch latch = new CountdownLatch(2);
-            using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
                 try
                 {
                     threadAssertTrue(latch.CurrentCount > 0);
-                    started.Set();
                     latch.Wait();
                     threadAssertTrue(latch.CurrentCount == 0);
                 }
@@ -119,14 +117,20 @@ namespace J2N.Threading
                 }
             });
             t.Start();
-            assertTrue(started.Wait(MaxWaitMilliseconds));
-            Thread.Sleep(ShortDelayMilliseconds); // give the worker a chance to block in Wait()
-            assertEquals(2, latch.CurrentCount);
-            latch.Signal();
-            assertEquals(1, latch.CurrentCount);
-            latch.Signal();
-            assertEquals(0, latch.CurrentCount);
-            JoinAndAssertCompleted(t);
+            try
+            {
+                Thread.Sleep(ShortDelayMilliseconds); // give the worker a chance to block in Wait()
+                assertEquals(2, latch.CurrentCount);
+                latch.Signal();
+                assertEquals(1, latch.CurrentCount);
+                latch.Signal();
+                assertEquals(0, latch.CurrentCount);
+                JoinAndAssertCompleted(t);
+            }
+            catch (ThreadInterruptedException)
+            {
+                unexpectedException();
+            }
         }
 
         /**
@@ -136,13 +140,11 @@ namespace J2N.Threading
         public void TestTimedAwait()
         {
             using CountdownLatch latch = new CountdownLatch(2);
-            using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
                 try
                 {
                     threadAssertTrue(latch.CurrentCount > 0);
-                    started.Set();
                     threadAssertTrue(latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
                 }
                 catch (ThreadInterruptedException)
@@ -151,14 +153,20 @@ namespace J2N.Threading
                 }
             });
             t.Start();
-            assertTrue(started.Wait(MaxWaitMilliseconds));
-            Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(2, latch.CurrentCount);
-            latch.Signal();
-            assertEquals(1, latch.CurrentCount);
-            latch.Signal();
-            assertEquals(0, latch.CurrentCount);
-            JoinAndAssertCompleted(t);
+            try
+            {
+                Thread.Sleep(ShortDelayMilliseconds);
+                assertEquals(2, latch.CurrentCount);
+                latch.Signal();
+                assertEquals(1, latch.CurrentCount);
+                latch.Signal();
+                assertEquals(0, latch.CurrentCount);
+                JoinAndAssertCompleted(t);
+            }
+            catch (ThreadInterruptedException)
+            {
+                unexpectedException();
+            }
         }
 
         /**
@@ -168,13 +176,11 @@ namespace J2N.Threading
         public void TestAwait_InterruptedException()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
                 try
                 {
                     threadAssertTrue(latch.CurrentCount > 0);
-                    started.Set();
                     latch.Wait();
                     threadShouldThrow();
                 }
@@ -184,11 +190,16 @@ namespace J2N.Threading
                 }
             });
             t.Start();
-            assertTrue(started.Wait(MaxWaitMilliseconds));
-            Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(1, latch.CurrentCount);
-            t.Interrupt();
-            JoinAndAssertCompleted(t);
+            try
+            {
+                assertEquals(1, latch.CurrentCount);
+                t.Interrupt();
+                JoinAndAssertCompleted(t);
+            }
+            catch (ThreadInterruptedException)
+            {
+                unexpectedException();
+            }
         }
 
         /**
@@ -198,13 +209,11 @@ namespace J2N.Threading
         public void TestTimedAwait_InterruptedException()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
                 try
                 {
                     threadAssertTrue(latch.CurrentCount > 0);
-                    started.Set();
                     latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds));
                     threadShouldThrow();
                 }
@@ -214,11 +223,17 @@ namespace J2N.Threading
                 }
             });
             t.Start();
-            assertTrue(started.Wait(MaxWaitMilliseconds));
-            Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(1, latch.CurrentCount);
-            t.Interrupt();
-            JoinAndAssertCompleted(t);
+            try
+            {
+                Thread.Sleep(ShortDelayMilliseconds);
+                assertEquals(1, latch.CurrentCount);
+                t.Interrupt();
+                JoinAndAssertCompleted(t);
+            }
+            catch (ThreadInterruptedException)
+            {
+                unexpectedException();
+            }
         }
 
         /**
@@ -242,8 +257,15 @@ namespace J2N.Threading
                 }
             });
             t.Start();
-            assertEquals(1, latch.CurrentCount);
-            JoinAndAssertCompleted(t);
+            try
+            {
+                assertEquals(1, latch.CurrentCount);
+                JoinAndAssertCompleted(t);
+            }
+            catch (ThreadInterruptedException)
+            {
+                unexpectedException();
+            }
         }
 
         /**

--- a/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
+++ b/tests/NUnit/J2N.Tests/Threading/TestCountdownLatch.cs
@@ -24,7 +24,7 @@ using System.Threading;
 
 namespace J2N.Threading
 {
-    public class TestCountdownLatch : TestCase
+    public class TestCountdownLatch : JSR166TestCase
     {
         // Delay in milliseconds for waits that are expected to time out, or for
         // giving a background thread a chance to block.
@@ -52,52 +52,52 @@ namespace J2N.Threading
         }
 
         /**
-         * a latch constructed with count zero starts open: Await does not block
-         * and CountDown has no effect
+         * a latch constructed with count zero starts open: Wait does not block
+         * and Signal has no effect
          */
-        [Test]
+        [Test] // J2N specific
         public void TestConstructor_ZeroCount()
         {
             using CountdownLatch latch = new CountdownLatch(0);
-            assertEquals(0, latch.Count);
-            latch.Await(); // returns immediately, the count is already zero
-            assertTrue(latch.Await(0));
-            assertTrue(latch.Await(TimeSpan.Zero));
-            latch.CountDown(); // no-op
-            assertEquals(0, latch.Count);
+            assertEquals(0, latch.CurrentCount);
+            latch.Wait(); // returns immediately, the count is already zero
+            assertTrue(latch.Wait(0));
+            assertTrue(latch.Wait(TimeSpan.Zero));
+            latch.Signal(); // no-op
+            assertEquals(0, latch.CurrentCount);
         }
 
         /**
-         * Count returns initial count and decreases after CountDown
+         * CurrentCount returns initial count and decreases after Signal
          */
         [Test]
         public void TestCount()
         {
             using CountdownLatch latch = new CountdownLatch(2);
-            assertEquals(2, latch.Count);
-            latch.CountDown();
-            assertEquals(1, latch.Count);
+            assertEquals(2, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(1, latch.CurrentCount);
         }
 
         /**
-         * CountDown decrements count when positive and has no effect when zero
+         * Signal decrements count when positive and has no effect when zero
          */
         [Test]
         public void TestCountDown()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            assertEquals(1, latch.Count);
-            latch.CountDown();
-            assertEquals(0, latch.Count);
+            assertEquals(1, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(0, latch.CurrentCount);
             // Unlike CountdownEvent.Signal(), which throws InvalidOperationException
             // once the count reaches zero, counting down past zero is a no-op,
             // matching Java's CountDownLatch.countDown() semantics.
-            latch.CountDown();
-            assertEquals(0, latch.Count);
+            latch.Signal();
+            assertEquals(0, latch.CurrentCount);
         }
 
         /**
-         * Await returns after CountDown to zero, but not before
+         * Wait returns after the count reaches zero, but not before
          */
         [Test]
         public void TestAwait()
@@ -106,23 +106,31 @@ namespace J2N.Threading
             using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
-                started.Set();
-                latch.Await();
-                assertEquals(0, latch.Count);
+                try
+                {
+                    threadAssertTrue(latch.CurrentCount > 0);
+                    started.Set();
+                    latch.Wait();
+                    threadAssertTrue(latch.CurrentCount == 0);
+                }
+                catch (ThreadInterruptedException)
+                {
+                    threadUnexpectedException();
+                }
             });
             t.Start();
             assertTrue(started.Wait(MaxWaitMilliseconds));
-            Thread.Sleep(ShortDelayMilliseconds); // give the worker a chance to block in Await()
-            assertEquals(2, latch.Count);
-            latch.CountDown();
-            assertEquals(1, latch.Count);
-            latch.CountDown();
-            assertEquals(0, latch.Count);
+            Thread.Sleep(ShortDelayMilliseconds); // give the worker a chance to block in Wait()
+            assertEquals(2, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(1, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(0, latch.CurrentCount);
             JoinAndAssertCompleted(t);
         }
 
         /**
-         * timed Await returns after CountDown to zero
+         * timed Wait returns after the count reaches zero
          */
         [Test]
         public void TestTimedAwait()
@@ -131,22 +139,30 @@ namespace J2N.Threading
             using ManualResetEventSlim started = new ManualResetEventSlim(false);
             ThreadJob t = new ThreadJob(() =>
             {
-                started.Set();
-                assertTrue(latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
+                try
+                {
+                    threadAssertTrue(latch.CurrentCount > 0);
+                    started.Set();
+                    threadAssertTrue(latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
+                }
+                catch (ThreadInterruptedException)
+                {
+                    threadUnexpectedException();
+                }
             });
             t.Start();
             assertTrue(started.Wait(MaxWaitMilliseconds));
             Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(2, latch.Count);
-            latch.CountDown();
-            assertEquals(1, latch.Count);
-            latch.CountDown();
-            assertEquals(0, latch.Count);
+            assertEquals(2, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(1, latch.CurrentCount);
+            latch.Signal();
+            assertEquals(0, latch.CurrentCount);
             JoinAndAssertCompleted(t);
         }
 
         /**
-         * Await throws ThreadInterruptedException if interrupted before counted down
+         * Wait throws ThreadInterruptedException if interrupted before counted down
          */
         [Test]
         public void TestAwait_InterruptedException()
@@ -157,10 +173,10 @@ namespace J2N.Threading
             {
                 try
                 {
-                    assertTrue(latch.Count > 0);
+                    threadAssertTrue(latch.CurrentCount > 0);
                     started.Set();
-                    latch.Await();
-                    fail("Should throw ThreadInterruptedException");
+                    latch.Wait();
+                    threadShouldThrow();
                 }
                 catch (ThreadInterruptedException)
                 {
@@ -170,13 +186,13 @@ namespace J2N.Threading
             t.Start();
             assertTrue(started.Wait(MaxWaitMilliseconds));
             Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(1, latch.Count);
+            assertEquals(1, latch.CurrentCount);
             t.Interrupt();
             JoinAndAssertCompleted(t);
         }
 
         /**
-         * timed Await throws ThreadInterruptedException if interrupted before counted down
+         * timed Wait throws ThreadInterruptedException if interrupted before counted down
          */
         [Test]
         public void TestTimedAwait_InterruptedException()
@@ -187,10 +203,10 @@ namespace J2N.Threading
             {
                 try
                 {
-                    assertTrue(latch.Count > 0);
+                    threadAssertTrue(latch.CurrentCount > 0);
                     started.Set();
-                    latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds));
-                    fail("Should throw ThreadInterruptedException");
+                    latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds));
+                    threadShouldThrow();
                 }
                 catch (ThreadInterruptedException)
                 {
@@ -200,57 +216,71 @@ namespace J2N.Threading
             t.Start();
             assertTrue(started.Wait(MaxWaitMilliseconds));
             Thread.Sleep(ShortDelayMilliseconds);
-            assertEquals(1, latch.Count);
+            assertEquals(1, latch.CurrentCount);
             t.Interrupt();
             JoinAndAssertCompleted(t);
         }
 
         /**
-         * timed Await times out if not counted down before timeout, leaving the count unchanged
+         * timed Wait times out if not counted down before timeout, leaving the count unchanged
          */
         [Test]
         public void TestAwaitTimeout()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            assertFalse(latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
-            assertEquals(1, latch.Count);
+            ThreadJob t = new ThreadJob(() =>
+            {
+                try
+                {
+                    threadAssertTrue(latch.CurrentCount > 0);
+                    threadAssertFalse(latch.Wait(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
+                    threadAssertTrue(latch.CurrentCount > 0);
+                }
+                catch (ThreadInterruptedException)
+                {
+                    threadUnexpectedException();
+                }
+            });
+            t.Start();
+            assertEquals(1, latch.CurrentCount);
+            JoinAndAssertCompleted(t);
         }
 
         /**
          * the millisecond overload observes the same timeout and completion semantics
          * as the TimeSpan overload, including zero and infinite timeouts
          */
-        [Test]
+        [Test] // J2N specific
         public void TestAwait_MillisecondsTimeout()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            assertFalse(latch.Await(0));
-            assertFalse(latch.Await(ShortDelayMilliseconds));
-            assertEquals(1, latch.Count);
-            latch.CountDown();
-            assertTrue(latch.Await(0));
-            assertTrue(latch.Await(ShortDelayMilliseconds));
-            assertTrue(latch.Await(Timeout.Infinite));
-            assertTrue(latch.Await(Timeout.InfiniteTimeSpan));
+            assertFalse(latch.Wait(0));
+            assertFalse(latch.Wait(ShortDelayMilliseconds));
+            assertEquals(1, latch.CurrentCount);
+            latch.Signal();
+            assertTrue(latch.Wait(0));
+            assertTrue(latch.Wait(ShortDelayMilliseconds));
+            assertTrue(latch.Wait(Timeout.Infinite));
+            assertTrue(latch.Wait(Timeout.InfiniteTimeSpan));
         }
 
         /**
          * timeouts that are neither non-negative nor -1 milliseconds (infinite) are rejected
          */
-        [Test]
+        [Test] // J2N specific
         public void TestAwait_OutOfRangeTimeout()
         {
             using CountdownLatch latch = new CountdownLatch(1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(-2));
-            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(TimeSpan.FromMilliseconds(-2)));
-            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Await(TimeSpan.MaxValue));
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Wait(-2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Wait(TimeSpan.FromMilliseconds(-2)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => latch.Wait(TimeSpan.MaxValue));
         }
 
         /**
-         * Await(CancellationToken) throws OperationCanceledException when the token
+         * Wait(CancellationToken) throws OperationCanceledException when the token
          * is canceled while waiting, leaving the latch closed
          */
-        [Test]
+        [Test] // J2N specific
         public void TestAwait_CancellationToken_Canceled()
         {
             using CountdownLatch latch = new CountdownLatch(1);
@@ -261,7 +291,7 @@ namespace J2N.Threading
                 try
                 {
                     started.Set();
-                    latch.Await(cts.Token);
+                    latch.Wait(cts.Token);
                     fail("Should throw OperationCanceledException");
                 }
                 catch (OperationCanceledException)
@@ -274,14 +304,14 @@ namespace J2N.Threading
             Thread.Sleep(ShortDelayMilliseconds);
             cts.Cancel();
             JoinAndAssertCompleted(t);
-            assertEquals(1, latch.Count);
+            assertEquals(1, latch.CurrentCount);
         }
 
         /**
          * the timed token overloads throw OperationCanceledException when the token
          * is canceled while waiting
          */
-        [Test]
+        [Test] // J2N specific
         public void TestTimedAwait_CancellationToken_Canceled()
         {
             using CountdownLatch latch = new CountdownLatch(1);
@@ -292,7 +322,7 @@ namespace J2N.Threading
                 try
                 {
                     started.Signal();
-                    latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds), cts.Token);
+                    latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds), cts.Token);
                     fail("Should throw OperationCanceledException");
                 }
                 catch (OperationCanceledException)
@@ -305,7 +335,7 @@ namespace J2N.Threading
                 try
                 {
                     started.Signal();
-                    latch.Await(MaxWaitMilliseconds, cts.Token);
+                    latch.Wait(MaxWaitMilliseconds, cts.Token);
                     fail("Should throw OperationCanceledException");
                 }
                 catch (OperationCanceledException)
@@ -320,14 +350,14 @@ namespace J2N.Threading
             cts.Cancel();
             JoinAndAssertCompleted(timeSpanWaiter);
             JoinAndAssertCompleted(millisecondsWaiter);
-            assertEquals(1, latch.Count);
+            assertEquals(1, latch.CurrentCount);
         }
 
         /**
          * token-observing waits complete normally when the latch is counted down
          * and the token is never canceled
          */
-        [Test]
+        [Test] // J2N specific
         public void TestAwait_CancellationToken_NotCanceled()
         {
             using CountdownLatch latch = new CountdownLatch(1);
@@ -336,43 +366,43 @@ namespace J2N.Threading
             ThreadJob untimedWaiter = new ThreadJob(() =>
             {
                 started.Signal();
-                latch.Await(cts.Token); // completes normally when the count reaches zero
+                latch.Wait(cts.Token); // completes normally when the count reaches zero
             });
             ThreadJob timedWaiter = new ThreadJob(() =>
             {
                 started.Signal();
-                assertTrue(latch.Await(MaxWaitMilliseconds, cts.Token));
+                assertTrue(latch.Wait(MaxWaitMilliseconds, cts.Token));
             });
             untimedWaiter.Start();
             timedWaiter.Start();
             assertTrue(started.Wait(MaxWaitMilliseconds));
             Thread.Sleep(ShortDelayMilliseconds);
-            latch.CountDown();
+            latch.Signal();
             JoinAndAssertCompleted(untimedWaiter);
             JoinAndAssertCompleted(timedWaiter);
-            assertEquals(0, latch.Count);
+            assertEquals(0, latch.CurrentCount);
         }
 
         /**
          * an already-canceled token throws OperationCanceledException even when
          * the count is zero, matching CountdownEvent.Wait
          */
-        [Test]
+        [Test] // J2N specific
         public void TestAwait_PreCanceledToken()
         {
             using CountdownLatch latch = new CountdownLatch(0);
             using CancellationTokenSource cts = new CancellationTokenSource();
             cts.Cancel();
-            Assert.Throws<OperationCanceledException>(() => latch.Await(cts.Token));
-            Assert.Throws<OperationCanceledException>(() => latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds), cts.Token));
-            Assert.Throws<OperationCanceledException>(() => latch.Await(ShortDelayMilliseconds, cts.Token));
+            Assert.Throws<OperationCanceledException>(() => latch.Wait(cts.Token));
+            Assert.Throws<OperationCanceledException>(() => latch.Wait(TimeSpan.FromMilliseconds(ShortDelayMilliseconds), cts.Token));
+            Assert.Throws<OperationCanceledException>(() => latch.Wait(ShortDelayMilliseconds, cts.Token));
         }
 
         /**
-         * Count never goes negative and never increases, even when concurrent
-         * CountDown calls race past the early-return guard
+         * CurrentCount never goes negative and never increases, even when concurrent
+         * Signal calls race past the early-return guard
          */
-        [Test]
+        [Test] // J2N specific
         public void TestCount_NeverNegative()
         {
             const int ThreadCount = 8;
@@ -389,9 +419,9 @@ namespace J2N.Threading
                     long previous = long.MaxValue;
                     for (int j = 0; j < CountDownsPerThread; j++)
                     {
-                        latch.CountDown();
-                        long current = latch.Count;
-                        // Count is clamped at zero and the internal counter is
+                        latch.Signal();
+                        long current = latch.CurrentCount;
+                        // CurrentCount is clamped at zero and the internal counter is
                         // decrement-only, so each thread must observe a
                         // non-negative, non-increasing sequence.
                         assertTrue(current >= 0);
@@ -406,15 +436,15 @@ namespace J2N.Threading
             foreach (ThreadJob thread in threads)
                 JoinAndAssertCompleted(thread);
 
-            assertEquals(0, latch.Count);
-            assertTrue(latch.Await(0));
+            assertEquals(0, latch.CurrentCount);
+            assertTrue(latch.Wait(0));
             assertTrue(latch.ToString().IndexOf("Count = 0", StringComparison.Ordinal) >= 0);
         }
 
         /**
          * all waiting threads are released together when the count reaches zero
          */
-        [Test]
+        [Test] // J2N specific
         public void TestMultipleWaiters()
         {
             const int WaiterCount = 5;
@@ -429,7 +459,7 @@ namespace J2N.Threading
                 {
                     started.Signal();
                     // bounded so a release regression fails the test instead of hanging it
-                    assertTrue(latch.Await(MaxWaitMilliseconds));
+                    assertTrue(latch.Wait(MaxWaitMilliseconds));
                     Interlocked.Increment(ref released);
                 });
             }
@@ -438,7 +468,7 @@ namespace J2N.Threading
             assertTrue(started.Wait(MaxWaitMilliseconds));
             Thread.Sleep(ShortDelayMilliseconds);
             assertEquals(0, Volatile.Read(ref released));
-            latch.CountDown();
+            latch.Signal();
             foreach (ThreadJob waiter in waiters)
                 JoinAndAssertCompleted(waiter);
             assertEquals(WaiterCount, released);
@@ -448,7 +478,7 @@ namespace J2N.Threading
          * a single waiter is released once the count is exhausted by multiple
          * threads each counting down once
          */
-        [Test]
+        [Test] // J2N specific
         public void TestManyCountersOneWaiter()
         {
             const int CounterCount = 5;
@@ -457,12 +487,12 @@ namespace J2N.Threading
             ThreadJob[] counters = new ThreadJob[CounterCount];
             for (int i = 0; i < CounterCount; i++)
             {
-                counters[i] = new ThreadJob(() => latch.CountDown());
+                counters[i] = new ThreadJob(() => latch.Signal());
             }
             foreach (ThreadJob counter in counters)
                 counter.Start();
-            assertTrue(latch.Await(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
-            assertEquals(0, latch.Count);
+            assertTrue(latch.Wait(TimeSpan.FromMilliseconds(MaxWaitMilliseconds)));
+            assertEquals(0, latch.CurrentCount);
             foreach (ThreadJob counter in counters)
                 JoinAndAssertCompleted(counter);
         }
@@ -476,29 +506,29 @@ namespace J2N.Threading
             using CountdownLatch latch = new CountdownLatch(2);
             string s0 = latch.ToString();
             assertTrue(s0.IndexOf("Count = 2", StringComparison.Ordinal) >= 0);
-            latch.CountDown();
+            latch.Signal();
             string s1 = latch.ToString();
             assertTrue(s1.IndexOf("Count = 1", StringComparison.Ordinal) >= 0);
-            latch.CountDown();
+            latch.Signal();
             string s2 = latch.ToString();
             assertTrue(s2.IndexOf("Count = 0", StringComparison.Ordinal) >= 0);
         }
 
         /**
          * Dispose is idempotent; waiting on or counting down a disposed latch
-         * throws ObjectDisposedException, while Count remains readable
+         * throws ObjectDisposedException, while CurrentCount remains readable
          */
-        [Test]
+        [Test] // J2N specific
         public void TestDispose()
         {
             CountdownLatch latch = new CountdownLatch(1);
             latch.Dispose();
             latch.Dispose(); // double dispose is a no-op
-            Assert.Throws<ObjectDisposedException>(() => latch.Await());
-            Assert.Throws<ObjectDisposedException>(() => latch.Await(ShortDelayMilliseconds));
-            Assert.Throws<ObjectDisposedException>(() => latch.Await(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
-            Assert.Throws<ObjectDisposedException>(() => latch.CountDown());
-            assertEquals(1, latch.Count); // Count stays readable, like CountdownEvent.CurrentCount
+            Assert.Throws<ObjectDisposedException>(() => latch.Wait());
+            Assert.Throws<ObjectDisposedException>(() => latch.Wait(ShortDelayMilliseconds));
+            Assert.Throws<ObjectDisposedException>(() => latch.Wait(TimeSpan.FromMilliseconds(ShortDelayMilliseconds)));
+            Assert.Throws<ObjectDisposedException>(() => latch.Signal());
+            assertEquals(1, latch.CurrentCount); // CurrentCount stays readable, like CountdownEvent.CurrentCount
         }
     }
 }


### PR DESCRIPTION
Fixes #187.

Adds `J2N.Threading.CountdownLatch`, a port of Java's `java.util.concurrent.CountDownLatch`. Main difference from `System.Threading.CountdownEvent`: `CountDown()` after the count reaches zero is a no-op instead of throwing, matching Java semantics.

Starting point was the internal copy and ported Harmony tests from apache/lucenenet#1311, reworked for J2N:

- Renamed that copy's `Wait`/`Signal` to `Await`/`CountDown` so Java code ports mechanically, per [the #1311 discussion](https://github.com/apache/lucenenet/pull/1311#discussion_r3325326884). Can rename back if you want the .NET names.
- Added overloads matching the `CountdownEvent.Wait` surface for .NET-style calls: `Await(CancellationToken)`, `Await(int)`, `Await(TimeSpan, CancellationToken)`, `Await(int, CancellationToken)`.
- `IDisposable` stays since the type wraps a `ManualResetEventSlim`. Java's type has no `close()`, so the remarks call out the departure, and `CountDown()` on a disposed latch throws `ObjectDisposedException`, as `CountdownEvent.Signal()` does.
- Harmony tests ported into J2N.Tests, plus coverage for the new overloads, zero-count construction, post-zero `CountDown()`, disposal, and `Count` clamping under concurrent decrements.
