### PR TITLE
Mark ISpanFormattable obsolete, #130

### DIFF
--- a/src/J2N/Numerics/Number.cs
+++ b/src/J2N/Numerics/Number.cs
@@ -32,7 +32,9 @@ namespace J2N.Numerics
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
+#pragma warning disable CS0618 // Type or member is obsolete - ISpanFormattable is our own compatibility shim on platforms where System.ISpanFormattable doesn't exist. See https://github.com/NightOwl888/J2N/issues/130.
     public abstract class Number : IFormattable, ISpanFormattable
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         // From System.Convert
 

--- a/src/J2N/compatibility/ISpanFormattable.cs
+++ b/src/J2N/compatibility/ISpanFormattable.cs
@@ -6,6 +6,10 @@ namespace System
     /// Provides functionality to format the string representation of an object into
     /// a span.
     /// </summary>
+    [Obsolete("This interface is a compatibility shim for platforms that do not define System.ISpanFormattable, " +
+        "and it collides with the built-in interface of the same name when a .NET Standard build of J2N is " +
+        "consumed from .NET 6.0 or higher. Cast to J2N.Numerics.Number to call TryFormat() instead. " +
+        "This interface will be removed in J2N 3.0.")]
     public interface ISpanFormattable : IFormattable
     {
         /// <summary>


### PR DESCRIPTION
Related #130 

This marks the ISpanFormattable type obsolete per the rationale in https://github.com/NightOwl888/J2N/issues/130#issuecomment-4392097836